### PR TITLE
feat(stream): cursor-based WebSocket event replay via ?lastEventId

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -94,8 +94,9 @@ export function createApp(opts: AppOptions = {}): { httpServer: HttpServer; clos
   const httpServer = createServer(app);
 
   // ── Event persistence ──────────────────────────────────────────────────────
-  // Record every Coordinator event so a (re)connecting client can replay the
-  // task's full history before live streaming begins.
+  // Record every Coordinator event (with its EventBus-assigned per-task seq) so
+  // a (re)connecting client can replay history before live streaming begins —
+  // either the full history, or only events past a `?lastEventId` cursor.
   const eventStore = opts.eventStore ?? createEventStore();
   const stopRecording = eventBus.subscribeAll(event => eventStore.append(event));
 

--- a/backend/src/api/routes/stream.ts
+++ b/backend/src/api/routes/stream.ts
@@ -9,7 +9,21 @@ import type { EventStore } from '../../coordinator/eventStore';
 import type { Task } from '../../coordinator/types';
 import { WS_CLOSE } from '../../types/stream';
 
-const STREAM_PATH = /^\/tasks\/([^/]+)\/stream$/;
+const STREAM_PATH = /^\/tasks\/([^/?]+)\/stream(?:\?.*)?$/;
+
+/**
+ * Parse the optional `?lastEventId=<number>` cursor from a stream URL. Returns
+ * the parsed non-negative integer, or undefined when the param is absent or
+ * malformed (in which case the client gets a full replay — backward compatible).
+ */
+function parseLastEventId(url: string): number | undefined {
+  const qIndex = url.indexOf('?');
+  if (qIndex === -1) return undefined;
+  const raw = new URLSearchParams(url.slice(qIndex + 1)).get('lastEventId');
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : undefined;
+}
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_PONG_TIMEOUT_MS = 10_000;
@@ -37,8 +51,13 @@ export interface TaskStreamDeps extends TaskStreamOptions {
  * Exposes ws://<host>/tasks/:id/stream. Each connection:
  *   1. must send `{ walletPublicKey }` as its first message (auth handshake);
  *   2. is validated against the task owner — non-owners get a 403 close frame;
- *   3. receives a chronological replay of all past events from the store;
+ *   3. receives a chronological replay of past events from the store — all of
+ *      them by default, or only those with seq > N when the handshake URL
+ *      carries an optional `?lastEventId=N` cursor;
  *   4. then streams live events as the Coordinator emits them.
+ *
+ * Every event sent to the client carries a per-task monotonic `seq`, so the
+ * client can persist the last seq it saw and resume from it on reconnect.
  *
  * A heartbeat ping is sent on an interval and the socket is closed if no pong
  * arrives in time. All subscriptions and timers are cleaned up on disconnect.
@@ -65,14 +84,20 @@ export function attachTaskStream(deps: TaskStreamDeps): () => void {
       return;
     }
     const taskId = match[1]!;
+    const lastEventId = parseLastEventId(req.url ?? '');
     wss.handleUpgrade(req, socket, head, ws => {
-      wss.emit('connection', ws, req, taskId);
+      wss.emit('connection', ws, req, taskId, lastEventId);
     });
   };
 
   httpServer.on('upgrade', onUpgrade);
 
-  wss.on('connection', (ws: WebSocket, _req: IncomingMessage, taskId: string) => {
+  wss.on('connection', (
+    ws: WebSocket,
+    _req: IncomingMessage,
+    taskId: string,
+    lastEventId?: number
+  ) => {
     const task = getTask(taskId);
     if (!task) {
       ws.close(WS_CLOSE.TASK_NOT_FOUND, 'Task not found');
@@ -80,7 +105,10 @@ export function attachTaskStream(deps: TaskStreamDeps): () => void {
     }
 
     let authed = false;
-    let lastSentSeq = 0;
+    // Cursor for the next flush: events with seq > lastSentSeq are replayed.
+    // With ?lastEventId=N we resume after seq N; without it we fall back to -1
+    // so the full history (seq 0 → latest) is replayed — backward compatible.
+    let lastSentSeq = lastEventId ?? -1;
     let unsubLive: (() => void) | undefined;
     let heartbeat: NodeJS.Timeout | undefined;
     let pongTimer: NodeJS.Timeout | undefined;
@@ -104,9 +132,10 @@ export function attachTaskStream(deps: TaskStreamDeps): () => void {
     const flush = (): void => {
       const events = eventStore.listByTaskSince(taskId, lastSentSeq);
       for (const event of events) {
-        const { seq, ...dagEvent } = event;
-        send(dagEvent);
-        lastSentSeq = seq;
+        // Send the full event including its seq so the client can record a
+        // cursor and resume from it via ?lastEventId on a later reconnect.
+        send(event);
+        lastSentSeq = event.seq;
       }
     };
 

--- a/backend/src/coordinator/eventBus.ts
+++ b/backend/src/coordinator/eventBus.ts
@@ -10,7 +10,18 @@ class EventBus extends EventEmitter {
   /** Internal channel that receives every event regardless of taskId. */
   private static readonly ALL = '__all__';
 
+  /** Next sequence number to assign per taskId (counter starts at 0). */
+  private readonly nextSeqByTask = new Map<string, number>();
+
   emit(taskId: string, event: DAGEvent): boolean {
+    // Stamp a per-task monotonic sequence number BEFORE any subscriber sees the
+    // event, so the persistence recorder and every live handler observe the
+    // same seq. seq starts at 0 for each taskId and increments by 1 per event,
+    // giving clients a stable cursor to resume a stream from (?lastEventId).
+    const seq = this.nextSeqByTask.get(taskId) ?? 0;
+    this.nextSeqByTask.set(taskId, seq + 1);
+    event.seq = seq;
+
     // Notify the persistence recorder FIRST so the event is durably stored
     // before any per-task subscriber reacts to it.  Live WebSocket handlers
     // drain newly-persisted rows, so the row must exist by the time they run.

--- a/backend/src/coordinator/eventStore.ts
+++ b/backend/src/coordinator/eventStore.ts
@@ -2,9 +2,9 @@ import Database from 'better-sqlite3';
 import type { DAGEvent, DAGEventType } from './types';
 
 /**
- * A persisted event with its monotonic store sequence id.  The `seq` is the
- * SQLite autoincrement row id and defines the canonical chronological order
- * used for replay and for streaming "events newer than X".
+ * A persisted event with its per-task sequence id.  The `seq` is assigned by
+ * the EventBus (monotonic per taskId, starting at 0) and defines the canonical
+ * chronological order used for replay and for streaming "events newer than X".
  */
 export interface StoredEvent extends DAGEvent {
   seq: number;
@@ -41,7 +41,8 @@ export function createEventStore(db?: Database.Database | string): EventStore {
 
   database.exec(`
     CREATE TABLE IF NOT EXISTS task_events (
-      seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      seq         INTEGER NOT NULL,
       taskId      TEXT NOT NULL,
       type        TEXT NOT NULL,
       nodeId      TEXT,
@@ -52,8 +53,8 @@ export function createEventStore(db?: Database.Database | string): EventStore {
   `);
 
   const insertStmt = database.prepare(`
-    INSERT INTO task_events (taskId, type, nodeId, timestamp, payloadJson)
-    VALUES (@taskId, @type, @nodeId, @timestamp, @payloadJson)
+    INSERT INTO task_events (seq, taskId, type, nodeId, timestamp, payloadJson)
+    VALUES (@seq, @taskId, @type, @nodeId, @timestamp, @payloadJson)
   `);
   const listStmt = database.prepare(
     'SELECT * FROM task_events WHERE taskId = ? ORDER BY seq ASC'
@@ -76,14 +77,18 @@ export function createEventStore(db?: Database.Database | string): EventStore {
 
   return {
     append(event: DAGEvent): StoredEvent {
-      const info = insertStmt.run({
+      // seq is assigned upstream by the EventBus; default to 0 only for events
+      // that never passed through the bus (defensive — should not happen).
+      const seq = event.seq ?? 0;
+      insertStmt.run({
+        seq,
         taskId: event.taskId,
         type: event.type,
         nodeId: event.nodeId ?? null,
         timestamp: event.timestamp,
         payloadJson: event.payload !== undefined ? JSON.stringify(event.payload) : null,
       });
-      return { ...event, seq: Number(info.lastInsertRowid) };
+      return { ...event, seq };
     },
 
     listByTask(taskId: string): StoredEvent[] {

--- a/backend/src/coordinator/types.ts
+++ b/backend/src/coordinator/types.ts
@@ -42,4 +42,11 @@ export interface DAGEvent {
   nodeId?: string;
   timestamp: string;
   payload?: unknown;
+  /**
+   * Per-task monotonic sequence number assigned by the EventBus when the event
+   * is emitted. Starts at 0 for each taskId and increments by 1 per event, so
+   * a client can resume a stream from a known cursor. Absent only on events
+   * that have not yet passed through the bus.
+   */
+  seq?: number;
 }

--- a/backend/tests/e2e/stream.test.ts
+++ b/backend/tests/e2e/stream.test.ts
@@ -91,14 +91,15 @@ describe('WebSocket task stream', () => {
   function connect(
     taskId: string,
     wallet: string,
-    opts: { autoPong?: boolean } = {}
+    opts: { autoPong?: boolean; lastEventId?: number } = {}
   ): {
     ws: WebSocket;
     events: WsEvent[];
     untilCompleted: Promise<WsEvent[]>;
     closed: Promise<{ code: number; reason: string }>;
   } {
-    const ws = new WebSocket(`${wsBase}/tasks/${taskId}/stream`);
+    const query = opts.lastEventId !== undefined ? `?lastEventId=${opts.lastEventId}` : '';
+    const ws = new WebSocket(`${wsBase}/tasks/${taskId}/stream${query}`);
     const events: WsEvent[] = [];
     let resolveDone!: (e: WsEvent[]) => void;
     let rejectDone!: (err: Error) => void;
@@ -232,6 +233,47 @@ describe('WebSocket task stream', () => {
     for (let i = 1; i < timestamps.length; i++) {
       expect(timestamps[i]!).toBeGreaterThanOrEqual(timestamps[i - 1]!);
     }
+  }, 20_000);
+
+  it('replays only events after ?lastEventId on reconnect (cursor-based replay)', async () => {
+    const taskId = await createTaskFor(OWNER);
+    // Drive the task to completion and capture the full, seq-stamped history.
+    const first = connect(taskId, OWNER);
+    const all = await first.untilCompleted;
+    first.ws.close();
+
+    // Every event carries a per-task monotonic seq, 0-indexed and contiguous.
+    const seqs = all.map(e => e.seq as number);
+    expect(seqs[0]).toBe(0);
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]!).toBe(seqs[i - 1]! + 1);
+    }
+
+    // Reconnect with a cursor partway through; only later events must replay.
+    const cursor = seqs[4]!; // resume after the 5th event
+    const second = connect(taskId, OWNER, { lastEventId: cursor });
+    const replayed = await second.untilCompleted;
+    second.ws.close();
+
+    expect(replayed.every(e => (e.seq as number) > cursor)).toBe(true);
+    expect(replayed[0]!.seq).toBe(cursor + 1);
+    expect(replayed).toHaveLength(all.length - (cursor + 1));
+    expect(replayed[replayed.length - 1]!.type).toBe('task_completed');
+  }, 20_000);
+
+  it('replays the full history when no ?lastEventId is given', async () => {
+    const taskId = await createTaskFor(OWNER);
+    const first = connect(taskId, OWNER);
+    const all = await first.untilCompleted;
+    first.ws.close();
+
+    const second = connect(taskId, OWNER);
+    const replayed = await second.untilCompleted;
+    second.ws.close();
+
+    // Full replay starts at seq 0 and matches the original run.
+    expect(replayed[0]!.seq).toBe(0);
+    expect(replayed.map(e => e.seq)).toEqual(all.map(e => e.seq));
   }, 20_000);
 
   it('closes stale connections that never pong', async () => {

--- a/backend/tests/replay.test.ts
+++ b/backend/tests/replay.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for cursor-based stream replay (Issue: WebSocket resume).
+ *
+ * Covers:
+ *   - the EventBus assigns a per-task monotonic seq starting at 0;
+ *   - the EventStore replays the full history by default;
+ *   - the EventStore replays only events with seq > cursor (partial replay).
+ */
+
+import { eventBus } from '../src/coordinator/eventBus';
+import { createEventStore } from '../src/coordinator/eventStore';
+import type { DAGEvent } from '../src/coordinator/types';
+
+function makeEvent(taskId: string, seq?: number): DAGEvent {
+  return {
+    type: 'node_started',
+    taskId,
+    nodeId: `node_${seq ?? 0}`,
+    timestamp: new Date().toISOString(),
+    seq,
+  };
+}
+
+describe('EventBus seq assignment', () => {
+  it('stamps a per-task monotonic seq starting at 0', () => {
+    const taskId = 'task_seq_basic';
+    const seen: Array<number | undefined> = [];
+    const unsub = eventBus.subscribe(taskId, e => seen.push(e.seq));
+
+    for (let i = 0; i < 4; i++) {
+      eventBus.emit(taskId, makeEvent(taskId));
+    }
+    unsub();
+
+    expect(seen).toEqual([0, 1, 2, 3]);
+  });
+
+  it('keeps separate, independent seq counters per taskId', () => {
+    const a = 'task_seq_a';
+    const b = 'task_seq_b';
+    const seenA: Array<number | undefined> = [];
+    const seenB: Array<number | undefined> = [];
+    const unsubA = eventBus.subscribe(a, e => seenA.push(e.seq));
+    const unsubB = eventBus.subscribe(b, e => seenB.push(e.seq));
+
+    eventBus.emit(a, makeEvent(a)); // a:0
+    eventBus.emit(b, makeEvent(b)); // b:0
+    eventBus.emit(a, makeEvent(a)); // a:1
+    eventBus.emit(b, makeEvent(b)); // b:1
+    eventBus.emit(a, makeEvent(a)); // a:2
+    unsubA();
+    unsubB();
+
+    expect(seenA).toEqual([0, 1, 2]);
+    expect(seenB).toEqual([0, 1]);
+  });
+});
+
+describe('EventStore cursor replay', () => {
+  it('replays the full history (seq 0 → latest) by default', () => {
+    const store = createEventStore();
+    const taskId = 'task_full_replay';
+    for (let seq = 0; seq <= 9; seq++) store.append(makeEvent(taskId, seq));
+
+    expect(store.listByTask(taskId).map(e => e.seq)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    store.close();
+  });
+
+  it('replays only events with seq greater than the cursor', () => {
+    const store = createEventStore();
+    const taskId = 'task_partial_replay';
+    for (let seq = 0; seq <= 9; seq++) store.append(makeEvent(taskId, seq));
+
+    // Connect with lastEventId=5 → only events 6 onwards.
+    expect(store.listByTaskSince(taskId, 5).map(e => e.seq)).toEqual([6, 7, 8, 9]);
+    store.close();
+  });
+
+  it('isolates replay to a single taskId', () => {
+    const store = createEventStore();
+    for (let seq = 0; seq <= 2; seq++) store.append(makeEvent('task_x', seq));
+    for (let seq = 0; seq <= 2; seq++) store.append(makeEvent('task_y', seq));
+
+    expect(store.listByTaskSince('task_x', 0).map(e => e.seq)).toEqual([1, 2]);
+    expect(store.listByTask('task_y').map(e => e.seq)).toEqual([0, 1, 2]);
+    store.close();
+  });
+});


### PR DESCRIPTION
Closes #61

## Background
`GET /tasks/:id/stream` replayed a task's **full** event history on every (re)connect. Long-running tasks accumulate hundreds of events — replaying all of them on reconnect wastes bandwidth and causes UI flicker. Clients need to resume from where they left off.

## What changed
- **`coordinator/eventBus.ts`** — `emit()` now stamps each event with a per-task **monotonic `seq`** (0-indexed, +1 per event) *before* any subscriber sees it, so the persistence recorder and live handlers observe the same seq. Counters are isolated per `taskId`.
- **`coordinator/types.ts`** — `DAGEvent` gains an optional `seq` (set by the bus; emitters don't supply it).
- **`coordinator/eventStore.ts`** — persists and queries by the EventBus-assigned per-task `seq` (separate `id` PK for physical row order) instead of a global autoincrement cursor.
- **`api/routes/stream.ts`** — the handshake accepts an optional `?lastEventId=N` query param. With it, only events with `seq > N` are replayed; without it, the full history (seq 0 → latest) is replayed as before (backward compatible). Every event sent to the client now includes its `seq` so clients can record a resume cursor.
- **`api/app.ts`** — comment updated to reflect cursor-based replay.

> Note: the WebSocket handling referenced in the issue (`app.ts`) is factored into `api/routes/stream.ts`, which `app.ts` wires up — the change lives there.

## Acceptance criteria
- ✅ Connect with `?lastEventId=5` only replays events 6 onwards
- ✅ Connect without the param replays all events (seq 0 → latest)
- ✅ `seq` increments monotonically for the same `taskId`
- ✅ Unit test asserts partial replay
- ✅ No regression in existing `pipeline.test.ts`

## Tests
- `tests/replay.test.ts` (new) — per-task monotonic seq, independent per-task counters, full replay, and **partial replay** (`seq > cursor`).
- `tests/e2e/stream.test.ts` — cursor-based reconnect replays only later events; no-param reconnect replays the full history.
- All 21 tests across `replay`, `stream` (e2e), and `pipeline` (e2e) pass.