### PR TITLE
#175 [CRITICAL] Fix Stats Module: PostgreSQL SQL in SQLite Codebase + Route Not Wired

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -19,6 +19,7 @@ import {
 } from "../payment";
 import { agentsRouter } from "./routes/agents";
 import { healthRouter } from "./routes/health";
+import { createStatsRouter } from "./routes/stats";
 import { rateLimitMiddleware } from "./middleware/rateLimit";
 import { authMiddleware } from "./middleware/auth";
 import { requestId } from "./middleware/requestId";
@@ -71,6 +72,9 @@ export function createApp(opts: AppOptions = {}): {
 
   // ── Health routes ───────────────────────────────────────────────────────────
   app.use("/health", healthRouter);
+
+  // ── Stats routes ───────────────────────────────────────────────────────────
+  app.use("/api/stats", createStatsRouter(getTaskDb()));
 
   // ── Agent routes ───────────────────────────────────────────────────────────
   app.use("/api/agents", agentsRouter);

--- a/backend/src/api/docs/openapi.ts
+++ b/backend/src/api/docs/openapi.ts
@@ -155,11 +155,11 @@ Close codes are defined in \`src/types/stream.ts\` (\`WS_CLOSE\`), covering: tas
     security: [{ WalletAuth: [] }],
   },
   // NOTE: annotations live in app.ts (inline task routes) and
-  // routes/agents.ts, routes/health.ts. routes/tasks.ts is NOT included —
+  // routes/agents.ts, routes/health.ts, routes/stats.ts. routes/tasks.ts is NOT included —
   // it is not wired into the running app (app.ts defines /api/tasks routes
   // inline instead) and documenting it would describe endpoints that don't
   // actually run.
-  apis: ["./src/api/app.ts", "./src/api/routes/agents.ts", "./src/api/routes/health.ts"],
+  apis: ["./src/api/app.ts", "./src/api/routes/agents.ts", "./src/api/routes/health.ts", "./src/api/routes/stats.ts"],
 };
 
 export const openapiSpec = swaggerJsdoc(options);

--- a/backend/src/api/routes/stats.test.ts
+++ b/backend/src/api/routes/stats.test.ts
@@ -1,23 +1,33 @@
 import express from 'express';
 import type { AddressInfo } from 'net';
+import Database from 'better-sqlite3';
 import { createStatsRouter } from './stats';
 import type { DbClient } from '../../db/stats';
 
+function createTestDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE agents (id TEXT PRIMARY KEY);
+    CREATE TABLE tasks (id TEXT PRIMARY KEY, status TEXT NOT NULL, "createdAt" TEXT NOT NULL);
+    CREATE TABLE payments (id TEXT PRIMARY KEY, amount REAL NOT NULL, status TEXT NOT NULL, "createdAt" TEXT NOT NULL);
+  `);
+  return db;
+}
+
 describe('Stats API route', () => {
   it('returns 200 and reuses cached stats for two requests within TTL', async () => {
-    const queryMock = jest.fn(async (text: string) => {
-      if (text.includes('FROM agents')) return { rows: [{ count: 1 }] };
-      if (text.includes('FROM tasks') && text.includes('SUM(CASE WHEN status =')) return { rows: [{ total: 2, succeeded: 2 }] };
-      if (text.includes('DATE_TRUNC') && text.includes('FROM tasks')) return { rows: [] };
-      if (text.includes('COUNT(*) AS count FROM tasks')) return { rows: [{ count: 2 }] };
-      if (text.includes('COALESCE(SUM(amount)') && text.includes('GROUP BY hour')) return { rows: [] };
-      if (text.includes('COALESCE(SUM(amount)')) return { rows: [{ amount: 10_000_000 }] };
-      return { rows: [] };
-    });
+    const db = createTestDb();
+    
+    // Add mock data
+    db.prepare('INSERT INTO agents (id) VALUES (?)').run('agent_1');
+    db.prepare('INSERT INTO tasks (id, status, "createdAt") VALUES (?, ?, ?)').run('task_1', 'completed', new Date().toISOString());
+    db.prepare('INSERT INTO payments (id, amount, status, "createdAt") VALUES (?, ?, ?, ?)').run('p1', 10000000, 'released', new Date().toISOString());
 
-    const db: DbClient = { query: queryMock as any };
+    // Spy on db.prepare to count invocations (6 queries in getStats)
+    const prepareSpy = jest.spyOn(db, 'prepare');
+
     const app = express();
-    app.use('/api', createStatsRouter(db));
+    app.use('/api/stats', createStatsRouter(db));
 
     const server = app.listen(0);
     const address = server.address() as AddressInfo;
@@ -30,10 +40,13 @@ describe('Stats API route', () => {
     const secondJson = await secondResponse.json();
 
     server.close();
+    db.close();
 
     expect(firstResponse.status).toBe(200);
     expect(secondResponse.status).toBe(200);
     expect(firstJson).toEqual(secondJson);
-    expect(queryMock).toHaveBeenCalledTimes(6);
+    
+    // getStats executes 6 queries. If cached, it should still be 6.
+    expect(prepareSpy).toHaveBeenCalledTimes(6);
   });
 });

--- a/backend/src/api/routes/stats.ts
+++ b/backend/src/api/routes/stats.ts
@@ -9,7 +9,48 @@ export function createStatsRouter(db: DbClient) {
     computeStats: () => getStats(db)
   });
 
-  router.get('/stats', async (req, res) => {
+  /**
+   * @openapi
+   * /api/stats:
+   *   get:
+   *     summary: Get network statistics
+   *     operationId: getStats
+   *     tags: [Stats]
+   *     security: []
+   *     responses:
+   *       200:
+   *         description: Current network statistics
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 totalAgents: { type: integer }
+   *                 totalTasks: { type: integer }
+   *                 uptimePercent: { type: number }
+   *                 totalXLMTransacted: { type: number }
+   *                 tasksLast24h:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       timestamp: { type: string, format: date-time }
+   *                       value: { type: number }
+   *                 xlmLast24h:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       timestamp: { type: string, format: date-time }
+   *                       value: { type: number }
+   *       500:
+   *         description: Unable to load stats
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   */
+  router.get('/', async (req, res) => {
     try {
       const stats = await cache.get();
       return res.status(200).json(stats);

--- a/backend/src/db/stats.test.ts
+++ b/backend/src/db/stats.test.ts
@@ -1,55 +1,97 @@
+import Database from 'better-sqlite3';
 import { getStats } from './stats';
 
 const now = new Date('2026-06-17T12:00:00.000Z');
 
-function createMockDb() {
-  return {
-    query: jest.fn(async (text: string, params?: unknown[]) => {
-      if (text.includes('FROM agents')) {
-        return { rows: [{ count: 15 }] };
-      }
+function createTestDb() {
+  const db = new Database(':memory:');
+  
+  db.exec(`
+    CREATE TABLE agents (id TEXT PRIMARY KEY);
+    CREATE TABLE tasks (
+      id TEXT PRIMARY KEY,
+      status TEXT NOT NULL,
+      "createdAt" TEXT NOT NULL
+    );
+    CREATE TABLE payments (
+      id TEXT PRIMARY KEY,
+      amount REAL NOT NULL,
+      status TEXT NOT NULL,
+      "createdAt" TEXT NOT NULL
+    );
+  `);
 
-      if (text.includes('FROM tasks') && text.includes('SUM(CASE WHEN status =')) {
-        return { rows: [{ total: 10, succeeded: 8 }] };
-      }
-
-      if (text.includes('DATE_TRUNC') && text.includes('FROM tasks')) {
-        return {
-          rows: [
-            { hour: '2026-06-16T13:00:00.000Z', count: 2 },
-            { hour: '2026-06-16T17:00:00.000Z', count: 3 },
-            { hour: '2026-06-17T12:00:00.000Z', count: 4 }
-          ]
-        };
-      }
-
-      if (text.includes('COUNT(*) AS count FROM tasks')) {
-        return { rows: [{ count: 154 }] };
-      }
-
-      if (text.includes('COALESCE(SUM(amount)') && text.includes('FROM payments')) {
-        if (text.includes('GROUP BY hour')) {
-          return {
-            rows: [
-              { hour: '2026-06-16T13:00:00.000Z', sum: 15_000_000 },
-              { hour: '2026-06-16T17:00:00.000Z', sum: 5_000_000 },
-              { hour: '2026-06-17T12:00:00.000Z', sum: 10_000_000 }
-            ]
-          };
-        }
-
-        return { rows: [{ amount: 123456789 }] };
-      }
-
-      return { rows: [] };
-    })
-  };
+  return db;
 }
 
 describe('getStats', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
   it('builds 24 hourly points and computes uptime and XLM transacted precisely', async () => {
-    const db = createMockDb();
-    const stats = await getStats(db as any, now);
+    // Insert 15 agents
+    const insertAgent = db.prepare('INSERT INTO agents (id) VALUES (?)');
+    for (let i = 0; i < 15; i++) {
+      insertAgent.run(`agent_${i}`);
+    }
+
+    // Insert 154 total tasks. We need 10 tasks in the last 7 days for uptime,
+    // and specific tasks in the last 24h for tasksLast24h.
+    
+    // For uptime (last 7 days): we want 10 total, 8 'completed'.
+    // The query checks createdAt >= '2026-06-10T12:00:00.000Z'
+    // We also need tasks for the 24h hourly buckets:
+    // 2 at 2026-06-16T13:XX:XX
+    // 3 at 2026-06-16T17:XX:XX
+    // 4 at 2026-06-17T12:XX:XX
+    // Total in last 7 days is 9 tasks from the hourly buckets. So we can add 1 more to make it 10.
+    // Of these 10, 8 should be 'completed'.
+    
+    const insertTask = db.prepare('INSERT INTO tasks (id, status, "createdAt") VALUES (?, ?, ?)');
+    
+    let taskId = 0;
+    const addTasks = (count: number, status: string, time: string) => {
+      for (let i = 0; i < count; i++) {
+        insertTask.run(`task_${taskId++}`, status, time);
+      }
+    };
+
+    // 2 at 2026-06-16T13:XX:XX
+    addTasks(2, 'completed', '2026-06-16T13:15:00.000Z');
+    // 3 at 2026-06-16T17:XX:XX
+    addTasks(3, 'completed', '2026-06-16T17:30:00.000Z');
+    // 4 at 2026-06-17T12:XX:XX
+    addTasks(3, 'completed', '2026-06-17T12:10:00.000Z');
+    addTasks(1, 'failed', '2026-06-17T12:15:00.000Z'); // 1 failed
+    
+    // Now we have 9 tasks in the last 7 days. Add 1 more failed task within the last 7 days.
+    addTasks(1, 'failed', '2026-06-15T12:00:00.000Z');
+    
+    // Now we have 10 tasks in the last 7 days, 8 completed, 2 failed.
+    // Total tasks so far: 10. We need 154 total. So add 144 old tasks (> 7 days ago).
+    addTasks(144, 'completed', '2026-01-01T00:00:00.000Z');
+
+    // Total XLM Transacted: 12.3456789 -> 123456789 stroops
+    // For xlmLast24h:
+    // 2026-06-16T13:00:00.000Z -> 15_000_000
+    // 2026-06-16T17:00:00.000Z -> 5_000_000
+    // 2026-06-17T12:00:00.000Z -> 10_000_000
+    // These sum to 30_000_000 stroops. We need 93_456_789 more for the old payments to reach 123_456_789.
+    
+    const insertPayment = db.prepare('INSERT INTO payments (id, amount, status, "createdAt") VALUES (?, ?, ?, ?)');
+    insertPayment.run('p1', 15_000_000, 'released', '2026-06-16T13:15:00.000Z');
+    insertPayment.run('p2', 5_000_000, 'released', '2026-06-16T17:30:00.000Z');
+    insertPayment.run('p3', 10_000_000, 'released', '2026-06-17T12:10:00.000Z');
+    insertPayment.run('p4', 93_456_789, 'released', '2026-01-01T00:00:00.000Z');
+
+    const stats = await getStats(db, now);
 
     expect(stats.totalAgents).toBe(15);
     expect(stats.totalTasks).toBe(154);
@@ -67,19 +109,8 @@ describe('getStats', () => {
   });
 
   it('returns 100 uptime percent when no tasks exist in the last 7 days', async () => {
-    const db = {
-      query: jest.fn(async (text: string) => {
-        if (text.includes('FROM agents')) return { rows: [{ count: 1 }] };
-        if (text.includes('FROM tasks') && text.includes('SUM(CASE WHEN status =')) return { rows: [{ total: 0, succeeded: 0 }] };
-        if (text.includes('DATE_TRUNC') && text.includes('FROM tasks')) return { rows: [] };
-        if (text.includes('COUNT(*) AS count FROM tasks')) return { rows: [{ count: 0 }] };
-        if (text.includes('COALESCE(SUM(amount)') && text.includes('GROUP BY hour')) return { rows: [] };
-        if (text.includes('COALESCE(SUM(amount)')) return { rows: [{ amount: 0 }] };
-        return { rows: [] };
-      })
-    };
-
-    const stats = await getStats(db as any, now);
+    // Leave db empty
+    const stats = await getStats(db, now);
     expect(stats.uptimePercent).toBe(100);
   });
 });

--- a/backend/src/db/stats.ts
+++ b/backend/src/db/stats.ts
@@ -1,6 +1,6 @@
 import type { StatsResponse, TimePoint } from '../types/stats';
 
-import type Database from 'better-sqlite3';
+import Database from 'better-sqlite3';
 
 export type DbClient = Database.Database;
 

--- a/backend/src/db/stats.ts
+++ b/backend/src/db/stats.ts
@@ -2,7 +2,7 @@ import type { StatsResponse, TimePoint } from '../types/stats';
 
 import type Database from 'better-sqlite3';
 
-export type DbClient = Database;
+export type DbClient = Database.Database;
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 const STROOP_FACTOR = 1e7;

--- a/backend/src/db/stats.ts
+++ b/backend/src/db/stats.ts
@@ -1,8 +1,8 @@
 import type { StatsResponse, TimePoint } from '../types/stats';
 
-export interface DbClient {
-  query<T>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
-}
+import type Database from 'better-sqlite3';
+
+export type DbClient = Database;
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 const STROOP_FACTOR = 1e7;
@@ -26,8 +26,8 @@ function buildHourlySeries(start: Date, end: Date, rows: Array<{ hour: string; v
 }
 
 async function queryCount(db: DbClient, queryText: string, params: unknown[] = []): Promise<number> {
-  const result = await db.query<{ count: number }>(queryText, params);
-  return Number(result.rows[0]?.count ?? 0);
+  const result = db.prepare(queryText).get(...params) as { count: number } | undefined;
+  return Number(result?.count ?? 0);
 }
 
 async function getTotalAgents(db: DbClient): Promise<number> {
@@ -39,44 +39,41 @@ async function getTotalTasks(db: DbClient): Promise<number> {
 }
 
 async function getTotalXLMTransacted(db: DbClient): Promise<number> {
-  const result = await db.query<{ amount: string | number }>(
+  const result = db.prepare(
     "SELECT COALESCE(SUM(amount), 0) AS amount FROM payments WHERE status = 'released'"
-  );
-  const rawAmount = Number(result.rows[0]?.amount ?? 0);
+  ).get() as { amount: string | number } | undefined;
+  const rawAmount = Number(result?.amount ?? 0);
   return normalizeDecimal(rawAmount / STROOP_FACTOR);
 }
 
 async function getUptimePercent(db: DbClient, since: Date): Promise<number> {
-  const result = await db.query<{ total: string | number; succeeded: string | number }>(
-    "SELECT COUNT(*) AS total, SUM(CASE WHEN status = 'succeeded' THEN 1 ELSE 0 END) AS succeeded FROM tasks WHERE \"createdAt\" >= $1",
-    [since.toISOString()]
-  );
+  const result = db.prepare(
+    "SELECT COUNT(*) AS total, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed FROM tasks WHERE \"createdAt\" >= ?"
+  ).get(since.toISOString()) as { total: string | number; completed: string | number } | undefined;
 
-  const total = Number(result.rows[0]?.total ?? 0);
-  const succeeded = Number(result.rows[0]?.succeeded ?? 0);
+  const total = Number(result?.total ?? 0);
+  const completed = Number(result?.completed ?? 0);
   if (total === 0) {
     return 100;
   }
 
-  return normalizeDecimal((succeeded / total) * 100);
+  return normalizeDecimal((completed / total) * 100);
 }
 
 async function getTasksHourlyCounts(db: DbClient, since: Date): Promise<Array<{ hour: string; value: number }>> {
-  const result = await db.query<{ hour: string; count: string | number }>(
-    "SELECT DATE_TRUNC('hour', \"createdAt\") AS hour, COUNT(*) AS count FROM tasks WHERE \"createdAt\" >= $1 GROUP BY hour ORDER BY hour",
-    [since.toISOString()]
-  );
+  const rows = db.prepare(
+    "SELECT strftime('%Y-%m-%d %H:00:00', \"createdAt\") AS hour, COUNT(*) AS count FROM tasks WHERE \"createdAt\" >= ? GROUP BY hour ORDER BY hour"
+  ).all(since.toISOString()) as Array<{ hour: string; count: string | number }>;
 
-  return result.rows.map((row) => ({ hour: row.hour, value: Number(row.count ?? 0) }));
+  return rows.map((row) => ({ hour: row.hour, value: Number(row.count ?? 0) }));
 }
 
 async function getXLMHourlyTotals(db: DbClient, since: Date): Promise<Array<{ hour: string; value: number }>> {
-  const result = await db.query<{ hour: string; sum: string | number }>(
-    "SELECT DATE_TRUNC('hour', \"createdAt\") AS hour, COALESCE(SUM(amount), 0) AS sum FROM payments WHERE status = 'released' AND \"createdAt\" >= $1 GROUP BY hour ORDER BY hour",
-    [since.toISOString()]
-  );
+  const rows = db.prepare(
+    "SELECT strftime('%Y-%m-%d %H:00:00', \"createdAt\") AS hour, COALESCE(SUM(amount), 0) AS sum FROM payments WHERE status = 'released' AND \"createdAt\" >= ? GROUP BY hour ORDER BY hour"
+  ).all(since.toISOString()) as Array<{ hour: string; sum: string | number }>;
 
-  return result.rows.map((row) => ({ hour: row.hour, value: normalizeDecimal(Number(row.sum ?? 0) / STROOP_FACTOR) }));
+  return rows.map((row) => ({ hour: row.hour, value: normalizeDecimal(Number(row.sum ?? 0) / STROOP_FACTOR) }));
 }
 
 export async function getStats(db: DbClient, now: Date = new Date()): Promise<StatsResponse> {


### PR DESCRIPTION
 

 Closes #175 

## Summary

This Pull Request resolves a critical system failure where the `/api/stats` endpoint was completely non-functional. The root cause was twofold: the route was never actually wired into the main Express application, and the underlying database queries were written using PostgreSQL-specific syntax (e.g., `$1` parameters, `DATE_TRUNC`) while the entire ai-net backend relies on a SQLite database (`better-sqlite3`). This resulted in a total collapse of network statistics functionality, causing the dashboard KPI cards to show zero data and frontend network hooks to throw errors. 

By comprehensively rewriting the stats queries to use native SQLite syntax and properly mounting the stats router, this PR restores the core monitoring functionality, ensuring real-time uptime metrics, task execution counts, and transaction volumes can be successfully processed and visualized by the frontend.

## Changes

- **Database Client Migration (`backend/src/db/stats.ts`)**: 
  - Rewrote the `DbClient` interface to directly accept a `better-sqlite3` `Database` instance rather than a generic asynchronous query wrapper.
  - Replaced all asynchronous `await db.query()` calls with synchronous `db.prepare(query).get()` and `db.prepare(query).all()` calls, aligning with `better-sqlite3`'s synchronous nature.
- **SQL Dialect Translation (`backend/src/db/stats.ts`)**: 
  - Substituted all PostgreSQL numbered placeholders (`$1`, `$2`) with SQLite parameterized placeholders (`?`).
  - Swapped PostgreSQL's `DATE_TRUNC('hour', "createdAt")` with SQLite's `strftime('%Y-%m-%d %H:00:00', "createdAt")` for correct hourly bucketing of tasks and XLM volume.
  - Corrected the task status query clause from `status = 'succeeded'` to `status = 'completed'` to match the actual underlying domain data types.
- **Route Wiring & Initialization (`backend/src/api/app.ts` & `backend/src/api/routes/stats.ts`)**:
  - Modified `backend/src/api/routes/stats.ts` to attach to `/` instead of `/stats` to avoid repetitive route nesting.
  - Imported and explicitly mounted the stats router via `app.use("/api/stats", createStatsRouter(getTaskDb()));` in the main Express app, bringing the dead code back to life.
- **OpenAPI Specifications (`backend/src/api/routes/stats.ts` & `backend/src/api/docs/openapi.ts`)**:
  - Embedded rich `@openapi` swagger annotations directly above the route handler in `stats.ts`, clearly documenting the response schema (agents, tasks, uptime percent, historical 24h series data).
  - Wired the new `stats.ts` file path into the `apis` array of the swagger generator config.
- **Testing Infrastructure (`backend/src/db/stats.test.ts`)**:
  - Scrapped the hard-coded `jest.fn()` mock database entirely.
  - Initialized a true in-memory `:memory:` SQLite database using `better-sqlite3` for integration tests.
  - Built robust seeding logic that accurately inserts time-series data across agents, tasks, and payments, strictly validating that the new `strftime` queries parse metrics and compute uptime precisely as expected.

## Testing

- ✅ **Automated Tests**: Executed `npm run test -- src/db/stats.test.ts`. The in-memory SQLite integration tests simulate historical timestamps, proving that the uptime calculation correctly identifies tasks older than 7 days, and that the 24h hourly bucketing successfully parses out exact timestamp bounds.
- 🔍 **Manual Verification Plan**:
  - Verify that a GET request to `/api/stats` returns a `200 OK` status instead of `404 Not Found`.
  - Validate the response structure matches the documented schema (`totalAgents`, `totalTasks`, `uptimePercent`, etc.).
  - Cross-check the Frontend Dashboard to confirm the network health badge, KPI cards, and chart components are actively rendering the retrieved metrics.

## Related Issue

- Ref: #175 - [CRITICAL] Fix Stats Module: PostgreSQL SQL in SQLite Codebase + Route Not Wired

## Checklist

- [x] Tests pass
- [x] Lint is clean
- [x] Documentation updated if needed
