### PR TITLE
feat: live DAG task-stream WebSocket at /tasks/:id/stream

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -1,13 +1,13 @@
-import express, { Request, Response, NextFunction } from 'express';
+import express, { Request, Response } from 'express';
 import { createServer, Server as HttpServer } from 'http';
-import { WebSocketServer, WebSocket } from 'ws';
 import { randomUUID } from 'crypto';
 
 import { decompose } from '../coordinator/decompose';
 import { executeDAG, type DispatchFn, type PaymentReleaseFn } from '../coordinator/coordinator';
 import { createTask, getTask } from '../coordinator/taskStore';
 import { eventBus } from '../coordinator/eventBus';
-import type { DAGEvent } from '../coordinator/types';
+import { createEventStore, type EventStore } from '../coordinator/eventStore';
+import { attachTaskStream, type TaskStreamOptions } from './routes/stream';
 import { createPaymentReleaseFn, type StellarReleasePaymentFn } from '../payment';
 
 export interface AppOptions {
@@ -15,6 +15,10 @@ export interface AppOptions {
   dispatch?: DispatchFn;
   /** Called after each node completes; defaults to no-op (returns 'mock-hash') */
   releasePayment?: PaymentReleaseFn;
+  /** Event log for stream replay; defaults to an in-memory SQLite store */
+  eventStore?: EventStore;
+  /** Heartbeat / auth timing for the WebSocket stream */
+  stream?: TaskStreamOptions;
 }
 
 /**
@@ -85,62 +89,25 @@ export function createApp(opts: AppOptions = {}): { httpServer: HttpServer; clos
   // ── HTTP server ────────────────────────────────────────────────────────────
   const httpServer = createServer(app);
 
+  // ── Event persistence ──────────────────────────────────────────────────────
+  // Record every Coordinator event so a (re)connecting client can replay the
+  // task's full history before live streaming begins.
+  const eventStore = opts.eventStore ?? createEventStore();
+  const stopRecording = eventBus.subscribeAll(event => eventStore.append(event));
+
   // ── WebSocket: /tasks/:id/stream ───────────────────────────────────────────
-  const wss = new WebSocketServer({ noServer: true });
-
-  httpServer.on('upgrade', (req, socket, head) => {
-    const url = req.url ?? '';
-    const match = url.match(/^\/tasks\/([^/]+)\/stream$/);
-    if (!match) {
-      socket.destroy();
-      return;
-    }
-    wss.handleUpgrade(req, socket, head, ws => {
-      wss.emit('connection', ws, req, match[1]);
-    });
-  });
-
-  wss.on('connection', (ws: WebSocket, _req: unknown, taskId: string) => {
-    const task = getTask(taskId);
-    if (!task) {
-      ws.close(4004, 'Task not found');
-      return;
-    }
-
-    // Subscribe before replay so no live events are missed in the window between
-    const unsub = eventBus.subscribe(taskId, (event: DAGEvent) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify(event));
-      }
-    });
-
-    // Replay past events derived from current DAG + task state
-    for (const node of task.dag) {
-      if (node.status === 'running' || node.status === 'completed' || node.status === 'failed') {
-        ws.send(JSON.stringify({ type: 'node_started',    taskId, nodeId: node.nodeId, timestamp: task.updatedAt }));
-      }
-      if (node.status === 'completed') {
-        ws.send(JSON.stringify({ type: 'payment_released', taskId, nodeId: node.nodeId, timestamp: task.updatedAt }));
-        ws.send(JSON.stringify({ type: 'node_completed',  taskId, nodeId: node.nodeId, timestamp: task.updatedAt }));
-      }
-      if (node.status === 'failed') {
-        ws.send(JSON.stringify({ type: 'node_failed', taskId, nodeId: node.nodeId, timestamp: task.updatedAt }));
-      }
-    }
-
-    // If the task is already terminal, synthesize the final event so clients can exit
-    if (task.status === 'completed') {
-      ws.send(JSON.stringify({ type: 'task_completed', taskId, timestamp: task.updatedAt }));
-    } else if (task.status === 'failed') {
-      ws.send(JSON.stringify({ type: 'task_failed', taskId, timestamp: task.updatedAt }));
-    }
-
-    ws.on('close', unsub);
-    ws.on('error', unsub);
+  const detachStream = attachTaskStream({
+    httpServer,
+    eventStore,
+    eventBus,
+    getTask,
+    ...opts.stream,
   });
 
   function close(): void {
-    wss.close();
+    detachStream();
+    stopRecording();
+    eventStore.close();
     httpServer.close();
   }
 

--- a/backend/src/api/routes/stream.ts
+++ b/backend/src/api/routes/stream.ts
@@ -1,0 +1,186 @@
+import type { Server as HttpServer } from 'http';
+import type { Socket } from 'net';
+import type { IncomingMessage } from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
+
+import { eventBus as defaultEventBus } from '../../coordinator/eventBus';
+import { getTask as defaultGetTask } from '../../coordinator/taskStore';
+import type { EventStore } from '../../coordinator/eventStore';
+import type { Task } from '../../coordinator/types';
+import { WS_CLOSE } from '../../types/stream';
+
+const STREAM_PATH = /^\/tasks\/([^/]+)\/stream$/;
+
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+const DEFAULT_PONG_TIMEOUT_MS = 10_000;
+const DEFAULT_AUTH_TIMEOUT_MS = 10_000;
+
+export interface TaskStreamOptions {
+  /** Interval between server heartbeat pings. Default 30s. */
+  heartbeatIntervalMs?: number;
+  /** How long to wait for a pong before closing as stale. Default 10s. */
+  pongTimeoutMs?: number;
+  /** How long to wait for the auth handshake before closing. Default 10s. */
+  authTimeoutMs?: number;
+}
+
+export interface TaskStreamDeps extends TaskStreamOptions {
+  httpServer: HttpServer;
+  eventStore: EventStore;
+  eventBus?: typeof defaultEventBus;
+  getTask?: (taskId: string) => Task | undefined;
+}
+
+/**
+ * Attach the live DAG-execution stream to an HTTP server.
+ *
+ * Exposes ws://<host>/tasks/:id/stream. Each connection:
+ *   1. must send `{ walletPublicKey }` as its first message (auth handshake);
+ *   2. is validated against the task owner — non-owners get a 403 close frame;
+ *   3. receives a chronological replay of all past events from the store;
+ *   4. then streams live events as the Coordinator emits them.
+ *
+ * A heartbeat ping is sent on an interval and the socket is closed if no pong
+ * arrives in time. All subscriptions and timers are cleaned up on disconnect.
+ *
+ * @returns a detach function that stops the stream and closes open sockets.
+ */
+export function attachTaskStream(deps: TaskStreamDeps): () => void {
+  const {
+    httpServer,
+    eventStore,
+    eventBus = defaultEventBus,
+    getTask = defaultGetTask,
+    heartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS,
+    pongTimeoutMs = DEFAULT_PONG_TIMEOUT_MS,
+    authTimeoutMs = DEFAULT_AUTH_TIMEOUT_MS,
+  } = deps;
+
+  const wss = new WebSocketServer({ noServer: true });
+
+  const onUpgrade = (req: IncomingMessage, socket: Socket, head: Buffer): void => {
+    const match = (req.url ?? '').match(STREAM_PATH);
+    if (!match) {
+      socket.destroy();
+      return;
+    }
+    const taskId = match[1]!;
+    wss.handleUpgrade(req, socket, head, ws => {
+      wss.emit('connection', ws, req, taskId);
+    });
+  };
+
+  httpServer.on('upgrade', onUpgrade);
+
+  wss.on('connection', (ws: WebSocket, _req: IncomingMessage, taskId: string) => {
+    const task = getTask(taskId);
+    if (!task) {
+      ws.close(WS_CLOSE.TASK_NOT_FOUND, 'Task not found');
+      return;
+    }
+
+    let authed = false;
+    let lastSentSeq = 0;
+    let unsubLive: (() => void) | undefined;
+    let heartbeat: NodeJS.Timeout | undefined;
+    let pongTimer: NodeJS.Timeout | undefined;
+
+    // Close the socket if the client never completes the auth handshake.
+    const authTimer = setTimeout(() => {
+      if (!authed && ws.readyState === WebSocket.OPEN) {
+        ws.close(WS_CLOSE.AUTH_TIMEOUT, 'Auth handshake timed out');
+      }
+    }, authTimeoutMs);
+
+    const send = (data: unknown): void => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(data));
+      }
+    };
+
+    // Stream every persisted event newer than the last one we sent. Driven by
+    // both the initial replay and each live emit, so ordering is canonical
+    // (store seq) and no event is ever sent twice.
+    const flush = (): void => {
+      const events = eventStore.listByTaskSince(taskId, lastSentSeq);
+      for (const event of events) {
+        const { seq, ...dagEvent } = event;
+        send(dagEvent);
+        lastSentSeq = seq;
+      }
+    };
+
+    const cleanup = (): void => {
+      clearTimeout(authTimer);
+      if (heartbeat) clearInterval(heartbeat);
+      if (pongTimer) clearTimeout(pongTimer);
+      if (unsubLive) unsubLive();
+    };
+
+    const startHeartbeat = (): void => {
+      heartbeat = setInterval(() => {
+        if (ws.readyState !== WebSocket.OPEN) return;
+        send({ type: 'ping' });
+        if (pongTimer) clearTimeout(pongTimer);
+        pongTimer = setTimeout(() => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.close(WS_CLOSE.STALE, 'Heartbeat timeout');
+          }
+        }, pongTimeoutMs);
+      }, heartbeatIntervalMs);
+    };
+
+    const completeAuth = (walletPublicKey: string): void => {
+      if (walletPublicKey !== task.walletPublicKey) {
+        ws.close(WS_CLOSE.FORBIDDEN, 'Forbidden: wallet does not own task');
+        return;
+      }
+      authed = true;
+      clearTimeout(authTimer);
+
+      // Subscribe before the initial replay so any event emitted during replay
+      // is captured; flush() dedupes via lastSentSeq, so order is preserved
+      // and nothing is delivered twice.
+      unsubLive = eventBus.subscribe(taskId, () => flush());
+      flush();
+      startHeartbeat();
+    };
+
+    ws.on('message', raw => {
+      let msg: unknown;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        if (!authed) ws.close(WS_CLOSE.BAD_REQUEST, 'Expected JSON auth message');
+        return;
+      }
+
+      if (!authed) {
+        const walletPublicKey = (msg as { walletPublicKey?: unknown })?.walletPublicKey;
+        if (typeof walletPublicKey !== 'string' || walletPublicKey === '') {
+          ws.close(WS_CLOSE.BAD_REQUEST, 'First message must be { walletPublicKey }');
+          return;
+        }
+        completeAuth(walletPublicKey);
+        return;
+      }
+
+      // Authenticated: the only client message we expect is a heartbeat pong.
+      if ((msg as { type?: unknown })?.type === 'pong' && pongTimer) {
+        clearTimeout(pongTimer);
+        pongTimer = undefined;
+      }
+    });
+
+    ws.on('close', cleanup);
+    ws.on('error', cleanup);
+  });
+
+  return function detach(): void {
+    httpServer.off('upgrade', onUpgrade);
+    for (const client of wss.clients) {
+      client.terminate();
+    }
+    wss.close();
+  };
+}

--- a/backend/src/coordinator/coordinator.ts
+++ b/backend/src/coordinator/coordinator.ts
@@ -100,12 +100,14 @@ export class Coordinator {
     const scheduled = new Set<string>();
     const nodeById = new Map(dag.map(node => [node.nodeId, node]));
     let inFlight = 0;
+    let settled = false;
 
     updateTaskIfPresent(taskId, { status: 'running' });
 
     await new Promise<void>(resolve => {
       const finishIfSettled = (): void => {
-        if (completed.size + failed.size !== dag.length) return;
+        if (settled || completed.size + failed.size !== dag.length) return;
+        settled = true;
 
         const status = failed.size === 0 ? 'completed' : 'failed';
         updateTaskIfPresent(taskId, { status, dag });

--- a/backend/src/coordinator/eventBus.ts
+++ b/backend/src/coordinator/eventBus.ts
@@ -2,16 +2,31 @@ import { EventEmitter } from 'events';
 import type { DAGEvent } from './types';
 
 /**
- * In-process pub/sub bus.  Coordinator emits events; WebSocket handler subscribes per taskId.
+ * In-process pub/sub bus.  Coordinator emits events; WebSocket handlers
+ * subscribe per taskId, and a persistence recorder subscribes to *all* events
+ * via {@link EventBus.subscribeAll} so they can be replayed on reconnect.
  */
 class EventBus extends EventEmitter {
+  /** Internal channel that receives every event regardless of taskId. */
+  private static readonly ALL = '__all__';
+
   emit(taskId: string, event: DAGEvent): boolean {
+    // Notify the persistence recorder FIRST so the event is durably stored
+    // before any per-task subscriber reacts to it.  Live WebSocket handlers
+    // drain newly-persisted rows, so the row must exist by the time they run.
+    super.emit(EventBus.ALL, event);
     return super.emit(taskId, event);
   }
 
   subscribe(taskId: string, handler: (e: DAGEvent) => void): () => void {
     this.on(taskId, handler);
     return () => this.off(taskId, handler);
+  }
+
+  /** Subscribe to every event on the bus (used by the persistence recorder). */
+  subscribeAll(handler: (e: DAGEvent) => void): () => void {
+    this.on(EventBus.ALL, handler);
+    return () => this.off(EventBus.ALL, handler);
   }
 }
 

--- a/backend/src/coordinator/eventStore.ts
+++ b/backend/src/coordinator/eventStore.ts
@@ -1,0 +1,103 @@
+import Database from 'better-sqlite3';
+import type { DAGEvent, DAGEventType } from './types';
+
+/**
+ * A persisted event with its monotonic store sequence id.  The `seq` is the
+ * SQLite autoincrement row id and defines the canonical chronological order
+ * used for replay and for streaming "events newer than X".
+ */
+export interface StoredEvent extends DAGEvent {
+  seq: number;
+}
+
+/**
+ * Durable, ordered log of {@link DAGEvent}s keyed by taskId.  Used to replay a
+ * task's history to a (re)connecting WebSocket client before streaming live
+ * events.  Append order is preserved by an autoincrement primary key, so
+ * replay is always chronological.
+ */
+export interface EventStore {
+  /** Append an event and return it with its assigned sequence id. */
+  append(event: DAGEvent): StoredEvent;
+  /** All events for a task in chronological order. */
+  listByTask(taskId: string): StoredEvent[];
+  /** Events for a task with seq strictly greater than `afterSeq`, ordered. */
+  listByTaskSince(taskId: string, afterSeq: number): StoredEvent[];
+  /** Release underlying resources. */
+  close(): void;
+}
+
+/**
+ * Create a SQLite-backed {@link EventStore}.
+ *
+ * @param db  An existing better-sqlite3 database, or a file path.  Defaults to
+ *            an in-memory database scoped to the process — sufficient for a
+ *            single long-running server and for tests, while still exercising
+ *            the real "replay from DB" code path.
+ */
+export function createEventStore(db?: Database.Database | string): EventStore {
+  const database =
+    typeof db === 'string' ? new Database(db) : db ?? new Database(':memory:');
+
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS task_events (
+      seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+      taskId      TEXT NOT NULL,
+      type        TEXT NOT NULL,
+      nodeId      TEXT,
+      timestamp   TEXT NOT NULL,
+      payloadJson TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_task_events_task ON task_events (taskId, seq);
+  `);
+
+  const insertStmt = database.prepare(`
+    INSERT INTO task_events (taskId, type, nodeId, timestamp, payloadJson)
+    VALUES (@taskId, @type, @nodeId, @timestamp, @payloadJson)
+  `);
+  const listStmt = database.prepare(
+    'SELECT * FROM task_events WHERE taskId = ? ORDER BY seq ASC'
+  );
+  const listSinceStmt = database.prepare(
+    'SELECT * FROM task_events WHERE taskId = ? AND seq > ? ORDER BY seq ASC'
+  );
+
+  function rowToEvent(row: Record<string, unknown>): StoredEvent {
+    const payloadJson = row.payloadJson as string | null;
+    return {
+      seq: row.seq as number,
+      type: row.type as DAGEventType,
+      taskId: row.taskId as string,
+      nodeId: (row.nodeId as string | null) ?? undefined,
+      timestamp: row.timestamp as string,
+      payload: payloadJson != null ? JSON.parse(payloadJson) : undefined,
+    };
+  }
+
+  return {
+    append(event: DAGEvent): StoredEvent {
+      const info = insertStmt.run({
+        taskId: event.taskId,
+        type: event.type,
+        nodeId: event.nodeId ?? null,
+        timestamp: event.timestamp,
+        payloadJson: event.payload !== undefined ? JSON.stringify(event.payload) : null,
+      });
+      return { ...event, seq: Number(info.lastInsertRowid) };
+    },
+
+    listByTask(taskId: string): StoredEvent[] {
+      return (listStmt.all(taskId) as Array<Record<string, unknown>>).map(rowToEvent);
+    },
+
+    listByTaskSince(taskId: string, afterSeq: number): StoredEvent[] {
+      return (listSinceStmt.all(taskId, afterSeq) as Array<Record<string, unknown>>).map(
+        rowToEvent
+      );
+    },
+
+    close(): void {
+      database.close();
+    },
+  };
+}

--- a/backend/src/types/stream.ts
+++ b/backend/src/types/stream.ts
@@ -1,0 +1,54 @@
+/**
+ * WebSocket protocol types for the live task-stream endpoint
+ * (ws://<host>/tasks/:id/stream).
+ *
+ * Handshake:
+ *   1. Client connects and sends an {@link AuthMessage} as its FIRST message.
+ *   2. Server validates ownership of the task; on mismatch it closes the
+ *      socket with {@link WS_CLOSE.FORBIDDEN} (a 403-equivalent close frame).
+ *   3. Server replays all past {@link DAGEvent}s from the store, then streams
+ *      live events as they are emitted.
+ *
+ * Heartbeat:
+ *   Server sends a {@link ServerPingMessage} every 30s and closes the socket
+ *   with {@link WS_CLOSE.STALE} if the client does not reply with a
+ *   {@link ClientPongMessage} within 10s.
+ */
+
+/** First message a client must send: proves which wallet owns the task. */
+export interface AuthMessage {
+  walletPublicKey: string;
+}
+
+/** Client's reply to a server heartbeat ping. */
+export interface ClientPongMessage {
+  type: 'pong';
+}
+
+/** Any message a client may send after the socket opens. */
+export type ClientMessage = AuthMessage | ClientPongMessage;
+
+/** Server heartbeat ping; the client must answer with a {@link ClientPongMessage}. */
+export interface ServerPingMessage {
+  type: 'ping';
+}
+
+/**
+ * Application-defined WebSocket close codes (range 4000–4999 is reserved for
+ * application use per RFC 6455). They mirror the HTTP status they represent so
+ * clients can map a close frame back to a familiar meaning.
+ */
+export const WS_CLOSE = {
+  /** Malformed handshake — first message was not a valid {@link AuthMessage}. */
+  BAD_REQUEST: 4400,
+  /** No auth message arrived before the handshake deadline. */
+  AUTH_TIMEOUT: 4401,
+  /** walletPublicKey does not own the task — HTTP 403 equivalent. */
+  FORBIDDEN: 4403,
+  /** Unknown taskId — HTTP 404 equivalent. */
+  TASK_NOT_FOUND: 4404,
+  /** Heartbeat pong not received in time; connection considered stale. */
+  STALE: 4408,
+} as const;
+
+export type WsCloseCode = (typeof WS_CLOSE)[keyof typeof WS_CLOSE];

--- a/backend/tests/e2e/pipeline.test.ts
+++ b/backend/tests/e2e/pipeline.test.ts
@@ -144,8 +144,12 @@ function collectWsEvents(taskId: string, timeoutMs = 30_000): Promise<Array<Reco
       reject(new Error('WS collection timed out'));
     }, timeoutMs);
 
+    // Auth handshake: the owning wallet must be sent as the first message.
+    ws.on('open', () => ws.send(JSON.stringify({ walletPublicKey: 'GFAKEWALLETPUBLICKEY' })));
+
     ws.on('message', raw => {
       const event = JSON.parse(raw.toString()) as Record<string, unknown>;
+      if (event['type'] === 'ping') return; // heartbeat, not a DAG event
       events.push(event);
       if (event['type'] === 'task_completed' || event['type'] === 'task_failed') {
         clearTimeout(timer);

--- a/backend/tests/e2e/stream.test.ts
+++ b/backend/tests/e2e/stream.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Integration tests for the live task-stream WebSocket — ws://<host>/tasks/:id/stream.
+ *
+ * Covers the acceptance criteria:
+ *   - node_started reaches the client within 100ms of the Coordinator emitting it
+ *   - a non-owner walletPublicKey receives a 403-equivalent close frame
+ *   - reconnecting replays prior events in chronological order with no duplicates
+ *   - the heartbeat closes stale connections that never pong
+ *   - the EventBus subscription is cleaned up on disconnect
+ *   - a full task run streams events in the correct order with no duplicates
+ */
+
+import request from 'supertest';
+import { WebSocket } from 'ws';
+import type { AddressInfo } from 'net';
+import type { Server as HttpServer } from 'http';
+
+import { createApp } from '../../src/api/app';
+import { eventBus } from '../../src/coordinator/eventBus';
+import { WS_CLOSE } from '../../src/types/stream';
+import type { DispatchFn, PaymentReleaseFn } from '../../src/coordinator/coordinator';
+import type { DAGNode } from '../../src/coordinator/types';
+import {
+  researchFixture,
+  riskFixture,
+  codingFixture,
+  designFixture,
+  reportFixture,
+} from '../fixtures/agentResults';
+import type { AgentResult } from '../../src/agents/research/types';
+
+const PROMPT = 'Generate a market-entry report for solar energy in Southeast Asia';
+const OWNER = 'GOWNERWALLETPUBLICKEY';
+const NODE_IDS = ['node_research', 'node_risk', 'node_coding', 'node_design', 'node_report'];
+
+const mockReleasePayment: PaymentReleaseFn = async (_taskId, nodeId) => `fakehash_${nodeId}`;
+
+const fixtureByType: Record<string, AgentResult> = {
+  research: researchFixture,
+  risk: riskFixture,
+  coding: codingFixture,
+  design: designFixture,
+  report: reportFixture,
+};
+
+const mockDispatch: DispatchFn = async (taskId, node: DAGNode, _context) => {
+  const fixture = fixtureByType[node.agentType];
+  if (!fixture) throw new Error(`No fixture for agentType: ${node.agentType}`);
+  await new Promise(r => setTimeout(r, 5));
+  return { ...fixture, taskId, nodeId: node.nodeId };
+};
+
+type WsEvent = Record<string, unknown>;
+
+describe('WebSocket task stream', () => {
+  let httpServer: HttpServer;
+  let wsBase: string;
+  let closeApp: () => void;
+
+  beforeAll(done => {
+    const { httpServer: srv, close } = createApp({
+      dispatch: mockDispatch,
+      releasePayment: mockReleasePayment,
+      // Fast heartbeat so the stale-connection test runs quickly.
+      stream: { heartbeatIntervalMs: 60, pongTimeoutMs: 60, authTimeoutMs: 2_000 },
+    });
+    httpServer = srv;
+    closeApp = close;
+    httpServer.listen(0, '127.0.0.1', () => {
+      const addr = httpServer.address() as AddressInfo;
+      wsBase = `ws://127.0.0.1:${addr.port}`;
+      done();
+    });
+  });
+
+  afterAll(done => {
+    closeApp();
+    done();
+  });
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  async function createTaskFor(wallet: string): Promise<string> {
+    const res = await request(httpServer)
+      .post('/api/tasks')
+      .send({ prompt: PROMPT, walletPublicKey: wallet });
+    return res.body.taskId as string;
+  }
+
+  /** Connect, send the auth handshake, and collect DAG events (ignoring pings). */
+  function connect(
+    taskId: string,
+    wallet: string,
+    opts: { autoPong?: boolean } = {}
+  ): {
+    ws: WebSocket;
+    events: WsEvent[];
+    untilCompleted: Promise<WsEvent[]>;
+    closed: Promise<{ code: number; reason: string }>;
+  } {
+    const ws = new WebSocket(`${wsBase}/tasks/${taskId}/stream`);
+    const events: WsEvent[] = [];
+    let resolveDone!: (e: WsEvent[]) => void;
+    let rejectDone!: (err: Error) => void;
+    const untilCompleted = new Promise<WsEvent[]>((resolve, reject) => {
+      resolveDone = resolve;
+      rejectDone = reject;
+    });
+    const closed = new Promise<{ code: number; reason: string }>(resolve => {
+      ws.on('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+    });
+
+    ws.on('open', () => ws.send(JSON.stringify({ walletPublicKey: wallet })));
+    ws.on('error', () => {
+      /* surfaced via the `closed` promise */
+    });
+    ws.on('message', raw => {
+      const event = JSON.parse(raw.toString()) as WsEvent;
+      if (event.type === 'ping') {
+        if (opts.autoPong !== false) ws.send(JSON.stringify({ type: 'pong' }));
+        return;
+      }
+      events.push(event);
+      if (event.type === 'task_completed') resolveDone(events);
+      if (event.type === 'task_failed') rejectDone(new Error('task failed'));
+    });
+
+    return { ws, events, untilCompleted, closed };
+  }
+
+  function assertNoDuplicateNodeEvents(events: WsEvent[]): void {
+    const keys = events
+      .filter(e => e.nodeId !== undefined)
+      .map(e => `${e.type}:${e.nodeId}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  }
+
+  // ── Tests ──────────────────────────────────────────────────────────────────
+
+  it('streams a full task run in the correct order with no duplicates', async () => {
+    const taskId = await createTaskFor(OWNER);
+    const { ws, events } = connect(taskId, OWNER);
+    const collected = await Promise.race([
+      new Promise<WsEvent[]>((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), 15_000)
+      ),
+      (async () => {
+        // Wait until task_completed shows up.
+        while (!events.some(e => e.type === 'task_completed')) {
+          await new Promise(r => setTimeout(r, 25));
+        }
+        return events;
+      })(),
+    ]);
+
+    const types = collected.map(e => e.type);
+    expect(types.filter(t => t === 'node_started')).toHaveLength(NODE_IDS.length);
+    expect(types.filter(t => t === 'node_completed')).toHaveLength(NODE_IDS.length);
+    expect(types.filter(t => t === 'payment_released')).toHaveLength(NODE_IDS.length);
+    expect(types.filter(t => t === 'task_completed')).toHaveLength(1);
+    expect(types).not.toContain('node_failed');
+    expect(collected[collected.length - 1]!.type).toBe('task_completed');
+
+    assertNoDuplicateNodeEvents(collected);
+
+    // Per-node ordering: started → completed → payment_released.
+    for (const nodeId of NODE_IDS) {
+      const started = collected.findIndex(e => e.type === 'node_started' && e.nodeId === nodeId);
+      const completed = collected.findIndex(e => e.type === 'node_completed' && e.nodeId === nodeId);
+      const paid = collected.findIndex(e => e.type === 'payment_released' && e.nodeId === nodeId);
+      expect(started).toBeGreaterThanOrEqual(0);
+      expect(started).toBeLessThan(completed);
+      expect(completed).toBeLessThan(paid);
+    }
+
+    ws.close();
+  }, 20_000);
+
+  it('delivers node_started to the client within 100ms of the Coordinator emitting it', async () => {
+    // Create a task but do not run it, then connect and emit a node_started
+    // directly on the bus to measure pure stream latency.
+    const taskId = await createTaskFor(OWNER);
+    const { ws } = connect(taskId, OWNER);
+    await new Promise(r => setTimeout(r, 100)); // allow auth handshake to complete
+
+    const latency = await new Promise<number>(resolve => {
+      ws.on('message', raw => {
+        const event = JSON.parse(raw.toString()) as WsEvent;
+        if (event.type === 'node_started' && event.nodeId === 'probe') {
+          resolve(Date.now() - start);
+        }
+      });
+      const start = Date.now();
+      eventBus.emit(taskId, {
+        type: 'node_started',
+        taskId,
+        nodeId: 'probe',
+        timestamp: new Date().toISOString(),
+      });
+    });
+
+    expect(latency).toBeLessThan(100);
+    ws.close();
+  }, 10_000);
+
+  it('closes with a 403 close frame for a non-owner walletPublicKey', async () => {
+    const taskId = await createTaskFor(OWNER);
+    const { closed } = connect(taskId, 'GIMPOSTERWALLETPUBLICKEY');
+    const { code } = await closed;
+    expect(code).toBe(WS_CLOSE.FORBIDDEN);
+  }, 10_000);
+
+  it('replays prior events in chronological order on reconnect', async () => {
+    const taskId = await createTaskFor(OWNER);
+    // Drive the task to completion on a first connection.
+    const first = connect(taskId, OWNER);
+    await first.untilCompleted;
+    first.ws.close();
+
+    // Reconnect fresh — everything must be replayed from the store.
+    const second = connect(taskId, OWNER);
+    const replayed = await second.untilCompleted;
+    second.ws.close();
+
+    const types = replayed.map(e => e.type);
+    expect(types.filter(t => t === 'node_started')).toHaveLength(NODE_IDS.length);
+    expect(types[types.length - 1]).toBe('task_completed');
+    assertNoDuplicateNodeEvents(replayed);
+
+    // Timestamps must be non-decreasing (chronological replay).
+    const timestamps = replayed.map(e => Date.parse(e.timestamp as string));
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i]!).toBeGreaterThanOrEqual(timestamps[i - 1]!);
+    }
+  }, 20_000);
+
+  it('closes stale connections that never pong', async () => {
+    const taskId = await createTaskFor(OWNER);
+    const { closed } = connect(taskId, OWNER, { autoPong: false });
+    const { code } = await closed;
+    expect(code).toBe(WS_CLOSE.STALE);
+  }, 10_000);
+
+  it('cleans up the EventBus subscription on disconnect', async () => {
+    const taskId = await createTaskFor(OWNER);
+    const before = eventBus.listenerCount(taskId);
+
+    const { ws } = connect(taskId, OWNER);
+    // Wait for the auth handshake to register the per-task subscription.
+    await new Promise<void>(resolve => {
+      const poll = setInterval(() => {
+        if (eventBus.listenerCount(taskId) > before) {
+          clearInterval(poll);
+          resolve();
+        }
+      }, 10);
+    });
+    expect(eventBus.listenerCount(taskId)).toBe(before + 1);
+
+    ws.close();
+    await new Promise<void>(resolve => {
+      const poll = setInterval(() => {
+        if (eventBus.listenerCount(taskId) === before) {
+          clearInterval(poll);
+          resolve();
+        }
+      }, 10);
+    });
+    expect(eventBus.listenerCount(taskId)).toBe(before);
+  }, 10_000);
+});


### PR DESCRIPTION
## Summary

Implements the live DAG-execution WebSocket server that the frontend monitoring page subscribes to at `ws://localhost:3001/tasks/:id/stream`.

Closes #23

## What was built

- **`src/types/stream.ts`** — WebSocket protocol types: the `{ walletPublicKey }` auth handshake, `ping`/`pong` heartbeat messages, and application close codes (incl. `4403` Forbidden).
- **`src/coordinator/eventStore.ts`** — SQLite-backed, chronologically-ordered event log (in-memory by default) used to replay a task's history on reconnect.
- **`src/coordinator/eventBus.ts`** — added `subscribeAll` so a persistence recorder observes every event; `emit` now notifies the recorder *before* per-task subscribers, so a live handler always sees a durable row.
- **`src/api/routes/stream.ts`** — the `/tasks/:id/stream` upgrade handler (via the `ws` library, attached to the Express HTTP server):
  - **Auth**: client sends `{ walletPublicKey }` as the first message; a non-owner is rejected with a `4403` close frame before any events stream.
  - **Replay-then-stream**: past events are replayed from the store in chronological order, then live events follow. A per-socket high-water mark (last sent seq) guarantees ordering with no duplicates.
  - **Heartbeat**: `{ type: "ping" }` every 30s; the socket is closed as stale if no `{ type: "pong" }` arrives within 10s.
  - **Cleanup**: the EventBus subscription and all timers are torn down on disconnect.
- **`src/api/app.ts`** — wires an EventStore-backed recorder onto the EventBus and attaches the stream, replacing the previous DAG-derived replay.
- **`src/coordinator/coordinator.ts`** — fixed a pre-existing bug where `finishIfSettled` could emit `task_completed`/`task_failed` more than once (surfaced by the no-duplicates criterion).

## Acceptance criteria

- [x] Client receives `node_started` within 100ms of the Coordinator starting that node
- [x] Connecting with a non-owner `walletPublicKey` receives a 403 close frame (`4403`)
- [x] Reconnecting mid-task replays prior events in chronological order
- [x] Heartbeat closes stale connections after 10s with no pong
- [x] EventBus subscription cleaned up on client disconnect
- [x] Integration test: full task run emits events in correct order with no duplicates

## Testing

- `tsc --noEmit` clean
- Full suite passes (44 passed, 2 skipped)
- New 6-test integration suite (`tests/e2e/stream.test.ts`) covers every acceptance criterion and runs with no open handles
- Existing pipeline e2e updated to perform the new auth handshake
