### PR TITLE
feat(backend): rate limiting and optional API key auth (#65)

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -9,6 +9,8 @@ import { createTask, getTask } from '../coordinator/taskStore';
 import { eventBus } from '../coordinator/eventBus';
 import type { DAGEvent } from '../coordinator/types';
 import { createPaymentReleaseFn, type StellarReleasePaymentFn } from '../payment';
+import { rateLimitMiddleware } from './middleware/rateLimit';
+import { authMiddleware } from './middleware/auth';
 
 export interface AppOptions {
   /** Called to execute a single DAG node; defaults to HTTP dispatch */
@@ -41,7 +43,7 @@ export function createApp(opts: AppOptions = {}): { httpServer: HttpServer; clos
     opts.releasePayment ?? createPaymentReleaseFn(tryLoadStellarRelease());
 
   // ── POST /api/tasks ────────────────────────────────────────────────────────
-  app.post('/api/tasks', (req: Request, res: Response) => {
+  app.post('/api/tasks', authMiddleware, rateLimitMiddleware, (req: Request, res: Response) => {
     const { prompt, walletPublicKey } = req.body as {
       prompt?: string;
       walletPublicKey?: string;

--- a/backend/src/api/middleware/auth.ts
+++ b/backend/src/api/middleware/auth.ts
@@ -1,0 +1,26 @@
+import type { Request, Response, NextFunction } from 'express';
+
+function loadKeys(): Set<string> | null {
+  const raw = process.env.API_KEYS;
+  if (!raw) return null;
+  const keys = raw.split(',').map(k => k.trim()).filter(Boolean);
+  return keys.length ? new Set(keys) : null;
+}
+
+export function authMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const keys = loadKeys();
+  if (!keys) {
+    // API_KEYS unset — no-op, backward compatible
+    next();
+    return;
+  }
+
+  const auth = req.headers['authorization'] ?? '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!token || !keys.has(token)) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  next();
+}

--- a/backend/src/api/middleware/rateLimit.ts
+++ b/backend/src/api/middleware/rateLimit.ts
@@ -1,0 +1,37 @@
+import type { Request, Response, NextFunction } from 'express';
+
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS = 20;
+
+/** Per-IP sliding-window entry */
+interface Window {
+  timestamps: number[];
+}
+
+const windows = new Map<string, Window>();
+
+export function rateLimitMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const ip = req.ip ?? 'unknown';
+  const now = Date.now();
+  const cutoff = now - WINDOW_MS;
+
+  let win = windows.get(ip);
+  if (!win) {
+    win = { timestamps: [] };
+    windows.set(ip, win);
+  }
+
+  // Evict timestamps outside the window
+  win.timestamps = win.timestamps.filter(t => t > cutoff);
+
+  if (win.timestamps.length >= MAX_REQUESTS) {
+    const oldest = win.timestamps[0]!;
+    const retryAfter = Math.ceil((oldest + WINDOW_MS - now) / 1000);
+    res.setHeader('Retry-After', String(retryAfter));
+    res.status(429).json({ error: 'Too many requests' });
+    return;
+  }
+
+  win.timestamps.push(now);
+  next();
+}

--- a/backend/tests/middleware.test.ts
+++ b/backend/tests/middleware.test.ts
@@ -1,0 +1,130 @@
+import { Request, Response, NextFunction } from 'express';
+
+// ── rateLimit ─────────────────────────────────────────────────────────────────
+
+// Re-require between tests to get a fresh module with empty windows map
+function freshRateLimit() {
+  jest.resetModules();
+  return require('../src/api/middleware/rateLimit').rateLimitMiddleware as typeof import('../src/api/middleware/rateLimit').rateLimitMiddleware;
+}
+
+function makeReq(ip = '127.0.0.1'): Request {
+  return { ip } as unknown as Request;
+}
+
+function makeRes(): { status: jest.Mock; json: jest.Mock; setHeader: jest.Mock; _status?: number } {
+  const res: ReturnType<typeof makeRes> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn(),
+  };
+  return res;
+}
+
+describe('rateLimitMiddleware', () => {
+  it('allows first 20 requests', () => {
+    const rateLimitMiddleware = freshRateLimit();
+    const req = makeReq();
+    for (let i = 0; i < 20; i++) {
+      const next = jest.fn();
+      rateLimitMiddleware(req, makeRes() as unknown as Response, next as NextFunction);
+      expect(next).toHaveBeenCalled();
+    }
+  });
+
+  it('blocks the 21st request with 429 and Retry-After header', () => {
+    const rateLimitMiddleware = freshRateLimit();
+    const req = makeReq();
+    const next = jest.fn();
+    for (let i = 0; i < 20; i++) {
+      rateLimitMiddleware(req, makeRes() as unknown as Response, next as NextFunction);
+    }
+    const res = makeRes();
+    rateLimitMiddleware(req, res as unknown as Response, jest.fn() as NextFunction);
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.setHeader).toHaveBeenCalledWith('Retry-After', expect.any(String));
+  });
+
+  it('does not rate-limit a different IP', () => {
+    const rateLimitMiddleware = freshRateLimit();
+    const next = jest.fn();
+    for (let i = 0; i < 20; i++) {
+      rateLimitMiddleware(makeReq('1.2.3.4'), makeRes() as unknown as Response, next as NextFunction);
+    }
+    // different IP should still pass
+    const next2 = jest.fn();
+    rateLimitMiddleware(makeReq('5.6.7.8'), makeRes() as unknown as Response, next2 as NextFunction);
+    expect(next2).toHaveBeenCalled();
+  });
+
+  it('allows requests again after window expires', () => {
+    jest.useFakeTimers();
+    const rateLimitMiddleware = freshRateLimit();
+    const req = makeReq('10.0.0.1');
+
+    for (let i = 0; i < 20; i++) {
+      rateLimitMiddleware(req, makeRes() as unknown as Response, jest.fn() as NextFunction);
+    }
+
+    // Advance past the 60s window
+    jest.advanceTimersByTime(61_000);
+
+    const next = jest.fn();
+    rateLimitMiddleware(req, makeRes() as unknown as Response, next as NextFunction);
+    expect(next).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});
+
+// ── authMiddleware ────────────────────────────────────────────────────────────
+
+function freshAuth(apiKeys?: string) {
+  jest.resetModules();
+  if (apiKeys !== undefined) {
+    process.env.API_KEYS = apiKeys;
+  } else {
+    delete process.env.API_KEYS;
+  }
+  return require('../src/api/middleware/auth').authMiddleware as typeof import('../src/api/middleware/auth').authMiddleware;
+}
+
+function makeAuthReq(authHeader?: string): Request {
+  return {
+    headers: authHeader ? { authorization: authHeader } : {},
+  } as unknown as Request;
+}
+
+afterEach(() => {
+  delete process.env.API_KEYS;
+  jest.resetModules();
+});
+
+describe('authMiddleware', () => {
+  it('passes all requests when API_KEYS is unset', () => {
+    const authMiddleware = freshAuth(undefined);
+    const next = jest.fn();
+    authMiddleware(makeAuthReq(), makeRes() as unknown as Response, next as NextFunction);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('passes request with valid API key', () => {
+    const authMiddleware = freshAuth('key-abc,key-xyz');
+    const next = jest.fn();
+    authMiddleware(makeAuthReq('Bearer key-abc'), makeRes() as unknown as Response, next as NextFunction);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 401 for invalid API key', () => {
+    const authMiddleware = freshAuth('key-abc');
+    const res = makeRes();
+    authMiddleware(makeAuthReq('Bearer wrong-key'), res as unknown as Response, jest.fn() as NextFunction);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 401 when Authorization header is missing', () => {
+    const authMiddleware = freshAuth('key-abc');
+    const res = makeRes();
+    authMiddleware(makeAuthReq(), res as unknown as Response, jest.fn() as NextFunction);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});


### PR DESCRIPTION
## Summary

Adds request rate limiting and optional API key authentication to `POST /api/tasks`, resolving issue #65.

## Changes

**`backend/src/api/middleware/rateLimit.ts`** (new)
- Sliding-window rate limiter: max 20 requests/minute per IP (in-memory, no Redis)
- Returns `429` with `Retry-After` header (seconds until window clears) when exceeded

**`backend/src/api/middleware/auth.ts`** (new)
- Reads `API_KEYS` env var (comma-separated); if unset → no-op (backward compatible)
- Validates `Authorization: Bearer <key>` header; returns `401` if missing or invalid

**`backend/src/api/app.ts`**
- `POST /api/tasks` now runs `authMiddleware` → `rateLimitMiddleware` → handler

**`backend/tests/middleware.test.ts`** (new)
- 8 unit tests: first 20 pass, 21st returns 429, Retry-After present, different IP unaffected, window expiry re-allows, valid key passes, invalid key 401, missing header 401, unset `API_KEYS` passes all

## Test Results

```
Tests: 46 passed, 2 skipped (Stellar E2E)
```

Closes #65