### PR TITLE
feat(agents): build filterable, sortable agent registry page

### DIFF
--- a/frontend/src/components/agents/AgentDetailModal.module.css
+++ b/frontend/src/components/agents/AgentDetailModal.module.css
@@ -1,0 +1,163 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.7);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+}
+
+.modal {
+  width: 100%;
+  max-width: 560px;
+  max-height: 85vh;
+  overflow-y: auto;
+  background: #0f172a;
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  padding: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+
+.id {
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--panel-border);
+  color: var(--text-secondary);
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+.closeButton:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin: 0;
+}
+
+.field {
+  min-width: 0;
+}
+
+.fieldWide {
+  grid-column: 1 / -1;
+  min-width: 0;
+}
+
+.grid dt {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}
+
+.grid dd {
+  margin: 0;
+}
+
+.value {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.mono {
+  font-family: monospace;
+  font-size: 0.82rem;
+  word-break: break-all;
+  color: var(--text-primary);
+}
+
+.status {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.statusActive {
+  background: rgba(16, 185, 129, 0.15);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  color: #6ee7b7;
+}
+
+.statusInactive {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pill {
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  color: #a5b4fc;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.txLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #818cf8;
+  text-decoration: none;
+}
+
+.txLink:hover {
+  color: #a5b4fc;
+  text-decoration: underline;
+}
+
+@media (max-width: 540px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/agents/AgentDetailModal.tsx
+++ b/frontend/src/components/agents/AgentDetailModal.tsx
@@ -1,0 +1,127 @@
+import { useEffect } from 'react'
+import { ExternalLink, X } from 'lucide-react'
+import type { AgentRecord } from '../../types/api'
+import { ReputationStars } from './ReputationStars'
+import styles from './AgentDetailModal.module.css'
+
+const STELLAR_EXPLORER = 'https://stellar.expert/explorer/testnet'
+
+interface AgentDetailModalProps {
+  agent: AgentRecord | null
+  onClose: () => void
+}
+
+export function AgentDetailModal({ agent, onClose }: AgentDetailModalProps) {
+  useEffect(() => {
+    if (!agent) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [agent, onClose])
+
+  if (!agent) return null
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Details for ${agent.name}`}
+    >
+      <div
+        className={styles.modal}
+        onClick={(e) => e.stopPropagation()}
+        data-testid="agent-detail-modal"
+      >
+        <header className={styles.header}>
+          <div>
+            <h2 className={styles.title}>{agent.name}</h2>
+            <code className={styles.id} title={agent.id}>
+              {agent.id}
+            </code>
+          </div>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        <dl className={styles.grid}>
+          <div className={styles.field}>
+            <dt>Status</dt>
+            <dd>
+              <span
+                className={`${styles.status} ${
+                  agent.status === 'active' ? styles.statusActive : styles.statusInactive
+                }`}
+              >
+                {agent.status}
+              </span>
+            </dd>
+          </div>
+
+          <div className={styles.field}>
+            <dt>Price</dt>
+            <dd className={styles.value}>{agent.price.toFixed(2)} XLM</dd>
+          </div>
+
+          <div className={styles.field}>
+            <dt>Reputation</dt>
+            <dd>
+              <ReputationStars value={agent.reputation} />
+            </dd>
+          </div>
+
+          <div className={styles.fieldWide}>
+            <dt>Capabilities</dt>
+            <dd className={styles.pills}>
+              {agent.capabilities.length === 0 ? (
+                <span className={styles.value}>—</span>
+              ) : (
+                agent.capabilities.map((cap) => (
+                  <span key={cap} className={styles.pill}>
+                    {cap}
+                  </span>
+                ))
+              )}
+            </dd>
+          </div>
+
+          {agent.endpoint && (
+            <div className={styles.fieldWide}>
+              <dt>Endpoint</dt>
+              <dd className={styles.mono}>{agent.endpoint}</dd>
+            </div>
+          )}
+
+          <div className={styles.fieldWide}>
+            <dt>Registration Transaction</dt>
+            <dd>
+              {agent.registrationTxHash ? (
+                <a
+                  className={styles.txLink}
+                  href={`${STELLAR_EXPLORER}/tx/${agent.registrationTxHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-testid="registration-tx-link"
+                >
+                  <span className={styles.mono}>{agent.registrationTxHash}</span>
+                  <ExternalLink size={14} aria-hidden="true" />
+                </a>
+              ) : (
+                <span className={styles.value}>Not available</span>
+              )}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/agents/AgentFilterBar.module.css
+++ b/frontend/src/components/agents/AgentFilterBar.module.css
@@ -1,0 +1,164 @@
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 24px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.groupLabel {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.groupLabel strong {
+  color: var(--text-primary);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.muted {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+/* Capability multi-select */
+.capList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.capChip {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  color: var(--text-secondary);
+  padding: 5px 12px;
+  border-radius: 9999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  box-shadow: none;
+  text-transform: capitalize;
+}
+
+.capChip:hover {
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.capChipActive,
+.capChipActive:hover {
+  background: rgba(99, 102, 241, 0.25);
+  border-color: var(--primary);
+  color: #c7d2fe;
+}
+
+/* Price slider */
+.slider {
+  width: 180px;
+  accent-color: var(--primary);
+  cursor: pointer;
+}
+
+.slider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Status toggle */
+.toggle {
+  display: inline-flex;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.toggleButton {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  padding: 7px 14px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  box-shadow: none;
+  border-radius: 0;
+}
+
+.toggleButton:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.toggleButtonActive,
+.toggleButtonActive:hover {
+  background: var(--primary);
+  color: #fff;
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.iconAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  color: var(--text-secondary);
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+.iconAction:hover {
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.resetButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  color: var(--text-secondary);
+  padding: 7px 12px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  box-shadow: none;
+}
+
+.resetButton:hover {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+  transform: none;
+  box-shadow: none;
+}

--- a/frontend/src/components/agents/AgentFilterBar.tsx
+++ b/frontend/src/components/agents/AgentFilterBar.tsx
@@ -1,0 +1,133 @@
+import { RotateCw, X } from 'lucide-react'
+import type { AgentFilters, StatusFilter } from '../../utils/agentRegistry'
+import styles from './AgentFilterBar.module.css'
+
+interface AgentFilterBarProps {
+  filters: AgentFilters
+  /** All capabilities available across the dataset. */
+  availableCapabilities: string[]
+  /** [min, max] price across the dataset, used to bound the slider. */
+  priceDomain: [number, number]
+  onChange: (next: Partial<AgentFilters>) => void
+  onReset: () => void
+  onRefresh: () => void
+}
+
+const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'active', label: 'Active' },
+  { value: 'inactive', label: 'Inactive' },
+]
+
+export function AgentFilterBar({
+  filters,
+  availableCapabilities,
+  priceDomain,
+  onChange,
+  onReset,
+  onRefresh,
+}: AgentFilterBarProps) {
+  const [domainMin, domainMax] = priceDomain
+  const effectiveMax = filters.priceMax ?? domainMax
+
+  const toggleCapability = (cap: string) => {
+    const selected = filters.capabilities.includes(cap)
+    onChange({
+      capabilities: selected
+        ? filters.capabilities.filter((c) => c !== cap)
+        : [...filters.capabilities, cap],
+    })
+  }
+
+  const hasActiveFilters =
+    filters.capabilities.length > 0 ||
+    filters.priceMin != null ||
+    filters.priceMax != null ||
+    filters.status !== 'all' ||
+    filters.sortKey != null
+
+  return (
+    <div className={styles.bar}>
+      <div className={styles.group}>
+        <span className={styles.groupLabel}>Capabilities</span>
+        <div className={styles.capList} role="group" aria-label="Filter by capability">
+          {availableCapabilities.length === 0 ? (
+            <span className={styles.muted}>None</span>
+          ) : (
+            availableCapabilities.map((cap) => {
+              const selected = filters.capabilities.includes(cap)
+              return (
+                <button
+                  key={cap}
+                  type="button"
+                  className={`${styles.capChip} ${selected ? styles.capChipActive : ''}`}
+                  aria-pressed={selected}
+                  onClick={() => toggleCapability(cap)}
+                >
+                  {cap}
+                </button>
+              )
+            })
+          )}
+        </div>
+      </div>
+
+      <div className={styles.group}>
+        <span className={styles.groupLabel}>
+          Max price: <strong>{effectiveMax.toFixed(2)} XLM</strong>
+        </span>
+        <input
+          type="range"
+          className={styles.slider}
+          min={domainMin}
+          max={domainMax}
+          step={0.01}
+          value={effectiveMax}
+          aria-label="Maximum price"
+          disabled={domainMax <= domainMin}
+          onChange={(e) => {
+            const v = Number(e.target.value)
+            onChange({ priceMax: v >= domainMax ? null : v })
+          }}
+        />
+      </div>
+
+      <div className={styles.group}>
+        <span className={styles.groupLabel}>Status</span>
+        <div className={styles.toggle} role="group" aria-label="Filter by status">
+          {STATUS_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`${styles.toggleButton} ${
+                filters.status === opt.value ? styles.toggleButtonActive : ''
+              }`}
+              aria-pressed={filters.status === opt.value}
+              onClick={() => onChange({ status: opt.value })}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.iconAction}
+          onClick={onRefresh}
+          title="Refresh now"
+          aria-label="Refresh now"
+        >
+          <RotateCw size={14} />
+        </button>
+        {hasActiveFilters && (
+          <button type="button" className={styles.resetButton} onClick={onReset}>
+            <X size={14} />
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/agents/AgentTable.module.css
+++ b/frontend/src/components/agents/AgentTable.module.css
@@ -1,0 +1,220 @@
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+
+.table th,
+.table td {
+  padding: 14px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--panel-border);
+  vertical-align: middle;
+}
+
+.table th {
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.sortButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  margin: 0;
+  color: var(--text-secondary);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sortButton:hover {
+  background: transparent;
+  transform: none;
+  box-shadow: none;
+  color: var(--text-primary);
+}
+
+.row {
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.row:hover td {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.row:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+}
+
+.mono {
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.price {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+/* Capability pills */
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pill {
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  color: #a5b4fc;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.noPill {
+  color: var(--text-secondary);
+}
+
+/* Reputation stars */
+.stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+}
+
+.starWrap {
+  position: relative;
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+}
+
+.starBg {
+  color: #475569;
+}
+
+.starFill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  overflow: hidden;
+  display: inline-flex;
+}
+
+.starFg {
+  color: #fbbf24;
+  fill: #fbbf24;
+}
+
+.starValue {
+  margin-left: 6px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Status badge */
+.status {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.statusActive {
+  background: rgba(16, 185, 129, 0.15);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  color: #6ee7b7;
+}
+
+.statusInactive {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
+.detailsButton {
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  color: var(--text-primary);
+  padding: 5px 12px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  box-shadow: none;
+}
+
+.detailsButton:hover {
+  background: rgba(99, 102, 241, 0.15);
+  border-color: rgba(99, 102, 241, 0.4);
+  transform: none;
+  box-shadow: none;
+}
+
+/* Skeleton */
+.skeletonRow td {
+  padding: 16px;
+}
+
+.skeletonCell {
+  display: block;
+  height: 14px;
+  width: 80%;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  animation: agentPulse 1.5s ease-in-out infinite;
+}
+
+@keyframes agentPulse {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+/* Empty state */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 48px 16px;
+  text-align: center;
+}
+
+.emptyIcon {
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.emptyTitle {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.emptySubtext {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}

--- a/frontend/src/components/agents/AgentTable.tsx
+++ b/frontend/src/components/agents/AgentTable.tsx
@@ -1,0 +1,162 @@
+import { ArrowDown, ArrowUp, ArrowUpDown, Inbox } from 'lucide-react'
+import type { AgentRecord } from '../../types/api'
+import type { SortDir, SortKey } from '../../utils/agentRegistry'
+import { ReputationStars } from './ReputationStars'
+import styles from './AgentTable.module.css'
+
+interface AgentTableProps {
+  agents: AgentRecord[]
+  loading: boolean
+  sortKey: SortKey | null
+  sortDir: SortDir
+  /** Toggle/apply sort on the given column. Reputation only sorts desc. */
+  onSort: (key: SortKey) => void
+  onRowClick: (agent: AgentRecord) => void
+}
+
+const SKELETON_ROWS = 5
+
+function truncateId(id: string): string {
+  if (id.length <= 14) return id
+  return `${id.slice(0, 6)}…${id.slice(-4)}`
+}
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) return <ArrowUpDown size={12} aria-hidden="true" />
+  return dir === 'asc' ? (
+    <ArrowUp size={12} aria-hidden="true" />
+  ) : (
+    <ArrowDown size={12} aria-hidden="true" />
+  )
+}
+
+export function AgentTable({
+  agents,
+  loading,
+  sortKey,
+  sortDir,
+  onSort,
+  onRowClick,
+}: AgentTableProps) {
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table} id="agent-table">
+        <thead>
+          <tr>
+            <th>Agent ID</th>
+            <th>Capabilities</th>
+            <th>
+              <button
+                type="button"
+                className={styles.sortButton}
+                onClick={() => onSort('price')}
+                aria-label="Sort by price"
+              >
+                Price (XLM)
+                <SortIcon active={sortKey === 'price'} dir={sortDir} />
+              </button>
+            </th>
+            <th>
+              <button
+                type="button"
+                className={styles.sortButton}
+                onClick={() => onSort('reputation')}
+                aria-label="Sort by reputation"
+              >
+                Reputation
+                <SortIcon active={sortKey === 'reputation'} dir={sortDir} />
+              </button>
+            </th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            Array.from({ length: SKELETON_ROWS }, (_, i) => (
+              <tr key={i} className={styles.skeletonRow} data-testid="agent-skeleton-row">
+                {Array.from({ length: 6 }, (_, c) => (
+                  <td key={c}>
+                    <span className={styles.skeletonCell} />
+                  </td>
+                ))}
+              </tr>
+            ))
+          ) : agents.length === 0 ? (
+            <tr>
+              <td colSpan={6}>
+                <div className={styles.emptyState} data-testid="agents-empty">
+                  <Inbox size={32} className={styles.emptyIcon} aria-hidden="true" />
+                  <p className={styles.emptyTitle}>No agents found</p>
+                  <p className={styles.emptySubtext}>
+                    No registered agents match your filters.
+                  </p>
+                </div>
+              </td>
+            </tr>
+          ) : (
+            agents.map((agent) => (
+              <tr
+                key={agent.id}
+                className={styles.row}
+                data-testid={`agent-row-${agent.id}`}
+                onClick={() => onRowClick(agent)}
+                tabIndex={0}
+                role="button"
+                aria-label={`View details for ${agent.name}`}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    onRowClick(agent)
+                  }
+                }}
+              >
+                <td className={styles.mono} title={agent.id}>
+                  {truncateId(agent.id)}
+                </td>
+                <td>
+                  <span className={styles.pills}>
+                    {agent.capabilities.length === 0 ? (
+                      <span className={styles.noPill}>—</span>
+                    ) : (
+                      agent.capabilities.map((cap) => (
+                        <span key={cap} className={styles.pill}>
+                          {cap}
+                        </span>
+                      ))
+                    )}
+                  </span>
+                </td>
+                <td className={styles.price}>{agent.price.toFixed(2)}</td>
+                <td>
+                  <ReputationStars value={agent.reputation} />
+                </td>
+                <td>
+                  <span
+                    className={`${styles.status} ${
+                      agent.status === 'active' ? styles.statusActive : styles.statusInactive
+                    }`}
+                  >
+                    {agent.status}
+                  </span>
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    className={styles.detailsButton}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onRowClick(agent)
+                    }}
+                  >
+                    Details
+                  </button>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/agents/ReputationStars.tsx
+++ b/frontend/src/components/agents/ReputationStars.tsx
@@ -1,0 +1,41 @@
+import { Star } from 'lucide-react'
+import styles from './AgentTable.module.css'
+
+interface ReputationStarsProps {
+  /** Reputation score on a 0-5 scale. */
+  value: number
+}
+
+/**
+ * Renders a 0-5 star reputation rating. Each whole point fills a star; a
+ * fractional remainder fills the next star proportionally via a clip overlay.
+ */
+export function ReputationStars({ value }: ReputationStarsProps) {
+  const clamped = Math.max(0, Math.min(5, value))
+  const label = `${clamped.toFixed(1)} out of 5`
+
+  return (
+    <span
+      className={styles.stars}
+      role="img"
+      aria-label={label}
+      title={label}
+      data-testid="reputation-stars"
+    >
+      {Array.from({ length: 5 }, (_, i) => {
+        const fill = Math.max(0, Math.min(1, clamped - i))
+        return (
+          <span key={i} className={styles.starWrap}>
+            <Star size={14} className={styles.starBg} aria-hidden="true" />
+            {fill > 0 && (
+              <span className={styles.starFill} style={{ width: `${fill * 100}%` }}>
+                <Star size={14} className={styles.starFg} aria-hidden="true" />
+              </span>
+            )}
+          </span>
+        )
+      })}
+      <span className={styles.starValue}>{clamped.toFixed(1)}</span>
+    </span>
+  )
+}

--- a/frontend/src/hooks/useAgentRegistry.ts
+++ b/frontend/src/hooks/useAgentRegistry.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getAgents } from '../services/api'
+import type { AgentRecord } from '../types/api'
+import { normalizeAgent } from '../utils/agentRegistry'
+
+const REFRESH_INTERVAL = 30_000
+
+export interface AgentRegistryResult {
+  agents: AgentRecord[]
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+/**
+ * Fetches the agent registry from `GET /api/agents` and keeps it fresh with a
+ * 30s background poll. `loading` is only true on the first load — subsequent
+ * refreshes (auto or manual) update `agents` in place so the table never
+ * remounts and the skeleton never flashes.
+ */
+export function useAgentRegistry(): AgentRegistryResult {
+  const [agents, setAgents] = useState<AgentRecord[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const isFirstLoad = useRef(true)
+  const fetchingRef = useRef(false)
+  const mountedRef = useRef(true)
+
+  const fetchAgents = useCallback(async () => {
+    if (fetchingRef.current) return
+    fetchingRef.current = true
+
+    if (isFirstLoad.current) setLoading(true)
+
+    try {
+      const data = await getAgents()
+      if (!mountedRef.current) return
+      setAgents(Array.isArray(data) ? data.map(normalizeAgent) : [])
+      setError(null)
+    } catch (err) {
+      if (!mountedRef.current) return
+      setError(err instanceof Error ? err.message : 'Failed to load agents')
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false)
+      }
+      isFirstLoad.current = false
+      fetchingRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    fetchAgents()
+
+    const interval = setInterval(fetchAgents, REFRESH_INTERVAL)
+    return () => {
+      mountedRef.current = false
+      clearInterval(interval)
+    }
+  }, [fetchAgents])
+
+  const refetch = useCallback(() => {
+    fetchAgents()
+  }, [fetchAgents])
+
+  return { agents, loading, error, refetch }
+}

--- a/frontend/src/pages/AgentsPage.module.css
+++ b/frontend/src/pages/AgentsPage.module.css
@@ -1,0 +1,58 @@
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin: 6px 0 0;
+}
+
+.errorBox {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 16px 20px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 12px;
+  color: #fca5a5;
+}
+
+.errorBox p {
+  margin: 0;
+}
+
+.retryButton {
+  background: rgba(239, 68, 68, 0.2);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-weight: 600;
+  box-shadow: none;
+}
+
+.retryButton:hover {
+  background: rgba(239, 68, 68, 0.3);
+  transform: none;
+  box-shadow: none;
+}

--- a/frontend/src/pages/AgentsPage.test.tsx
+++ b/frontend/src/pages/AgentsPage.test.tsx
@@ -1,0 +1,219 @@
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import AgentsPage from './AgentsPage'
+import type { AgentRecord } from '../types/api'
+
+const { getAgents } = vi.hoisted(() => ({ getAgents: vi.fn() }))
+
+vi.mock('../services/api', () => ({
+  getAgents,
+}))
+
+const AGENTS: AgentRecord[] = [
+  {
+    id: 'agent-research-001',
+    name: 'Research Specialist',
+    capabilities: ['research', 'report'],
+    price: 0.5,
+    reputation: 4.8,
+    status: 'active',
+    registrationTxHash: 'abc123def456',
+  },
+  {
+    id: 'agent-coding-002',
+    name: 'Smart Contract Dev',
+    capabilities: ['coding'],
+    price: 1.2,
+    reputation: 4.9,
+    status: 'active',
+  },
+  {
+    id: 'agent-audit-003',
+    name: 'QA Audit Agent',
+    capabilities: ['coding', 'audit'],
+    price: 0.8,
+    reputation: 4.2,
+    status: 'inactive',
+  },
+]
+
+// Surfaces the current URL search string so tests can assert URL persistence.
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="location-search">{location.search}</div>
+}
+
+function renderPage(initialEntries = ['/agents']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AgentsPage />
+      <LocationProbe />
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  getAgents.mockReset()
+  getAgents.mockResolvedValue(AGENTS)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('AgentsPage - rendering', () => {
+  it('renders all agents from GET /api/agents', async () => {
+    renderPage()
+    expect(await screen.findByTestId('agent-row-agent-research-001')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-row-agent-coding-002')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-row-agent-audit-003')).toBeInTheDocument()
+  })
+
+  it('shows a 5-row skeleton while loading', () => {
+    getAgents.mockReturnValue(new Promise(() => {})) // never resolves
+    renderPage()
+    expect(screen.getAllByTestId('agent-skeleton-row')).toHaveLength(5)
+  })
+
+  it('renders the empty state when the API returns []', async () => {
+    getAgents.mockResolvedValue([])
+    renderPage()
+    expect(await screen.findByTestId('agents-empty')).toBeInTheDocument()
+  })
+})
+
+describe('AgentsPage - filtering', () => {
+  it('hides non-matching agents when a capability is selected', async () => {
+    renderPage()
+    await screen.findByTestId('agent-row-agent-research-001')
+
+    fireEvent.click(screen.getByRole('button', { name: 'research', pressed: false }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-row-agent-coding-002')).not.toBeInTheDocument()
+    })
+    expect(screen.getByTestId('agent-row-agent-research-001')).toBeInTheDocument()
+  })
+
+  it('filters by the price slider without calling the API again', async () => {
+    renderPage()
+    await screen.findByTestId('agent-row-agent-coding-002')
+    expect(getAgents).toHaveBeenCalledTimes(1)
+
+    // Lower the max price below the most expensive agent (1.2 XLM).
+    const slider = screen.getByLabelText('Maximum price') as HTMLInputElement
+    fireEvent.change(slider, { target: { value: '0.9' } })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-row-agent-coding-002')).not.toBeInTheDocument()
+    })
+    expect(screen.getByTestId('agent-row-agent-research-001')).toBeInTheDocument()
+    // No extra fetch triggered by client-side filtering.
+    expect(getAgents).toHaveBeenCalledTimes(1)
+  })
+
+  it('filters by status toggle', async () => {
+    renderPage()
+    await screen.findByTestId('agent-row-agent-audit-003')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Inactive' }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('agent-row-agent-research-001')).not.toBeInTheDocument()
+    })
+    expect(screen.getByTestId('agent-row-agent-audit-003')).toBeInTheDocument()
+  })
+})
+
+describe('AgentsPage - URL persistence', () => {
+  it('writes filter state to the URL query string', async () => {
+    renderPage()
+    await screen.findByTestId('agent-row-agent-research-001')
+
+    fireEvent.click(screen.getByRole('button', { name: 'research', pressed: false }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search').textContent).toContain('caps=research')
+    })
+  })
+
+  it('hydrates filter state from the URL query string', async () => {
+    renderPage(['/agents?status=inactive'])
+    await screen.findByTestId('agent-row-agent-audit-003')
+
+    expect(screen.queryByTestId('agent-row-agent-research-001')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Inactive' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('writes sort state to the URL when a column header is clicked', async () => {
+    renderPage()
+    await screen.findByTestId('agent-row-agent-research-001')
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by price/i }))
+
+    await waitFor(() => {
+      const search = screen.getByTestId('location-search').textContent || ''
+      expect(search).toContain('sort=price')
+    })
+  })
+})
+
+describe('AgentsPage - detail modal', () => {
+  it('opens the modal with the registration tx hash linked to Stellar Explorer', async () => {
+    renderPage()
+    fireEvent.click(await screen.findByTestId('agent-row-agent-research-001'))
+
+    const modal = await screen.findByTestId('agent-detail-modal')
+    const link = within(modal).getByTestId('registration-tx-link')
+    expect(link).toHaveAttribute(
+      'href',
+      'https://stellar.expert/explorer/testnet/tx/abc123def456'
+    )
+  })
+
+  it('shows "Not available" when there is no registration tx hash', async () => {
+    renderPage()
+    fireEvent.click(await screen.findByTestId('agent-row-agent-coding-002'))
+
+    const modal = await screen.findByTestId('agent-detail-modal')
+    expect(within(modal).getByText('Not available')).toBeInTheDocument()
+  })
+})
+
+describe('AgentsPage - auto-refresh', () => {
+  it('updates the table on the 30s poll without showing the skeleton again', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    renderPage()
+
+    await screen.findByTestId('agent-row-agent-research-001')
+    expect(getAgents).toHaveBeenCalledTimes(1)
+
+    // Second poll returns an extra agent.
+    getAgents.mockResolvedValue([
+      ...AGENTS,
+      {
+        id: 'agent-new-004',
+        name: 'New Agent',
+        capabilities: ['design'],
+        price: 0.3,
+        reputation: 5,
+        status: 'active',
+      },
+    ])
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-row-agent-new-004')).toBeInTheDocument()
+    })
+    // Refresh must not flash the loading skeleton.
+    expect(screen.queryByTestId('agent-skeleton-row')).not.toBeInTheDocument()
+    expect(getAgents).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -1,75 +1,108 @@
-import React, { useState, useEffect } from 'react'
-import { getAgents } from '@services/api'
+import { useCallback, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useAgentRegistry } from '../hooks/useAgentRegistry'
+import { AgentTable } from '../components/agents/AgentTable'
+import { AgentFilterBar } from '../components/agents/AgentFilterBar'
+import { AgentDetailModal } from '../components/agents/AgentDetailModal'
 import type { AgentRecord } from '../types/api'
+import {
+  allCapabilities,
+  filterAndSortAgents,
+  filtersFromSearchParams,
+  filtersToSearchParams,
+  priceDomain,
+  type AgentFilters,
+  type SortKey,
+} from '../utils/agentRegistry'
+import styles from './AgentsPage.module.css'
 
-const AgentsPage: React.FC = () => {
-  const [agents, setAgents] = useState<AgentRecord[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+function AgentsPage() {
+  const { agents, loading, error, refetch } = useAgentRegistry()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [selected, setSelected] = useState<AgentRecord | null>(null)
 
-  useEffect(() => {
-    getAgents()
-      .then((data) => {
-        setAgents(data)
-        setLoading(false)
-      })
-      .catch((err: unknown) => {
-        setError(err instanceof Error ? err.message : 'Error loading agents')
-        setLoading(false)
-      })
-  }, [])
+  // Filter/sort state is derived from the URL so views are shareable.
+  const filters = useMemo(
+    () => filtersFromSearchParams(searchParams),
+    [searchParams]
+  )
+
+  const updateFilters = useCallback(
+    (next: Partial<AgentFilters>) => {
+      const merged = { ...filters, ...next }
+      setSearchParams(filtersToSearchParams(merged), { replace: true })
+    },
+    [filters, setSearchParams]
+  )
+
+  const resetFilters = useCallback(() => {
+    setSearchParams({}, { replace: true })
+  }, [setSearchParams])
+
+  const handleSort = useCallback(
+    (key: SortKey) => {
+      if (filters.sortKey !== key) {
+        // Reputation defaults to high-to-low; price to low-to-high.
+        updateFilters({ sortKey: key, sortDir: key === 'price' ? 'asc' : 'desc' })
+      } else {
+        updateFilters({ sortDir: filters.sortDir === 'asc' ? 'desc' : 'asc' })
+      }
+    },
+    [filters, updateFilters]
+  )
+
+  const capabilities = useMemo(() => allCapabilities(agents), [agents])
+  const domain = useMemo(() => priceDomain(agents), [agents])
+  const visibleAgents = useMemo(
+    () => filterAndSortAgents(agents, filters),
+    [agents, filters]
+  )
 
   return (
-    <div className="glass-panel">
-      <h1 style={{ marginBottom: '20px', fontSize: '1.8rem' }}>Agent Registry</h1>
-      
-      {loading ? (
-        <div id="loading-spinner">Loading registry...</div>
-      ) : error ? (
-        <div className="error-msg" id="registry-error">{error}</div>
-      ) : (
-        <div style={{ overflowX: 'auto' }}>
-          <table id="agent-table">
-            <thead>
-              <tr>
-                <th>Agent ID</th>
-                <th>Name</th>
-                <th>Capabilities</th>
-                <th>Price (XLM)</th>
-                <th>Reputation</th>
-                <th>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {agents.map((agent) => (
-                <tr key={agent.id} className="agent-row" data-testid={`agent-row-${agent.id}`}>
-                  <td style={{ fontFamily: 'monospace' }}>{agent.id}</td>
-                  <td>{agent.name}</td>
-                  <td>
-                    {agent.capabilities.map((cap) => (
-                      <span key={cap} className="chip" style={{ marginRight: '6px', fontSize: '0.75rem' }}>
-                        {cap}
-                      </span>
-                    ))}
-                  </td>
-                  <td>{agent.price}</td>
-                  <td>{agent.reputation}/5</td>
-                  <td>
-                    <span
-                      style={{
-                        color: agent.status === 'active' ? 'var(--success)' : 'var(--danger)',
-                        fontWeight: 'bold',
-                      }}
-                    >
-                      {agent.status}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <div>
+          <h1 className={styles.title}>Agent Registry</h1>
+          <p className={styles.subtitle}>
+            {loading
+              ? 'Loading registered agents…'
+              : `${visibleAgents.length} of ${agents.length} agent${
+                  agents.length === 1 ? '' : 's'
+                }`}
+          </p>
         </div>
+      </div>
+
+      {error && !loading ? (
+        <div className={styles.errorBox} id="registry-error" role="alert">
+          <p>Failed to load the agent registry: {error}</p>
+          <button type="button" className={styles.retryButton} onClick={refetch}>
+            Retry
+          </button>
+        </div>
+      ) : (
+        <>
+          <AgentFilterBar
+            filters={filters}
+            availableCapabilities={capabilities}
+            priceDomain={domain}
+            onChange={updateFilters}
+            onReset={resetFilters}
+            onRefresh={refetch}
+          />
+
+          <AgentTable
+            agents={visibleAgents}
+            loading={loading}
+            sortKey={filters.sortKey}
+            sortDir={filters.sortDir}
+            onSort={handleSort}
+            onRowClick={setSelected}
+          />
+        </>
       )}
+
+      <AgentDetailModal agent={selected} onClose={() => setSelected(null)} />
     </div>
   )
 }

--- a/frontend/src/utils/agentRegistry.test.ts
+++ b/frontend/src/utils/agentRegistry.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import {
+  allCapabilities,
+  filterAndSortAgents,
+  filtersFromSearchParams,
+  filtersToSearchParams,
+  normalizeAgent,
+  priceDomain,
+  DEFAULT_FILTERS,
+  type AgentFilters,
+} from './agentRegistry'
+import type { AgentRecord } from '../types/api'
+
+const agents: AgentRecord[] = [
+  {
+    id: 'a1',
+    name: 'Alpha',
+    capabilities: ['research', 'report'],
+    price: 0.5,
+    reputation: 4.8,
+    status: 'active',
+  },
+  {
+    id: 'a2',
+    name: 'Beta',
+    capabilities: ['coding'],
+    price: 1.2,
+    reputation: 4.9,
+    status: 'active',
+  },
+  {
+    id: 'a3',
+    name: 'Gamma',
+    capabilities: ['coding', 'audit'],
+    price: 0.8,
+    reputation: 4.2,
+    status: 'inactive',
+  },
+]
+
+describe('normalizeAgent', () => {
+  it('passes through the canonical frontend shape', () => {
+    const result = normalizeAgent(agents[0])
+    expect(result).toMatchObject({ id: 'a1', capabilities: ['research', 'report'], price: 0.5 })
+  })
+
+  it('normalizes the backend shape (capability/priceXLM)', () => {
+    const result = normalizeAgent({
+      id: 'b1',
+      capability: 'research',
+      priceXLM: 2.5,
+      endpoint: 'https://x.test',
+      status: 'registered',
+    })
+    expect(result.capabilities).toEqual(['research'])
+    expect(result.price).toBe(2.5)
+    expect(result.name).toBe('b1')
+  })
+
+  it('falls back to safe defaults for missing fields', () => {
+    const result = normalizeAgent({ id: 'c1' })
+    expect(result.capabilities).toEqual([])
+    expect(result.price).toBe(0)
+    expect(result.reputation).toBe(0)
+    expect(result.status).toBe('unknown')
+  })
+})
+
+describe('allCapabilities', () => {
+  it('returns sorted distinct capabilities', () => {
+    expect(allCapabilities(agents)).toEqual(['audit', 'coding', 'report', 'research'])
+  })
+})
+
+describe('priceDomain', () => {
+  it('returns min and max price', () => {
+    expect(priceDomain(agents)).toEqual([0.5, 1.2])
+  })
+
+  it('returns [0,0] when empty', () => {
+    expect(priceDomain([])).toEqual([0, 0])
+  })
+})
+
+describe('filterAndSortAgents', () => {
+  it('returns all agents with default filters', () => {
+    expect(filterAndSortAgents(agents, DEFAULT_FILTERS)).toHaveLength(3)
+  })
+
+  it('filters by capability (OR semantics)', () => {
+    const result = filterAndSortAgents(agents, { ...DEFAULT_FILTERS, capabilities: ['research'] })
+    expect(result.map((a) => a.id)).toEqual(['a1'])
+  })
+
+  it('matches any selected capability', () => {
+    const result = filterAndSortAgents(agents, {
+      ...DEFAULT_FILTERS,
+      capabilities: ['research', 'audit'],
+    })
+    expect(result.map((a) => a.id).sort()).toEqual(['a1', 'a3'])
+  })
+
+  it('filters by price range', () => {
+    const result = filterAndSortAgents(agents, {
+      ...DEFAULT_FILTERS,
+      priceMin: 0.6,
+      priceMax: 1.0,
+    })
+    expect(result.map((a) => a.id)).toEqual(['a3'])
+  })
+
+  it('filters by status', () => {
+    const result = filterAndSortAgents(agents, { ...DEFAULT_FILTERS, status: 'inactive' })
+    expect(result.map((a) => a.id)).toEqual(['a3'])
+  })
+
+  it('sorts by price ascending', () => {
+    const result = filterAndSortAgents(agents, {
+      ...DEFAULT_FILTERS,
+      sortKey: 'price',
+      sortDir: 'asc',
+    })
+    expect(result.map((a) => a.price)).toEqual([0.5, 0.8, 1.2])
+  })
+
+  it('sorts by price descending', () => {
+    const result = filterAndSortAgents(agents, {
+      ...DEFAULT_FILTERS,
+      sortKey: 'price',
+      sortDir: 'desc',
+    })
+    expect(result.map((a) => a.price)).toEqual([1.2, 0.8, 0.5])
+  })
+
+  it('sorts by reputation descending', () => {
+    const result = filterAndSortAgents(agents, {
+      ...DEFAULT_FILTERS,
+      sortKey: 'reputation',
+      sortDir: 'desc',
+    })
+    expect(result.map((a) => a.reputation)).toEqual([4.9, 4.8, 4.2])
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = [...agents]
+    filterAndSortAgents(agents, { ...DEFAULT_FILTERS, sortKey: 'price', sortDir: 'asc' })
+    expect(agents).toEqual(copy)
+  })
+})
+
+describe('URL query-string serialization', () => {
+  it('round-trips a full filter set', () => {
+    const filters: AgentFilters = {
+      capabilities: ['research', 'coding'],
+      priceMin: 0.2,
+      priceMax: 1.5,
+      status: 'active',
+      sortKey: 'reputation',
+      sortDir: 'desc',
+    }
+    const params = new URLSearchParams(filtersToSearchParams(filters))
+    expect(filtersFromSearchParams(params)).toEqual(filters)
+  })
+
+  it('omits default values from the query string', () => {
+    expect(filtersToSearchParams(DEFAULT_FILTERS)).toEqual({})
+  })
+
+  it('parses an empty query string into defaults', () => {
+    expect(filtersFromSearchParams(new URLSearchParams())).toEqual(DEFAULT_FILTERS)
+  })
+})

--- a/frontend/src/utils/agentRegistry.ts
+++ b/frontend/src/utils/agentRegistry.ts
@@ -1,0 +1,153 @@
+import type { AgentRecord } from '../types/api'
+
+export type SortKey = 'price' | 'reputation'
+export type SortDir = 'asc' | 'desc'
+export type StatusFilter = 'all' | 'active' | 'inactive'
+
+export interface AgentFilters {
+  /** Selected capabilities. An agent matches if it has at least one of these (OR). */
+  capabilities: string[]
+  /** Inclusive lower bound on price, or null for no lower bound. */
+  priceMin: number | null
+  /** Inclusive upper bound on price, or null for no upper bound. */
+  priceMax: number | null
+  status: StatusFilter
+  sortKey: SortKey | null
+  sortDir: SortDir
+}
+
+export const DEFAULT_FILTERS: AgentFilters = {
+  capabilities: [],
+  priceMin: null,
+  priceMax: null,
+  status: 'all',
+  sortKey: null,
+  sortDir: 'desc',
+}
+
+/**
+ * Normalize a raw record from `GET /api/agents` into the canonical shape used by
+ * the UI. The backend has historically exposed two shapes (`capability`/`priceXLM`
+ * vs `capabilities[]`/`price`), so we tolerate both rather than assuming one.
+ */
+export function normalizeAgent(raw: unknown): AgentRecord {
+  const r = (raw ?? {}) as Record<string, unknown>
+
+  const capabilities = Array.isArray(r.capabilities)
+    ? (r.capabilities as unknown[]).map(String)
+    : typeof r.capability === 'string' && r.capability
+      ? [r.capability]
+      : []
+
+  const price =
+    typeof r.price === 'number'
+      ? r.price
+      : typeof r.priceXLM === 'number'
+        ? r.priceXLM
+        : 0
+
+  const reputation = typeof r.reputation === 'number' ? r.reputation : 0
+  const id = String(r.id ?? '')
+
+  return {
+    id,
+    name: typeof r.name === 'string' && r.name ? r.name : id || 'Unknown',
+    capabilities,
+    price,
+    reputation,
+    status: typeof r.status === 'string' ? r.status : 'unknown',
+    endpoint: typeof r.endpoint === 'string' ? r.endpoint : undefined,
+    registrationTxHash:
+      (typeof r.registrationTxHash === 'string' && r.registrationTxHash) ||
+      (typeof r.txHash === 'string' && r.txHash) ||
+      undefined,
+  }
+}
+
+/** Distinct capabilities present across the dataset, sorted alphabetically. */
+export function allCapabilities(agents: AgentRecord[]): string[] {
+  const set = new Set<string>()
+  agents.forEach((a) => a.capabilities.forEach((c) => set.add(c)))
+  return Array.from(set).sort()
+}
+
+/** [min, max] price across the dataset; [0, 0] when empty. */
+export function priceDomain(agents: AgentRecord[]): [number, number] {
+  if (agents.length === 0) return [0, 0]
+  let min = Infinity
+  let max = -Infinity
+  for (const a of agents) {
+    if (a.price < min) min = a.price
+    if (a.price > max) max = a.price
+  }
+  return [min, max]
+}
+
+/** Apply filters then sort. Pure — never mutates the input array. */
+export function filterAndSortAgents(
+  agents: AgentRecord[],
+  filters: AgentFilters
+): AgentRecord[] {
+  const filtered = agents.filter((agent) => {
+    if (filters.capabilities.length > 0) {
+      const matches = filters.capabilities.some((c) => agent.capabilities.includes(c))
+      if (!matches) return false
+    }
+
+    if (filters.priceMin != null && agent.price < filters.priceMin) return false
+    if (filters.priceMax != null && agent.price > filters.priceMax) return false
+
+    if (filters.status !== 'all' && agent.status !== filters.status) return false
+
+    return true
+  })
+
+  if (!filters.sortKey) return filtered
+
+  const key = filters.sortKey
+  const factor = filters.sortDir === 'asc' ? 1 : -1
+  return [...filtered].sort((a, b) => (a[key] - b[key]) * factor)
+}
+
+// --- URL query-string (de)serialization -----------------------------------
+// Filter/sort state lives in the URL so views are shareable. We only emit
+// params that differ from the defaults to keep links tidy.
+
+export function filtersToSearchParams(filters: AgentFilters): Record<string, string> {
+  const params: Record<string, string> = {}
+
+  if (filters.capabilities.length > 0) {
+    params.caps = filters.capabilities.join(',')
+  }
+  if (filters.priceMin != null) params.pmin = String(filters.priceMin)
+  if (filters.priceMax != null) params.pmax = String(filters.priceMax)
+  if (filters.status !== 'all') params.status = filters.status
+  if (filters.sortKey) {
+    params.sort = filters.sortKey
+    params.dir = filters.sortDir
+  }
+
+  return params
+}
+
+function parseNumber(value: string | null): number | null {
+  if (value == null || value.trim() === '') return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+export function filtersFromSearchParams(params: URLSearchParams): AgentFilters {
+  const caps = params.get('caps')
+  const status = params.get('status')
+  const sort = params.get('sort')
+  const dir = params.get('dir')
+
+  return {
+    capabilities: caps ? caps.split(',').map((c) => c.trim()).filter(Boolean) : [],
+    priceMin: parseNumber(params.get('pmin')),
+    priceMax: parseNumber(params.get('pmax')),
+    status: status === 'active' || status === 'inactive' ? status : 'all',
+    sortKey: sort === 'price' || sort === 'reputation' ? sort : null,
+    sortDir: dir === 'asc' ? 'asc' : 'desc',
+  }
+}


### PR DESCRIPTION
closes #14 

summary
Replaces the bare-bones /agents page with a full filterable, sortable agent registry that gives developers and users visibility into registered agents — capabilities, pricing, reputation, and status — backed by GET /api/agents.

What's included
useAgentRegistry() hook — fetches GET /api/agents, returns { agents, loading, error, refetch }, polls every 30s and updates in place (loading only on first load, so no remount/skeleton flash on refresh).
AgentTable — columns: Agent ID (truncated), Capabilities (pill badges), Price (XLM), Reputation (0–5 stars), Status, Actions. Sortable by price (asc/desc) and reputation. 5-row skeleton while loading; empty state when there are no rows.
AgentFilterBar — capability multi-select, max-price slider, and status toggle — all client-side, no extra API calls.
AgentDetailModal — full metadata on row click, including the registration tx hash linked to Stellar Explorer (closes on Esc / overlay click).
URL-persisted state — all filter/sort state lives in the query string via useSearchParams, so views are shareable and reload-safe.
agentRegistry utils — normalizes both backend response shapes (capability/priceXLM and capabilities[]/price) and owns the filter/sort + URL (de)serialization as pure functions.
Testing
30 new tests (18 utils + 12 page integration) covering every acceptance criterion: renders all agents, capability/price/status filtering, slider filters without a refetch, modal tx-hash link, auto-refresh without skeleton flash, loading skeleton, empty state, and URL read/write round-trip.
Full suite: 63/63 passing. tsc --noEmit and vite build both clean.
Acceptance criteria
 Table renders all agents from GET /api/agents
 Capability filter hides non-matching agents in real time
 Price filter is client-side with no API call
 Modal shows registration tx hash linked to Stellar Explorer
 Auto-refresh updates the table without remounting
 Loading shows a 5-row skeleton
 Empty state renders on []
 Filter/sort state persisted in the URL query string
