### PR TITLE
feat(venice): implement Venice AI client with streaming and circuit b…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "3.9.1",
+    "recharts": "2.13.3",
     "@stellar/stellar-sdk": "12.3.0",
     "@vitejs/plugin-react": "4.3.4",
     "react": "18.3.1",

--- a/frontend/src/components/common/Skeleton.module.css
+++ b/frontend/src/components/common/Skeleton.module.css
@@ -1,0 +1,11 @@
+.skeleton {
+  background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 4px;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/frontend/src/components/dashboard/DashboardLayout.module.css
+++ b/frontend/src/components/dashboard/DashboardLayout.module.css
@@ -1,0 +1,8 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}

--- a/frontend/src/components/dashboard/KpiCard.module.css
+++ b/frontend/src/components/dashboard/KpiCard.module.css
@@ -1,0 +1,34 @@
+.card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skeleton {
+  height: 80px;
+  background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 4px;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.title {
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #0f172a;
+}

--- a/frontend/src/components/dashboard/NetworkHealthBadge.module.css
+++ b/frontend/src/components/dashboard/NetworkHealthBadge.module.css
@@ -1,0 +1,22 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.green { background-color: #22c55e; }
+.yellow { background-color: #eab308; }
+.red { background-color: #ef4444; }
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+}

--- a/frontend/src/components/dashboard/RecentTasksTable.module.css
+++ b/frontend/src/components/dashboard/RecentTasksTable.module.css
@@ -1,0 +1,47 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.table th {
+  font-weight: 600;
+  color: #64748b;
+  background: #f8fafc;
+}
+
+.row {
+  display: flex;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.empty {
+  padding: 2rem;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.875rem;
+}
+
+.viewLink {
+  color: #6366f1;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.viewLink:hover {
+  text-decoration: underline;
+}
+
+.pending { color: #eab308; }
+.completed { color: #22c55e; }
+.failed { color: #ef4444; }
+.default { color: #64748b; }

--- a/frontend/src/pages/dashboard.module.css
+++ b/frontend/src/pages/dashboard.module.css
@@ -1,0 +1,24 @@
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.health {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.recentTasks {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.heading {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0;
+}

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -10,7 +10,7 @@ import styles from './dashboard.module.css';
 
 export const DashboardPage: React.FC = () => {
   const { address } = useWallet();
-  const { data, loading, error } = useNetworkStats();
+  const { data, loading } = useNetworkStats();
 
   // Redirect unauthenticated users
   React.useEffect(() => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,7 +16,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"],
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@components': path.resolve(__dirname, './src/components'),
+      '@pages': path.resolve(__dirname, './src/pages'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@services': path.resolve(__dirname, './src/services'),
+      '@types': path.resolve(__dirname, './src/types'),
+      '@context': path.resolve(__dirname, './src/context'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+    globals: true,
+    include: ['src/**/*.test.{ts,tsx}'],
+    exclude: ['tests/e2e/**', 'node_modules/**'],
+  },
+});

--- a/smart-contracts/package-lock.json
+++ b/smart-contracts/package-lock.json
@@ -56,6 +56,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1424,6 +1425,7 @@
       "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1492,6 +1494,7 @@
       "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.13.0",
         "@typescript-eslint/types": "7.13.0",
@@ -1658,6 +1661,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2113,6 +2117,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2699,6 +2704,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3762,6 +3768,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5654,6 +5661,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5754,6 +5762,7 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/smart-contracts/src/venice/venice.ts
+++ b/smart-contracts/src/venice/venice.ts
@@ -8,39 +8,163 @@ const MODEL_ROUTING: Record<string, string> = {
   report: 'venice-xl',
 };
 
+const VENICE_BASE_URL = 'https://api.venice.ai/api/v1';
+const CIRCUIT_FAILURE_THRESHOLD = 3;
+const CIRCUIT_OPEN_DURATION_MS = 60_000;
+
+enum CircuitState {
+  CLOSED = 'CLOSED',
+  OPEN = 'OPEN',
+  HALF_OPEN = 'HALF_OPEN',
+}
+
 export class VeniceClient {
+  private circuitState: CircuitState = CircuitState.CLOSED;
+  private failureCount = 0;
+  private openedAt: number | null = null;
+
   constructor(private readonly apiKey = process.env.VENICE_API_KEY ?? '') {}
 
   getModelForAgent(capability: string): string {
     return MODEL_ROUTING[capability] ?? 'venice-xl';
   }
 
-  async complete(prompt: string, capability = 'report'): Promise<string> {
-    const apiKey = this.apiKey;
-    if (!apiKey) {
-      throw new Error('VENICE_API_KEY is not configured');
+  private checkCircuit(): void {
+    if (this.circuitState === CircuitState.OPEN) {
+      const elapsed = Date.now() - (this.openedAt ?? 0);
+      if (elapsed >= CIRCUIT_OPEN_DURATION_MS) {
+        this.circuitState = CircuitState.HALF_OPEN;
+      } else {
+        throw new Error('Circuit breaker is OPEN — Venice AI is unavailable');
+      }
     }
+  }
 
-    const response = await axios.post(
-      'https://api.venice.ai/api/v1/chat/completions',
-      {
-        model: this.getModelForAgent(capability),
-        messages: [{ role: 'user', content: prompt }],
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
+  private onSuccess(): void {
+    this.failureCount = 0;
+    this.circuitState = CircuitState.CLOSED;
+    this.openedAt = null;
+  }
+
+  private onFailure(): void {
+    this.failureCount += 1;
+    if (
+      this.failureCount >= CIRCUIT_FAILURE_THRESHOLD ||
+      this.circuitState === CircuitState.HALF_OPEN
+    ) {
+      this.circuitState = CircuitState.OPEN;
+      this.openedAt = Date.now();
+    }
+  }
+
+  private log(prompt: string, modelId: string): void {
+    const truncated = prompt.length > 200 ? `${prompt.slice(0, 200)}…` : prompt;
+    console.log(`[Venice] model=${modelId} prompt="${truncated}"`);
+  }
+
+  async complete(
+    prompt: string,
+    modelId: string,
+    options?: Record<string, unknown>,
+  ): Promise<string> {
+    if (!this.apiKey) throw new Error('VENICE_API_KEY is not configured');
+
+    this.checkCircuit();
+    const resolvedModel = MODEL_ROUTING[modelId] ?? modelId;
+    this.log(prompt, resolvedModel);
+
+    try {
+      const response = await axios.post(
+        `${VENICE_BASE_URL}/chat/completions`,
+        {
+          model: resolvedModel,
+          messages: [{ role: 'user', content: prompt }],
+          ...options,
         },
-        timeout: 60_000,
-      },
-    );
+        {
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          timeout: 60_000,
+        },
+      );
 
-    const content = response.data?.choices?.[0]?.message?.content;
-    if (typeof content !== 'string') {
-      throw new Error('Venice returned an empty response');
+      const content = response.data?.choices?.[0]?.message?.content;
+      if (typeof content !== 'string') throw new Error('Venice returned an empty response');
+
+      this.onSuccess();
+      return content;
+    } catch (err) {
+      this.onFailure();
+      throw err;
     }
+  }
 
-    return content;
+  async stream(
+    prompt: string,
+    modelId: string,
+    onChunk: (chunk: string) => void,
+  ): Promise<void> {
+    if (!this.apiKey) throw new Error('VENICE_API_KEY is not configured');
+
+    this.checkCircuit();
+    const resolvedModel = MODEL_ROUTING[modelId] ?? modelId;
+    this.log(prompt, resolvedModel);
+
+    try {
+      const response = await axios.post(
+        `${VENICE_BASE_URL}/chat/completions`,
+        {
+          model: resolvedModel,
+          messages: [{ role: 'user', content: prompt }],
+          stream: true,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          responseType: 'stream',
+          timeout: 60_000,
+        },
+      );
+
+      await new Promise<void>((resolve, reject) => {
+        let buffer = '';
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        response.data.on('data', (chunk: Buffer | string) => {
+          buffer += chunk.toString();
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith('data: ')) continue;
+            const data = trimmed.slice(6);
+            if (data === '[DONE]') return;
+
+            try {
+              const parsed = JSON.parse(data) as {
+                choices?: Array<{ delta?: { content?: string } }>;
+              };
+              const content = parsed?.choices?.[0]?.delta?.content;
+              if (typeof content === 'string') onChunk(content);
+            } catch {
+              // ignore malformed SSE lines
+            }
+          }
+        });
+
+        response.data.on('end', resolve);
+        response.data.on('error', reject);
+      });
+
+      this.onSuccess();
+    } catch (err) {
+      this.onFailure();
+      throw err;
+    }
   }
 }

--- a/smart-contracts/tests/agents/report.test.ts
+++ b/smart-contracts/tests/agents/report.test.ts
@@ -126,6 +126,7 @@ describe('ReportAgent', () => {
   });
 
   it('produces deterministic section structure from fixtures', () => {
+    jest.useFakeTimers();
     const first = assembleReportFromUpstream(
       'Solar energy market entry in Southeast Asia',
       [researchFixture, riskFixture],
@@ -134,6 +135,7 @@ describe('ReportAgent', () => {
       'Solar energy market entry in Southeast Asia',
       [researchFixture, riskFixture],
     );
+    jest.useRealTimers();
 
     expect(second).toEqual(first);
     expect(first.sections[0].heading).toBe('Executive Summary');

--- a/smart-contracts/tests/venice.test.ts
+++ b/smart-contracts/tests/venice.test.ts
@@ -1,0 +1,328 @@
+import { EventEmitter } from 'events';
+import axios from 'axios';
+import { VeniceClient } from '../src/venice/venice';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const makeSuccessResponse = (content: string) => ({
+  data: { choices: [{ message: { content } }] },
+});
+
+const makeStreamResponse = (lines: string[]) => {
+  const emitter = new EventEmitter();
+  setTimeout(() => {
+    for (const line of lines) {
+      emitter.emit('data', Buffer.from(line));
+    }
+    emitter.emit('end');
+  }, 0);
+  return { data: emitter };
+};
+
+describe('VeniceClient', () => {
+  let client: VeniceClient;
+
+  beforeEach(() => {
+    process.env.VENICE_API_KEY = 'test-key';
+    client = new VeniceClient();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.VENICE_API_KEY;
+  });
+
+  describe('complete', () => {
+    it('returns a full string response for a simple prompt', async () => {
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('Hello from Venice'));
+      const result = await client.complete('Say hello', 'venice-xl');
+      expect(result).toBe('Hello from Venice');
+    });
+
+    it('resolves model via routing map when capability name is passed', async () => {
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('ok'));
+      await client.complete('prompt', 'research');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ model: 'venice-xl' }),
+        expect.any(Object),
+      );
+    });
+
+    it('uses direct model id when not in routing map', async () => {
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('ok'));
+      await client.complete('prompt', 'custom-model');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ model: 'custom-model' }),
+        expect.any(Object),
+      );
+    });
+
+    it('throws when VENICE_API_KEY is not set', async () => {
+      delete process.env.VENICE_API_KEY;
+      const noKeyClient = new VeniceClient();
+      await expect(noKeyClient.complete('prompt', 'venice-xl')).rejects.toThrow(
+        'VENICE_API_KEY is not configured',
+      );
+    });
+
+    it('reads API key exclusively from process.env.VENICE_API_KEY', async () => {
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('ok'));
+      await client.complete('prompt', 'venice-xl');
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer test-key' }),
+        }),
+      );
+    });
+
+    it('throws when response has no content', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: { choices: [] } });
+      await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow(
+        'Venice returned an empty response',
+      );
+    });
+
+    it('truncates prompt to 200 chars in logs', async () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('ok'));
+      const longPrompt = 'x'.repeat(300);
+      await client.complete(longPrompt, 'venice-xl');
+      const logArg: string = consoleSpy.mock.calls[0][0];
+      expect(logArg).toContain('x'.repeat(200) + '…');
+      expect(logArg).not.toContain('x'.repeat(201) + 'x');
+      consoleSpy.mockRestore();
+    });
+
+    it('spreads extra options into the request body', async () => {
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('ok'));
+      await client.complete('prompt', 'venice-xl', { temperature: 0.5, max_tokens: 100 });
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ temperature: 0.5, max_tokens: 100 }),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('stream', () => {
+    it('calls onChunk for each SSE content delta and resolves after [DONE]', async () => {
+      const sseLines = [
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+        'data: [DONE]\n',
+      ];
+      mockedAxios.post.mockResolvedValueOnce(makeStreamResponse(sseLines));
+
+      const chunks: string[] = [];
+      await client.stream('prompt', 'venice-xl', (c) => chunks.push(c));
+
+      expect(chunks).toEqual(['Hello', ' world']);
+    });
+
+    it('calls onChunk multiple times before resolving', async () => {
+      const sseLines = [
+        'data: {"choices":[{"delta":{"content":"A"}}]}\n',
+        'data: {"choices":[{"delta":{"content":"B"}}]}\n',
+        'data: {"choices":[{"delta":{"content":"C"}}]}\n',
+        'data: [DONE]\n',
+      ];
+      mockedAxios.post.mockResolvedValueOnce(makeStreamResponse(sseLines));
+
+      const onChunk = jest.fn();
+      await client.stream('prompt', 'venice-xl', onChunk);
+
+      expect(onChunk).toHaveBeenCalledTimes(3);
+    });
+
+    it('resolves only after stream ends', async () => {
+      const emitter = new EventEmitter();
+      mockedAxios.post.mockResolvedValueOnce({ data: emitter });
+
+      let resolved = false;
+      const streamPromise = client
+        .stream('prompt', 'venice-xl', () => {})
+        .then(() => {
+          resolved = true;
+        });
+
+      // Allow axios mock promise to resolve and stream listeners to be registered
+      await new Promise<void>((r) => setImmediate(r));
+
+      expect(resolved).toBe(false);
+      emitter.emit('data', Buffer.from('data: {"choices":[{"delta":{"content":"x"}}]}\n'));
+      expect(resolved).toBe(false);
+      emitter.emit('end');
+
+      await streamPromise;
+      expect(resolved).toBe(true);
+    });
+
+    it('rejects when stream emits an error', async () => {
+      const emitter = new EventEmitter();
+      mockedAxios.post.mockResolvedValueOnce({ data: emitter });
+
+      const streamPromise = client.stream('prompt', 'venice-xl', () => {});
+
+      // Wait for axios mock to resolve and the error listener to be registered
+      await new Promise<void>((r) => setImmediate(r));
+
+      emitter.emit('error', new Error('stream error'));
+
+      await expect(streamPromise).rejects.toThrow('stream error');
+    });
+
+    it('ignores malformed SSE lines', async () => {
+      const sseLines = [
+        'data: not-json\n',
+        'data: {"choices":[{"delta":{"content":"ok"}}]}\n',
+        'data: [DONE]\n',
+      ];
+      mockedAxios.post.mockResolvedValueOnce(makeStreamResponse(sseLines));
+
+      const chunks: string[] = [];
+      await client.stream('prompt', 'venice-xl', (c) => chunks.push(c));
+
+      expect(chunks).toEqual(['ok']);
+    });
+  });
+
+  describe('model routing', () => {
+    const cases: Array<[string, string]> = [
+      ['research', 'venice-xl'],
+      ['risk', 'venice-xl'],
+      ['coding', 'venice-code'],
+      ['design', 'venice-xl'],
+      ['report', 'venice-xl'],
+    ];
+
+    it.each(cases)('getModelForAgent("%s") returns "%s"', (capability, expected) => {
+      expect(client.getModelForAgent(capability)).toBe(expected);
+    });
+
+    it('falls back to venice-xl for unknown capability', () => {
+      expect(client.getModelForAgent('unknown')).toBe('venice-xl');
+    });
+  });
+
+  describe('circuit breaker', () => {
+    it('opens after 3 consecutive failures', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('server error'));
+
+      for (let i = 0; i < 3; i++) {
+        await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow('server error');
+      }
+
+      await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow(
+        'Circuit breaker is OPEN',
+      );
+      // axios.post was called exactly 3 times — 4th call was rejected without hitting the network
+      expect(mockedAxios.post).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects calls immediately in open state without hitting the network', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('server error'));
+
+      for (let i = 0; i < 3; i++) {
+        await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow();
+      }
+
+      jest.clearAllMocks();
+
+      await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow(
+        'Circuit breaker is OPEN',
+      );
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('transitions closed → open → half-open → closed', async () => {
+      const dateSpy = jest.spyOn(Date, 'now');
+      let now = 1_000_000;
+      dateSpy.mockImplementation(() => now);
+
+      // Closed → Open: trigger 3 failures
+      mockedAxios.post.mockRejectedValue(new Error('server error'));
+      for (let i = 0; i < 3; i++) {
+        await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow('server error');
+      }
+
+      // Verify OPEN: call rejected without hitting network
+      jest.clearAllMocks();
+      await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow(
+        'Circuit breaker is OPEN',
+      );
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+
+      // Advance clock past 60s cooldown
+      now += 60_001;
+
+      // Open → Half-open → Closed: successful probe closes the circuit
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('probe ok'));
+      const result = await client.complete('prompt', 'venice-xl');
+      expect(result).toBe('probe ok');
+
+      // Verify CLOSED: subsequent calls work normally without circuit error
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('normal'));
+      await expect(client.complete('prompt', 'venice-xl')).resolves.toBe('normal');
+
+      dateSpy.mockRestore();
+    });
+
+    it('reopens from half-open on failure', async () => {
+      const dateSpy = jest.spyOn(Date, 'now');
+      let now = 1_000_000;
+      dateSpy.mockImplementation(() => now);
+
+      // Trigger OPEN
+      mockedAxios.post.mockRejectedValue(new Error('server error'));
+      for (let i = 0; i < 3; i++) {
+        await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow();
+      }
+
+      // Advance to HALF_OPEN
+      now += 60_001;
+
+      // Probe fails → back to OPEN
+      mockedAxios.post.mockRejectedValue(new Error('still down'));
+      await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow('still down');
+
+      // Immediately rejected again — circuit is OPEN
+      jest.clearAllMocks();
+      await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow(
+        'Circuit breaker is OPEN',
+      );
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+
+      dateSpy.mockRestore();
+    });
+
+    it('resets failure count after a success', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('err'));
+
+      // 2 failures — not yet open
+      for (let i = 0; i < 2; i++) {
+        await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow();
+      }
+
+      // 1 success — resets counter
+      mockedAxios.post.mockResolvedValueOnce(makeSuccessResponse('ok'));
+      await expect(client.complete('prompt', 'venice-xl')).resolves.toBe('ok');
+
+      // 2 more failures — still not open (counter was reset)
+      mockedAxios.post.mockRejectedValue(new Error('err'));
+      for (let i = 0; i < 2; i++) {
+        await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow('err');
+      }
+
+      // 3rd failure in new run opens it
+      await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow('err');
+      await expect(client.complete('prompt', 'venice-xl')).rejects.toThrow(
+        'Circuit breaker is OPEN',
+      );
+    });
+  });
+});

--- a/smart-contracts/tsconfig.json
+++ b/smart-contracts/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
…reaker

- Add VeniceClient with complete() and stream() methods
- Add model routing map per agent type (research, risk, coding, design, report)
- Implement circuit breaker: open after 3 failures, reset after 60s cooldown
- Add request logging with prompt truncation to 200 chars
- Read API key exclusively from process.env.VENICE_API_KEY
- Add unit tests for circuit breaker state transitions

Closes #4