### PR TITLE
Venice-powered code generation agent with Zod validation and upstream…

### DIFF
--- a/smart-contracts/package-lock.json
+++ b/smart-contracts/package-lock.json
@@ -56,7 +56,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1425,7 +1424,6 @@
       "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1494,7 +1492,6 @@
       "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.13.0",
         "@typescript-eslint/types": "7.13.0",
@@ -1661,7 +1658,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2117,7 +2113,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2704,7 +2699,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3768,7 +3762,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5661,7 +5654,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5762,7 +5754,6 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/smart-contracts/src/agents/coding/coding.ts
+++ b/smart-contracts/src/agents/coding/coding.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { registerAgent } from '../../registry/registry';
+import { Agent, AgentResult, SubTask } from '../../types/agent';
+import { VeniceClient } from '../../venice/venice';
+
+const CodingOutputSchema = z.object({
+  language: z.string(),
+  code: z.string().min(1, 'Code field cannot be empty'),
+  explanation: z.string(),
+  dependencies: z.array(z.string()),
+});
+
+export type CodingOutput = z.infer<typeof CodingOutputSchema>;
+
+const AGENT_ID = 'coding-agent-1';
+const AGENT_NAME = 'Coding Agent';
+const AGENT_CAPABILITY = 'coding';
+
+export class CodingAgent implements Agent {
+  constructor(private readonly venice: VeniceClient) {}
+
+  start(): void {
+    // registration happens on module load
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return Boolean(process.env.VENICE_API_KEY);
+  }
+
+  async execute(task: SubTask): Promise<AgentResult> {
+    const upstreamContext = task.upstreamResults?.length
+      ? `\n\nUpstream context:\n${JSON.stringify(task.upstreamResults, null, 2)}`
+      : '';
+
+    const prompt = [
+      'You are a code generation assistant. Respond with valid JSON only, no markdown.',
+      'Format: {"language":"string","code":"string","explanation":"string","dependencies":["string"]}',
+      upstreamContext,
+      `\nTask: ${task.prompt}`,
+    ].join('\n');
+
+    const model = this.venice.getModelForAgent(AGENT_CAPABILITY);
+    const content = await this.venice.complete(prompt, model);
+
+    const parsed = CodingOutputSchema.parse(JSON.parse(content));
+
+    return {
+      agentId: AGENT_ID,
+      agentName: AGENT_NAME,
+      capability: AGENT_CAPABILITY,
+      data: parsed,
+    };
+  }
+}
+
+registerAgent({
+  id: AGENT_ID,
+  name: AGENT_NAME,
+  capability: AGENT_CAPABILITY,
+  priceXLM: 1,
+  stellarAddress: '',
+});

--- a/smart-contracts/tests/coding.test.ts
+++ b/smart-contracts/tests/coding.test.ts
@@ -1,0 +1,87 @@
+import { CodingAgent, CodingOutput } from '../src/agents/coding/coding';
+import { getAgent } from '../src/registry/registry';
+import { VeniceClient } from '../src/venice/venice';
+
+const makeVenice = (response: object) => ({
+  complete: jest.fn().mockResolvedValue(JSON.stringify(response)),
+  getModelForAgent: jest.fn().mockReturnValue('venice-code'),
+  stream: jest.fn(),
+});
+
+const baseCodeResponse = {
+  language: 'typescript',
+  code: 'const add = (a: number, b: number): number => a + b;',
+  explanation: 'A simple function that adds two numbers.',
+  dependencies: [],
+};
+
+describe('CodingAgent', () => {
+
+  it('returns valid CodingOutput for a code generation prompt', async () => {
+    const venice = makeVenice(baseCodeResponse);
+    const agent = new CodingAgent(venice as unknown as VeniceClient);
+    const result = await agent.execute({
+      prompt: 'Write a function to add two numbers',
+    });
+    const output = result.data as CodingOutput;
+
+    expect(output.language).toBe('typescript');
+    expect(output.code).toBe(baseCodeResponse.code);
+    expect(output.explanation).toBeTruthy();
+    expect(Array.isArray(output.dependencies)).toBe(true);
+  });
+
+  it('uses venice-code model via getModelForAgent', async () => {
+    const venice = makeVenice(baseCodeResponse);
+    const agent = new CodingAgent(venice as unknown as VeniceClient);
+    await agent.execute({ prompt: 'Write a function' });
+
+    expect(venice.getModelForAgent).toHaveBeenCalledWith('coding');
+    expect(venice.complete).toHaveBeenCalledWith(
+      expect.any(String),
+      'venice-code',
+    );
+  });
+
+  it('Zod rejects response missing code field', async () => {
+    const venice = makeVenice({
+      language: 'ts',
+      explanation: '',
+      dependencies: [],
+    });
+    const agent = new CodingAgent(venice as unknown as VeniceClient);
+    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
+  });
+
+  it('registers with capability "coding" on module load', () => {
+    const meta = getAgent('coding-agent-1');
+    expect(meta?.capability).toBe('coding');
+  });
+
+  it('includes upstream context when upstreamResults are provided', async () => {
+    const venice = makeVenice(baseCodeResponse);
+    const agent = new CodingAgent(venice as unknown as VeniceClient);
+    await agent.execute({
+      prompt: 'Write a function',
+      upstreamResults: [
+        {
+          agentId: 'research-1',
+          agentName: 'Research Agent',
+          capability: 'research',
+          data: { summary: 'Growing market identified' },
+        },
+      ],
+    });
+
+    const promptArg = venice.complete.mock.calls[0][0] as string;
+    expect(promptArg).toContain('Growing market identified');
+  });
+
+  it('healthCheck returns false when VENICE_API_KEY is not set', async () => {
+    delete process.env.VENICE_API_KEY;
+    const venice = makeVenice(baseCodeResponse);
+    const agent = new CodingAgent(venice as unknown as VeniceClient);
+    const healthy = await agent.healthCheck();
+    expect(healthy).toBe(false);
+  });
+});


### PR DESCRIPTION

Closes #56 

## Summary

- Implements Agent (types/agent.ts) with start(), healthCheck(), execute()
- execute() builds a system prompt instructing the model to return JSON, appends any upstream context from task.upstreamResults, calls VeniceClient.getModelForAgent('coding') → 'venice-code', then venice.complete(prompt, model), and validates the response with a Zod schema requiring code to be a non-empty string
- Registers with the registry as capability "coding" via module-load side-effect 



## Changes
Created two files

1. smart-contracts/src/agents/coding/coding.ts which is a New CodingAgent class implementing the Agent interface, with Zod-validated CodingOutput, Venice model routing via getModelForAgent('coding'), and module-load registration.
2. smart-contracts/tests/coding.test.ts a 6 unit tests covering valid output, model routing, Zod rejection, registration, upstream context, and health check.

## Testing
 Mocked VeniceClient with jest.fn() stubs for complete, getModelForAgent, stream
- Covers: valid output shape, model routing assertion, Zod rejection of missing code, module-load registration, upstream context injection, and healthCheck without API key

## Related Issue
Closes #56 

## Checklist

- [x] Tests pass
- [x] Lint is clean
- [x] Documentation updated if needed
