### PR TITLE
Implement design agent UI output schema

### DIFF
--- a/smart-contracts/src/agents/design/design.ts
+++ b/smart-contracts/src/agents/design/design.ts
@@ -3,22 +3,107 @@ import { registerAgent } from '../../registry/registry';
 import { Agent, AgentResult, SubTask } from '../../types/agent';
 import { VeniceClient } from '../../venice/venice';
 
-const DiagramSpecSchema = z.object({
-  title: z.string(),
-  type: z.enum(['flowchart', 'sequence', 'erd']),
-  description: z.string(),
+const HexColorSchema = z
+  .string()
+  .regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, 'hex must be #RGB or #RRGGBB');
+
+const UIElementSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1),
+  description: z.string().min(1),
 });
+
+const WireframeSectionSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  layout: z.enum(['grid', 'flex', 'absolute']),
+  elements: z.array(UIElementSchema).min(1),
+});
+
+const ColorTokenSchema = z.object({
+  name: z.string().min(1),
+  hex: HexColorSchema,
+  usage: z.string().min(1),
+});
+
+const ComponentNodeSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  parentId: z.string().min(1).nullable().optional(),
+  description: z.string().min(1),
+});
+
+const AssetEntrySchema = z.object({
+  name: z.string().min(1),
+  type: z.enum(['icon', 'image', 'font']),
+  description: z.string().min(1),
+  suggestedSource: z.string().min(1),
+});
+
+const ComponentHierarchySchema = z
+  .array(ComponentNodeSchema)
+  .min(1)
+  .superRefine((nodes, ctx) => {
+    const ids = new Set<string>();
+
+    for (const node of nodes) {
+      if (ids.has(node.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate component id: ${node.id}`,
+          path: [nodes.indexOf(node), 'id'],
+        });
+      }
+      ids.add(node.id);
+    }
+
+    const byId = new Map(nodes.map((node) => [node.id, node]));
+
+    for (const node of nodes) {
+      if (node.parentId && !byId.has(node.parentId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Unknown parentId: ${node.parentId}`,
+          path: [nodes.indexOf(node), 'parentId'],
+        });
+      }
+
+      const visited = new Set<string>();
+      let current: typeof node | undefined = node;
+
+      while (current?.parentId) {
+        if (visited.has(current.id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Circular component hierarchy at: ${node.id}`,
+            path: [nodes.indexOf(node), 'parentId'],
+          });
+          break;
+        }
+
+        visited.add(current.id);
+        current = byId.get(current.parentId);
+      }
+    }
+  });
 
 const DesignOutputSchema = z.object({
-  components: z.array(z.string()).min(1, 'At least one component is required'),
-  interactions: z.array(z.string()),
-  diagrams: z
-    .array(DiagramSpecSchema)
-    .min(1, 'At least one diagram is required'),
-  rationale: z.string(),
+  wireframes: z.array(WireframeSectionSchema).min(2),
+  colorPalette: z.array(ColorTokenSchema).min(4).max(12),
+  componentHierarchy: ComponentHierarchySchema,
+  assetManifest: z
+    .array(AssetEntrySchema)
+    .min(1)
+    .refine((assets) => assets.some((asset) => asset.type === 'icon'), {
+      message: 'assetManifest must include at least one icon asset',
+    }),
 });
 
-export type DiagramSpec = z.infer<typeof DiagramSpecSchema>;
+export type UIElement = z.infer<typeof UIElementSchema>;
+export type WireframeSection = z.infer<typeof WireframeSectionSchema>;
+export type ColorToken = z.infer<typeof ColorTokenSchema>;
+export type ComponentNode = z.infer<typeof ComponentNodeSchema>;
+export type AssetEntry = z.infer<typeof AssetEntrySchema>;
 export type DesignOutput = z.infer<typeof DesignOutputSchema>;
 
 const AGENT_ID = 'design-agent-1';
@@ -29,7 +114,13 @@ export class DesignAgent implements Agent {
   constructor(private readonly venice: VeniceClient) {}
 
   start(): void {
-    // registration happens on module load
+    registerAgent({
+      id: AGENT_ID,
+      name: AGENT_NAME,
+      capability: AGENT_CAPABILITY,
+      priceXLM: 1,
+      stellarAddress: '',
+    });
   }
 
   async healthCheck(): Promise<boolean> {
@@ -42,16 +133,17 @@ export class DesignAgent implements Agent {
       : '';
 
     const prompt = [
-      'You are a software architecture design assistant. Respond with valid JSON only, no markdown.',
-      'Format: {"components":["string"],"interactions":["string"],"diagrams":[{"title":"string","type":"flowchart|sequence|erd","description":"string"}],"rationale":"string"}',
-      'Provide at least one component and at least one diagram.',
+      'You are a senior product designer. Respond with valid JSON only, no markdown.',
+      'Create structured UI/UX guidance for the product description.',
+      'Format: {"wireframes":[{"name":"string","description":"string","layout":"grid|flex|absolute","elements":[{"name":"string","type":"string","description":"string"}]}],"colorPalette":[{"name":"string","hex":"#RRGGBB","usage":"string"}],"componentHierarchy":[{"id":"string","name":"string","parentId":"string|null","description":"string"}],"assetManifest":[{"name":"string","type":"icon|image|font","description":"string","suggestedSource":"string"}]}',
+      'Return at least 2 wireframe sections, 4 to 12 color tokens, a tree-shaped component hierarchy with no cycles, and at least one icon asset.',
+      'Every color hex must be a valid #RGB or #RRGGBB value.',
       upstreamContext,
-      `\nTask: ${task.prompt}`,
+      `\nProduct description: ${task.prompt}`,
     ].join('\n');
 
     const model = this.venice.getModelForAgent(AGENT_CAPABILITY);
     const content = await this.venice.complete(prompt, model);
-
     const parsed = DesignOutputSchema.parse(JSON.parse(content));
 
     return {
@@ -63,10 +155,4 @@ export class DesignAgent implements Agent {
   }
 }
 
-registerAgent({
-  id: AGENT_ID,
-  name: AGENT_NAME,
-  capability: AGENT_CAPABILITY,
-  priceXLM: 1,
-  stellarAddress: '',
-});
+new DesignAgent(new VeniceClient()).start();

--- a/smart-contracts/tests/design.test.ts
+++ b/smart-contracts/tests/design.test.ts
@@ -9,41 +9,87 @@ const makeVenice = (response: object) => ({
 });
 
 const baseDesignResponse = {
-  components: ['API Gateway', 'Order Service', 'Postgres Database'],
-  interactions: [
-    'Client calls API Gateway',
-    'API Gateway routes to Order Service',
-    'Order Service persists to Postgres Database',
-  ],
-  diagrams: [
+  wireframes: [
     {
-      title: 'System Overview',
-      type: 'flowchart',
-      description: 'High-level component flow from client to database.',
+      name: 'Dashboard Overview',
+      description: 'A scan-friendly workspace for product performance.',
+      layout: 'grid',
+      elements: [
+        {
+          name: 'KPI Row',
+          type: 'metric group',
+          description: 'Four key metrics with compact labels and trends.',
+        },
+      ],
     },
     {
-      title: 'Order Creation',
-      type: 'sequence',
-      description: 'Sequence of calls when creating an order.',
+      name: 'Project Detail',
+      description: 'A focused view for reviewing work and next actions.',
+      layout: 'flex',
+      elements: [
+        {
+          name: 'Activity Timeline',
+          type: 'timeline',
+          description: 'Chronological product and team updates.',
+        },
+      ],
     },
   ],
-  rationale: 'A layered service architecture keeps concerns isolated and scalable.',
+  colorPalette: [
+    { name: 'Surface', hex: '#101820', usage: 'Primary app background' },
+    { name: 'Panel', hex: '#1E2A32', usage: 'Grouped controls and tables' },
+    { name: 'Accent', hex: '#27C5A4', usage: 'Primary actions and highlights' },
+    { name: 'Warning', hex: '#F2B84B', usage: 'Attention states' },
+  ],
+  componentHierarchy: [
+    {
+      id: 'app-shell',
+      name: 'App Shell',
+      parentId: null,
+      description: 'Owns page chrome and global layout.',
+    },
+    {
+      id: 'dashboard',
+      name: 'Dashboard',
+      parentId: 'app-shell',
+      description: 'Displays overview modules.',
+    },
+    {
+      id: 'kpi-row',
+      name: 'KPI Row',
+      parentId: 'dashboard',
+      description: 'Groups performance metrics.',
+    },
+  ],
+  assetManifest: [
+    {
+      name: 'Status Icons',
+      type: 'icon',
+      description: 'Consistent glyphs for success, warning, and failure states.',
+      suggestedSource: 'lucide-react',
+    },
+    {
+      name: 'Inter UI',
+      type: 'font',
+      description: 'Readable interface typeface.',
+      suggestedSource: 'Google Fonts',
+    },
+  ],
 };
 
 describe('DesignAgent', () => {
-  it('returns valid DesignOutput with at least 1 component and 1 diagram', async () => {
+  it('returns valid DesignOutput with at least 2 wireframe sections', async () => {
     const venice = makeVenice(baseDesignResponse);
     const agent = new DesignAgent(venice as unknown as VeniceClient);
     const result = await agent.execute({
-      prompt: 'Design an order management system',
+      prompt: 'Design a product analytics dashboard',
     });
     const output = result.data as DesignOutput;
 
-    expect(output.components.length).toBeGreaterThanOrEqual(1);
-    expect(output.diagrams.length).toBeGreaterThanOrEqual(1);
-    expect(output.components).toContain('API Gateway');
-    expect(output.diagrams[0].type).toBe('flowchart');
-    expect(output.rationale).toBeTruthy();
+    expect(output.wireframes.length).toBeGreaterThanOrEqual(2);
+    expect(output.colorPalette.length).toBeGreaterThanOrEqual(4);
+    expect(output.colorPalette.length).toBeLessThanOrEqual(12);
+    expect(output.assetManifest.some((asset) => asset.type === 'icon')).toBe(true);
     expect(result.capability).toBe('design');
   });
 
@@ -54,35 +100,47 @@ describe('DesignAgent', () => {
 
     expect(venice.getModelForAgent).toHaveBeenCalledWith('design');
     expect(venice.complete).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.stringContaining('senior product designer'),
       'venice-xl',
     );
   });
 
-  it('Zod rejects response missing components field', async () => {
-    const venice = makeVenice({
-      interactions: [],
-      diagrams: [
-        {
-          title: 'Overview',
-          type: 'flowchart',
-          description: 'A diagram.',
-        },
-      ],
-      rationale: 'Some rationale.',
-    });
-    const agent = new DesignAgent(venice as unknown as VeniceClient);
-    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
-  });
-
-  it('Zod rejects a diagram with an invalid type', async () => {
+  it('Zod rejects invalid hex color values', async () => {
     const venice = makeVenice({
       ...baseDesignResponse,
-      diagrams: [
+      colorPalette: [
+        ...baseDesignResponse.colorPalette.slice(0, 3),
+        { name: 'Broken', hex: '27C5A4', usage: 'Invalid missing hash' },
+      ],
+    });
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
+  });
+
+  it('Zod rejects a color palette outside the 4 to 12 token range', async () => {
+    const venice = makeVenice({
+      ...baseDesignResponse,
+      colorPalette: baseDesignResponse.colorPalette.slice(0, 3),
+    });
+    const agent = new DesignAgent(venice as unknown as VeniceClient);
+    await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
+  });
+
+  it('Zod rejects circular component hierarchy references', async () => {
+    const venice = makeVenice({
+      ...baseDesignResponse,
+      componentHierarchy: [
         {
-          title: 'Bad Diagram',
-          type: 'gantt',
-          description: 'Unsupported diagram type.',
+          id: 'parent',
+          name: 'Parent',
+          parentId: 'child',
+          description: 'Parent node.',
+        },
+        {
+          id: 'child',
+          name: 'Child',
+          parentId: 'parent',
+          description: 'Child node.',
         },
       ],
     });
@@ -90,8 +148,18 @@ describe('DesignAgent', () => {
     await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
   });
 
-  it('Zod rejects a response with an empty diagrams array', async () => {
-    const venice = makeVenice({ ...baseDesignResponse, diagrams: [] });
+  it('Zod rejects an asset manifest without an icon', async () => {
+    const venice = makeVenice({
+      ...baseDesignResponse,
+      assetManifest: [
+        {
+          name: 'Inter UI',
+          type: 'font',
+          description: 'Readable interface typeface.',
+          suggestedSource: 'Google Fonts',
+        },
+      ],
+    });
     const agent = new DesignAgent(venice as unknown as VeniceClient);
     await expect(agent.execute({ prompt: 'test' })).rejects.toThrow();
   });


### PR DESCRIPTION

Closes #10

## Summary

Implemented the smart-contracts Design Agent output contract for structured UI/UX guidance, including wireframes, color palette, component hierarchy, and asset manifest validation.

## Changes

- Replaced the previous architecture-diagram response shape with the requested Design Agent schema.
- Added Zod validation for:
  - at least 2 wireframe sections
  - 4 to 12 color tokens
  - valid `#RGB` or `#RRGGBB` hex colors
  - component hierarchy with no missing parents or circular references
  - asset manifest containing at least one `icon`
- Updated the Venice prompt to request senior product designer UI/UX output.
- Kept Design Agent registration with capability `design` on startup/module load.
- Updated focused unit tests for the new schema and validation rules.



