### PR TITLE
feat(agents): implement Research Agent with Venice + Zod validation

### DIFF
--- a/smart-contracts/src/agents/research/research.ts
+++ b/smart-contracts/src/agents/research/research.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import { registerAgent } from '../../registry/registry';
+import { Agent, AgentResult, SubTask } from '../../types/agent';
+import { VeniceClient } from '../../venice/venice';
+
+const VeniceResponseSchema = z.object({
+  summary: z.string().min(100, 'summary must be at least 100 characters'),
+  keyFindings: z.array(z.string()).min(1, 'keyFindings cannot be empty'),
+  dataSources: z.array(z.string()),
+});
+
+export interface ResearchOutput {
+  summary: string;
+  keyFindings: string[];
+  dataSources: string[];
+  generatedAt: number;
+}
+
+const AGENT_ID = 'research-agent-1';
+const AGENT_NAME = 'Research Agent';
+const AGENT_CAPABILITY = 'research';
+
+export class ResearchAgent implements Agent {
+  constructor(private readonly venice: VeniceClient) {}
+
+  start(): void {
+    // registration happens on module load
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return Boolean(process.env.VENICE_API_KEY);
+  }
+
+  async execute(task: SubTask): Promise<AgentResult> {
+    // Research is always the first node in a DAG, so there is normally no
+    // upstream context. We still forward it when present to stay consistent
+    // with downstream agents.
+    const upstreamContext = task.upstreamResults?.length
+      ? `\n\nUpstream context:\n${JSON.stringify(task.upstreamResults, null, 2)}`
+      : '';
+
+    const prompt = [
+      'You are a research assistant. Respond with valid JSON only, no markdown.',
+      'Format: {"summary":"string","keyFindings":["string"],"dataSources":["string"]}',
+      'The summary must be a thorough paragraph of at least 100 characters.',
+      upstreamContext,
+      `\nTask: ${task.prompt}`,
+    ].join('\n');
+
+    const model = this.venice.getModelForAgent(AGENT_CAPABILITY);
+    const content = await this.venice.complete(prompt, model);
+
+    const parsed = VeniceResponseSchema.parse(JSON.parse(content));
+
+    const output: ResearchOutput = {
+      summary: parsed.summary,
+      keyFindings: parsed.keyFindings,
+      dataSources: parsed.dataSources,
+      generatedAt: Date.now(),
+    };
+
+    return {
+      agentId: AGENT_ID,
+      agentName: AGENT_NAME,
+      capability: AGENT_CAPABILITY,
+      data: output,
+    };
+  }
+}
+
+registerAgent({
+  id: AGENT_ID,
+  name: AGENT_NAME,
+  capability: AGENT_CAPABILITY,
+  priceXLM: 1,
+  stellarAddress: '',
+});

--- a/smart-contracts/tests/research.test.ts
+++ b/smart-contracts/tests/research.test.ts
@@ -1,0 +1,123 @@
+import { ResearchAgent, ResearchOutput } from '../src/agents/research/research';
+import { getAgent } from '../src/registry/registry';
+import { VeniceClient } from '../src/venice/venice';
+
+const longSummary =
+  'The decentralized AI agent market is expanding rapidly, driven by demand for ' +
+  'autonomous coordination, on-chain payments, and composable agent networks built on Stellar.';
+
+const baseResearchResponse = {
+  summary: longSummary,
+  keyFindings: [
+    'Demand for agent-to-agent payments is growing',
+    'Stellar offers low-cost settlement',
+  ],
+  dataSources: ['https://example.com/report', 'internal-analysis'],
+};
+
+const makeVenice = (response: object) => ({
+  complete: jest.fn().mockResolvedValue(JSON.stringify(response)),
+  getModelForAgent: jest.fn().mockReturnValue('venice-xl'),
+  stream: jest.fn(),
+});
+
+describe('ResearchAgent', () => {
+  it('returns a valid ResearchOutput for a substantive prompt', async () => {
+    const venice = makeVenice(baseResearchResponse);
+    const agent = new ResearchAgent(venice as unknown as VeniceClient);
+    const result = await agent.execute({
+      prompt: 'Research the decentralized AI agent market',
+    });
+    const output = result.data as ResearchOutput;
+
+    expect(result.capability).toBe('research');
+    expect(output.summary).toBe(longSummary);
+    expect(Array.isArray(output.keyFindings)).toBe(true);
+    expect(output.keyFindings.length).toBeGreaterThan(0);
+    expect(Array.isArray(output.dataSources)).toBe(true);
+    expect(typeof output.generatedAt).toBe('number');
+  });
+
+  it('produces a summary that is at least 100 characters', async () => {
+    const venice = makeVenice(baseResearchResponse);
+    const agent = new ResearchAgent(venice as unknown as VeniceClient);
+    const result = await agent.execute({ prompt: 'Research the market' });
+    const output = result.data as ResearchOutput;
+
+    expect(output.summary.length).toBeGreaterThanOrEqual(100);
+  });
+
+  it('uses venice-xl model via getModelForAgent', async () => {
+    const venice = makeVenice(baseResearchResponse);
+    const agent = new ResearchAgent(venice as unknown as VeniceClient);
+    await agent.execute({ prompt: 'Research the market' });
+
+    expect(venice.getModelForAgent).toHaveBeenCalledWith('research');
+    expect(venice.complete).toHaveBeenCalledWith(expect.any(String), 'venice-xl');
+  });
+
+  it('Zod rejects a response missing keyFindings', async () => {
+    const venice = makeVenice({
+      summary: longSummary,
+      dataSources: [],
+    });
+    const agent = new ResearchAgent(venice as unknown as VeniceClient);
+    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
+  });
+
+  it('Zod rejects a summary shorter than 100 characters', async () => {
+    const venice = makeVenice({
+      summary: 'Too short.',
+      keyFindings: ['a finding'],
+      dataSources: [],
+    });
+    const agent = new ResearchAgent(venice as unknown as VeniceClient);
+    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
+  });
+
+  it('registers with capability "research" on module load (via getAgent)', () => {
+    const meta = getAgent('research-agent-1');
+    expect(meta?.capability).toBe('research');
+  });
+
+  it('sends an empty upstream context when none is provided (research is first)', async () => {
+    const venice = makeVenice(baseResearchResponse);
+    const agent = new ResearchAgent(venice as unknown as VeniceClient);
+    await agent.execute({ prompt: 'Research the market' });
+
+    const promptArg = venice.complete.mock.calls[0][0] as string;
+    expect(promptArg).not.toContain('Upstream context:');
+    expect(promptArg).toContain('Research the market');
+  });
+
+  it('forwards upstream context when upstreamResults are provided', async () => {
+    const venice = makeVenice(baseResearchResponse);
+    const agent = new ResearchAgent(venice as unknown as VeniceClient);
+    await agent.execute({
+      prompt: 'Research the market',
+      upstreamResults: [
+        {
+          agentId: 'seed-1',
+          agentName: 'Seed Agent',
+          capability: 'seed',
+          data: { note: 'prior context payload' },
+        },
+      ],
+    });
+
+    const promptArg = venice.complete.mock.calls[0][0] as string;
+    expect(promptArg).toContain('Upstream context:');
+    expect(promptArg).toContain('prior context payload');
+  });
+
+  it('healthCheck returns false when VENICE_API_KEY is not set', async () => {
+    const original = process.env.VENICE_API_KEY;
+    delete process.env.VENICE_API_KEY;
+    const venice = makeVenice(baseResearchResponse);
+    const agent = new ResearchAgent(venice as unknown as VeniceClient);
+
+    expect(await agent.healthCheck()).toBe(false);
+
+    if (original !== undefined) process.env.VENICE_API_KEY = original;
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **Research Agent** — the first node in every DAG, whose output feeds all downstream agents. Replaces the backend-only stub with a real agent under `smart-contracts/src/agents/research/`.

- `ResearchAgent` implements the `Agent` interface (`execute`, `start`, `healthCheck`).
- Calls `VeniceClient.complete()` with a structured JSON prompt, routing the model via `getModelForAgent("research")`.
- Returns `ResearchOutput { summary, keyFindings: string[], dataSources: string[], generatedAt: number }`.
- **Zod** validation on the Venice response: non-empty `keyFindings` and a `summary` of at least 100 characters; `generatedAt` is stamped server-side.
- Registers with capability `"research"` on module load via `registerAgent` (verified through `getAgent`).
- Forwards upstream context, expected empty since research always runs first.

## Files

- `smart-contracts/src/agents/research/research.ts`
- `smart-contracts/tests/research.test.ts`

## Testing

- `jest tests/research.test.ts` → 9/9 pass
- `tsc --noEmit` → clean
- `eslint` on the new file → clean
- Full suite unaffected (80 passed, 3 pre-existing skips)

## Acceptance Criteria

- [x] `execute` returns a valid `ResearchOutput` for any substantive prompt
- [x] Zod rejects a response missing `keyFindings`
- [x] `summary` is at least 100 characters
- [x] Agent registers with capability `"research"` — verified via `getAgent`
- [x] 6+ unit tests with mocked `VeniceClient` (9 included)

Closes #55
