### PR TITLE
feat(design): implement DesignAgent with Venice routing and Zod validation

### DIFF
--- a/smart-contracts/src/agents/design/design.ts
+++ b/smart-contracts/src/agents/design/design.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+import { registerAgent } from '../../registry/registry';
+import { Agent, AgentResult, SubTask } from '../../types/agent';
+import { VeniceClient } from '../../venice/venice';
+
+const DiagramSpecSchema = z.object({
+  title: z.string(),
+  type: z.enum(['flowchart', 'sequence', 'erd']),
+  description: z.string(),
+});
+
+const DesignOutputSchema = z.object({
+  components: z.array(z.string()).min(1, 'At least one component is required'),
+  interactions: z.array(z.string()),
+  diagrams: z
+    .array(DiagramSpecSchema)
+    .min(1, 'At least one diagram is required'),
+  rationale: z.string(),
+});
+
+export type DiagramSpec = z.infer<typeof DiagramSpecSchema>;
+export type DesignOutput = z.infer<typeof DesignOutputSchema>;
+
+const AGENT_ID = 'design-agent-1';
+const AGENT_NAME = 'Design Agent';
+const AGENT_CAPABILITY = 'design';
+
+export class DesignAgent implements Agent {
+  constructor(private readonly venice: VeniceClient) {}
+
+  start(): void {
+    // registration happens on module load
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return Boolean(process.env.VENICE_API_KEY);
+  }
+
+  async execute(task: SubTask): Promise<AgentResult> {
+    const upstreamContext = task.upstreamResults?.length
+      ? `\n\nUpstream context:\n${JSON.stringify(task.upstreamResults, null, 2)}`
+      : '';
+
+    const prompt = [
+      'You are a software architecture design assistant. Respond with valid JSON only, no markdown.',
+      'Format: {"components":["string"],"interactions":["string"],"diagrams":[{"title":"string","type":"flowchart|sequence|erd","description":"string"}],"rationale":"string"}',
+      'Provide at least one component and at least one diagram.',
+      upstreamContext,
+      `\nTask: ${task.prompt}`,
+    ].join('\n');
+
+    const model = this.venice.getModelForAgent(AGENT_CAPABILITY);
+    const content = await this.venice.complete(prompt, model);
+
+    const parsed = DesignOutputSchema.parse(JSON.parse(content));
+
+    return {
+      agentId: AGENT_ID,
+      agentName: AGENT_NAME,
+      capability: AGENT_CAPABILITY,
+      data: parsed,
+    };
+  }
+}
+
+registerAgent({
+  id: AGENT_ID,
+  name: AGENT_NAME,
+  capability: AGENT_CAPABILITY,
+  priceXLM: 1,
+  stellarAddress: '',
+});

--- a/smart-contracts/tests/design.test.ts
+++ b/smart-contracts/tests/design.test.ts
@@ -1,0 +1,130 @@
+import { DesignAgent, DesignOutput } from '../src/agents/design/design';
+import { getAgent } from '../src/registry/registry';
+import { VeniceClient } from '../src/venice/venice';
+
+const makeVenice = (response: object) => ({
+  complete: jest.fn().mockResolvedValue(JSON.stringify(response)),
+  getModelForAgent: jest.fn().mockReturnValue('venice-xl'),
+  stream: jest.fn(),
+});
+
+const baseDesignResponse = {
+  components: ['API Gateway', 'Order Service', 'Postgres Database'],
+  interactions: [
+    'Client calls API Gateway',
+    'API Gateway routes to Order Service',
+    'Order Service persists to Postgres Database',
+  ],
+  diagrams: [
+    {
+      title: 'System Overview',
+      type: 'flowchart',
+      description: 'High-level component flow from client to database.',
+    },
+    {
+      title: 'Order Creation',
+      type: 'sequence',
+      description: 'Sequence of calls when creating an order.',
+    },
+  ],
+  rationale: 'A layered service architecture keeps concerns isolated and scalable.',
+};
+
+describe('DesignAgent', () => {
+  it('returns valid DesignOutput with at least 1 component and 1 diagram', async () => {
+    const venice = makeVenice(baseDesignResponse);
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    const result = await agent.execute({
+      prompt: 'Design an order management system',
+    });
+    const output = result.data as DesignOutput;
+
+    expect(output.components.length).toBeGreaterThanOrEqual(1);
+    expect(output.diagrams.length).toBeGreaterThanOrEqual(1);
+    expect(output.components).toContain('API Gateway');
+    expect(output.diagrams[0].type).toBe('flowchart');
+    expect(output.rationale).toBeTruthy();
+    expect(result.capability).toBe('design');
+  });
+
+  it('uses venice-xl model via getModelForAgent', async () => {
+    const venice = makeVenice(baseDesignResponse);
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    await agent.execute({ prompt: 'Design a service' });
+
+    expect(venice.getModelForAgent).toHaveBeenCalledWith('design');
+    expect(venice.complete).toHaveBeenCalledWith(
+      expect.any(String),
+      'venice-xl',
+    );
+  });
+
+  it('Zod rejects response missing components field', async () => {
+    const venice = makeVenice({
+      interactions: [],
+      diagrams: [
+        {
+          title: 'Overview',
+          type: 'flowchart',
+          description: 'A diagram.',
+        },
+      ],
+      rationale: 'Some rationale.',
+    });
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
+  });
+
+  it('Zod rejects a diagram with an invalid type', async () => {
+    const venice = makeVenice({
+      ...baseDesignResponse,
+      diagrams: [
+        {
+          title: 'Bad Diagram',
+          type: 'gantt',
+          description: 'Unsupported diagram type.',
+        },
+      ],
+    });
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
+  });
+
+  it('Zod rejects a response with an empty diagrams array', async () => {
+    const venice = makeVenice({ ...baseDesignResponse, diagrams: [] });
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
+  });
+
+  it('registers with capability "design" on module load', () => {
+    const meta = getAgent('design-agent-1');
+    expect(meta?.capability).toBe('design');
+  });
+
+  it('includes upstream context when upstreamResults are provided', async () => {
+    const venice = makeVenice(baseDesignResponse);
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    await agent.execute({
+      prompt: 'Design a system',
+      upstreamResults: [
+        {
+          agentId: 'research-1',
+          agentName: 'Research Agent',
+          capability: 'research',
+          data: { summary: 'Event-driven patterns recommended' },
+        },
+      ],
+    });
+
+    const promptArg = venice.complete.mock.calls[0][0] as string;
+    expect(promptArg).toContain('Event-driven patterns recommended');
+  });
+
+  it('healthCheck returns false when VENICE_API_KEY is not set', async () => {
+    delete process.env.VENICE_API_KEY;
+    const venice = makeVenice(baseDesignResponse);
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    const healthy = await agent.healthCheck();
+    expect(healthy).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `DesignAgent`, which was declared in the Venice model routing map but previously unimplemented.

- `DesignAgent implements Agent` (`start` / `healthCheck` / `execute`), following the existing `CodingAgent` conventions
- Returns `DesignOutput { components: string[], interactions: string[], diagrams: DiagramSpec[], rationale: string }`
- `DiagramSpec = { title: string, type: 'flowchart' | 'sequence' | 'erd', description: string }`
- Zod validation on the Venice response — requires **≥1 component** and **≥1 diagram**, with `type` constrained via `z.enum`
- Routes through `venice.getModelForAgent('design')` → `venice-xl` (already present in the routing map)
- Registers with capability `"design"` on module load

## Files

- `smart-contracts/src/agents/design/design.ts`
- `smart-contracts/tests/design.test.ts`

## Acceptance Criteria

- ✅ Returns valid `DesignOutput` with at least 1 component and 1 diagram
- ✅ Zod rejects missing `components` field
- ✅ 5+ unit tests (8 total) with a mocked `VeniceClient`

## Testing

- `jest tests/design.test.ts` → **8 passed**
- `tsc --noEmit` → clean

Closes #57
