### PR TITLE
feat(backend): implement real HTTP dispatch for agent endpoints

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/tests'],
+  roots: ['<rootDir>/tests', '<rootDir>/src'],
   testMatch: ['**/?(*.)+(spec|test).[tj]s'],
   testTimeout: 130_000,
   transform: {

--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -7,6 +7,8 @@ import {
   type DispatchFn,
   type PaymentReleaseFn,
 } from "../coordinator/coordinator";
+import { httpDispatch } from "../coordinator/dispatch";
+import type { AgentRegistry } from "../types/agent";
 import { getTask } from "../coordinator/taskStore";
 import { eventBus } from "../coordinator/eventBus";
 import { createEventStore, type EventStore } from "../coordinator/eventStore";
@@ -31,7 +33,7 @@ import { createTaskDb, getTaskDb } from "../db/tasks";
 import { openapiSpec } from "./docs/openapi";
 
 export interface AppOptions {
-  /** Called to execute a single DAG node; defaults to HTTP dispatch */
+  /** Called to execute a single DAG node; defaults to HTTP dispatch via agent registry */
   dispatch?: DispatchFn;
   /** Called after each node completes; defaults to no-op (returns 'mock-hash') */
   releasePayment?: PaymentReleaseFn;
@@ -39,6 +41,11 @@ export interface AppOptions {
   eventStore?: EventStore;
   /** Heartbeat / auth timing for the WebSocket stream */
   stream?: TaskStreamOptions;
+  /**
+   * Agent registry used to resolve endpoint URLs for HTTP dispatch.
+   * Required when `dispatch` is not provided; ignored when `dispatch` is set.
+   */
+  agentRegistry?: AgentRegistry;
 }
 
 /**
@@ -74,7 +81,7 @@ export function createApp(opts: AppOptions = {}): {
   app.use(requestId);
   app.use(requestLogger);
 
-  const dispatch: DispatchFn = opts.dispatch ?? defaultDispatch;
+  const dispatch: DispatchFn = opts.dispatch ?? makeHttpDispatch(opts.agentRegistry);
   const releasePayment: PaymentReleaseFn =
     opts.releasePayment ?? createPaymentReleaseFn(tryLoadStellarRelease());
 
@@ -130,12 +137,29 @@ export function createApp(opts: AppOptions = {}): {
   return { httpServer, close };
 }
 
-async function defaultDispatch(
-  taskId: string,
-  node: DAGNode,
-  context: string,
-): Promise<unknown> {
-  // In production this POSTs to the agent's HTTP endpoint.
-  // The e2e test replaces this via opts.dispatch.
-  throw new Error(`No agent registered for type: ${node.type}`);
+/**
+ * Build a DispatchFn that looks up the cheapest agent for a node's type in the
+ * provided registry and forwards the call to that agent via HTTP.
+ *
+ * If no registry is provided (e.g. during tests that supply their own dispatch)
+ * the returned function throws a clear error so misconfiguration is obvious at
+ * runtime rather than producing a silent no-op.
+ */
+function makeHttpDispatch(registry?: AgentRegistry): DispatchFn {
+  return async (taskId: string, node: DAGNode, context: string): Promise<unknown> => {
+    if (!registry) {
+      throw new Error(
+        `No agent registry configured. Provide agentRegistry in AppOptions or supply a custom dispatch function.`,
+      );
+    }
+
+    const agents = await registry.getAgents(node.type);
+    if (!agents || agents.length === 0) {
+      throw new Error(`No agent registered for type: ${node.type}`);
+    }
+
+    // Pick cheapest available agent.
+    const agent = [...agents].sort((a, b) => a.cost - b.cost)[0];
+    return httpDispatch(agent, node.nodeId, node, context);
+  };
 }

--- a/backend/src/coordinator/dispatch.test.ts
+++ b/backend/src/coordinator/dispatch.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for the HTTP dispatch layer.
+ *
+ * Uses a mock `fetch` implementation so no real network I/O occurs.
+ */
+
+import { httpDispatch, DEFAULT_DISPATCH_OPTIONS, type DispatchOptions } from './dispatch';
+import type { AgentRegistration } from '../types/agent';
+import type { DAGNode } from '../types/task';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockAgent: AgentRegistration = {
+  id: 'agent-research-1',
+  type: 'research',
+  endpoint: 'http://agent-research:4001',
+  cost: 10,
+};
+
+const mockNode: DAGNode = {
+  nodeId: 'node_research',
+  type: 'research',
+  dependencies: [],
+  status: 'running',
+  prompt: 'Gather market data for solar energy in Southeast Asia',
+};
+
+const mockContext = '';
+
+/** Fast options to avoid slow retries during tests */
+const fastOptions: DispatchOptions = {
+  timeoutMs: 500,
+  maxRetries: 2,
+  retryDelayMs: 10,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a mock fetch that returns a successful JSON response */
+function successFetch(body: unknown): typeof fetch {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: () => Promise.resolve(JSON.stringify(body)),
+  }) as unknown as typeof fetch;
+}
+
+/** Build a mock fetch that always returns the given status code */
+function statusFetch(status: number, statusText = 'Error'): typeof fetch {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    text: () => Promise.resolve(''),
+  }) as unknown as typeof fetch;
+}
+
+/** Build a mock fetch that always rejects with a network error */
+function networkErrorFetch(message = 'ECONNREFUSED'): typeof fetch {
+  return jest.fn().mockRejectedValue(new Error(message)) as unknown as typeof fetch;
+}
+
+/** Build a mock fetch that simulates an AbortError (timeout) */
+function abortFetch(): typeof fetch {
+  const err = new Error('The operation was aborted');
+  err.name = 'AbortError';
+  return jest.fn().mockRejectedValue(err) as unknown as typeof fetch;
+}
+
+/** Build a mock fetch that fails N times then succeeds */
+function failThenSucceedFetch(failCount: number, successBody: unknown): typeof fetch {
+  let calls = 0;
+  return jest.fn().mockImplementation(() => {
+    calls += 1;
+    if (calls <= failCount) {
+      return Promise.resolve({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text: () => Promise.resolve(''),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: () => Promise.resolve(JSON.stringify(successBody)),
+    });
+  }) as unknown as typeof fetch;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('httpDispatch', () => {
+  describe('successful dispatch', () => {
+    it('returns parsed JSON response from the agent', async () => {
+      const expected = { summary: 'Solar energy is growing fast in SEA.' };
+      const mockFetch = successFetch(expected);
+
+      const result = await httpDispatch(
+        mockAgent,
+        mockNode.nodeId,
+        mockNode,
+        mockContext,
+        fastOptions,
+        mockFetch,
+      );
+
+      expect(result).toEqual(expected);
+    });
+
+    it('POSTs to <endpoint>/execute with correct headers and body', async () => {
+      const mockFetch = successFetch({});
+
+      await httpDispatch(
+        mockAgent,
+        mockNode.nodeId,
+        mockNode,
+        'some context',
+        fastOptions,
+        mockFetch,
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = (mockFetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://agent-research:4001/execute');
+      expect(init.method).toBe('POST');
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+
+      const body = JSON.parse(init.body as string) as {
+        nodeId: string;
+        node: DAGNode;
+        context: string;
+      };
+      expect(body.nodeId).toBe('node_research');
+      expect(body.node).toMatchObject({ type: 'research' });
+      expect(body.context).toBe('some context');
+    });
+
+    it('returns empty object when agent returns an empty body', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: () => Promise.resolve(''),
+      }) as unknown as typeof fetch;
+
+      const result = await httpDispatch(
+        mockAgent,
+        mockNode.nodeId,
+        mockNode,
+        mockContext,
+        fastOptions,
+        mockFetch,
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('strips trailing slash from agent endpoint before appending /execute', async () => {
+      const agentWithSlash = { ...mockAgent, endpoint: 'http://agent-research:4001/' };
+      const mockFetch = successFetch({});
+
+      await httpDispatch(agentWithSlash, mockNode.nodeId, mockNode, mockContext, fastOptions, mockFetch);
+
+      const [url] = (mockFetch as jest.Mock).mock.calls[0] as [string];
+      expect(url).toBe('http://agent-research:4001/execute');
+    });
+  });
+
+  describe('retry behaviour', () => {
+    it('retries on 503 and succeeds on the next attempt', async () => {
+      const expected = { data: 'recovered' };
+      const mockFetch = failThenSucceedFetch(1, expected);
+
+      const result = await httpDispatch(
+        mockAgent,
+        mockNode.nodeId,
+        mockNode,
+        mockContext,
+        fastOptions,
+        mockFetch,
+      );
+
+      expect(result).toEqual(expected);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on 429 rate-limit response', async () => {
+      const expected = { data: 'after rate limit' };
+      const mockFetch = failThenSucceedFetch(1, expected);
+      // Override the first call to return 429
+      const originalImpl = (mockFetch as jest.Mock).getMockImplementation()!;
+      let firstCall = true;
+      (mockFetch as jest.Mock).mockImplementation(() => {
+        if (firstCall) {
+          firstCall = false;
+          return Promise.resolve({ ok: false, status: 429, statusText: 'Too Many Requests', text: () => Promise.resolve('') });
+        }
+        return Promise.resolve({ ok: true, status: 200, statusText: 'OK', text: () => Promise.resolve(JSON.stringify(expected)) });
+      });
+
+      const result = await httpDispatch(
+        mockAgent,
+        mockNode.nodeId,
+        mockNode,
+        mockContext,
+        fastOptions,
+        mockFetch,
+      );
+
+      expect(result).toEqual(expected);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on network errors (ECONNREFUSED)', async () => {
+      const expected = { data: 'after network error' };
+      let calls = 0;
+      const mockFetch = jest.fn().mockImplementation(() => {
+        calls += 1;
+        if (calls === 1) return Promise.reject(new Error('ECONNREFUSED'));
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          text: () => Promise.resolve(JSON.stringify(expected)),
+        });
+      }) as unknown as typeof fetch;
+
+      const result = await httpDispatch(
+        mockAgent,
+        mockNode.nodeId,
+        mockNode,
+        mockContext,
+        fastOptions,
+        mockFetch,
+      );
+
+      expect(result).toEqual(expected);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws after all retries are exhausted', async () => {
+      const mockFetch = statusFetch(503, 'Service Unavailable');
+
+      await expect(
+        httpDispatch(
+          mockAgent,
+          mockNode.nodeId,
+          mockNode,
+          mockContext,
+          fastOptions,
+          mockFetch,
+        ),
+      ).rejects.toThrow(/503/);
+
+      // 1 initial + 2 retries = 3 total calls
+      expect(mockFetch).toHaveBeenCalledTimes(fastOptions.maxRetries + 1);
+    });
+
+    it('does NOT retry on 4xx non-retryable errors (e.g. 400)', async () => {
+      const mockFetch = statusFetch(400, 'Bad Request');
+
+      await expect(
+        httpDispatch(
+          mockAgent,
+          mockNode.nodeId,
+          mockNode,
+          mockContext,
+          fastOptions,
+          mockFetch,
+        ),
+      ).rejects.toThrow(/non-retryable 400/);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry on 404 Not Found', async () => {
+      const mockFetch = statusFetch(404, 'Not Found');
+
+      await expect(
+        httpDispatch(
+          mockAgent,
+          mockNode.nodeId,
+          mockNode,
+          mockContext,
+          fastOptions,
+          mockFetch,
+        ),
+      ).rejects.toThrow(/non-retryable 404/);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('timeout handling', () => {
+    it('wraps AbortError as a descriptive timeout error', async () => {
+      const mockFetch = abortFetch();
+
+      await expect(
+        httpDispatch(
+          mockAgent,
+          mockNode.nodeId,
+          mockNode,
+          mockContext,
+          { ...fastOptions, maxRetries: 0 },
+          mockFetch,
+        ),
+      ).rejects.toThrow(/timed out after 500ms/);
+    });
+
+    it('retries after timeout up to maxRetries times', async () => {
+      const mockFetch = abortFetch();
+
+      await expect(
+        httpDispatch(
+          mockAgent,
+          mockNode.nodeId,
+          mockNode,
+          mockContext,
+          fastOptions, // maxRetries: 2
+          mockFetch,
+        ),
+      ).rejects.toThrow(/timed out/);
+
+      // 1 initial + 2 retries = 3 attempts
+      expect(mockFetch).toHaveBeenCalledTimes(fastOptions.maxRetries + 1);
+    });
+  });
+
+  describe('DEFAULT_DISPATCH_OPTIONS', () => {
+    it('has 60s timeout, 3 max retries, 1s base delay', () => {
+      expect(DEFAULT_DISPATCH_OPTIONS.timeoutMs).toBe(60_000);
+      expect(DEFAULT_DISPATCH_OPTIONS.maxRetries).toBe(3);
+      expect(DEFAULT_DISPATCH_OPTIONS.retryDelayMs).toBe(1_000);
+    });
+  });
+});

--- a/backend/src/coordinator/dispatch.ts
+++ b/backend/src/coordinator/dispatch.ts
@@ -1,0 +1,116 @@
+/**
+ * HTTP dispatch layer for the coordinator.
+ *
+ * Sends a DAG node to a remote agent endpoint via HTTP POST and returns the
+ * parsed JSON response.  Retries on transient/5xx errors using exponential
+ * back-off; gives up after `maxRetries` attempts and rethrows the last error.
+ */
+
+import type { AgentRegistration } from '../types/agent';
+import type { DAGNode } from '../types/task';
+
+export interface DispatchOptions {
+  /** Maximum time (ms) to wait for a single HTTP request before aborting */
+  timeoutMs: number;
+  /** Number of retry attempts after the initial attempt (total = maxRetries + 1) */
+  maxRetries: number;
+  /** Base delay (ms) between retries; actual delay is retryDelayMs * 2^attempt */
+  retryDelayMs: number;
+}
+
+export const DEFAULT_DISPATCH_OPTIONS: DispatchOptions = {
+  timeoutMs: 60_000,
+  maxRetries: 3,
+  retryDelayMs: 1_000,
+};
+
+/**
+ * Status codes that are worth retrying. 5xx = server-side transient errors,
+ * 429 = rate-limited.
+ */
+function isRetryableStatus(status: number): boolean {
+  return status >= 500 || status === 429;
+}
+
+/**
+ * Dispatch a DAG node to an agent via HTTP POST with timeout and retry logic.
+ *
+ * @param agent   - Agent registration containing the endpoint URL.
+ * @param nodeId  - ID of the DAG node being dispatched (used for logging).
+ * @param node    - Full DAGNode payload forwarded to the agent.
+ * @param context - Serialised upstream results passed as additional context.
+ * @param options - Overrides for timeout / retry behaviour.
+ * @param fetchImpl - Injectable `fetch` implementation (defaults to global).
+ */
+export async function httpDispatch(
+  agent: AgentRegistration,
+  nodeId: string,
+  node: DAGNode,
+  context: string,
+  options: DispatchOptions = DEFAULT_DISPATCH_OPTIONS,
+  fetchImpl: typeof fetch = fetch,
+): Promise<unknown> {
+  const url = `${agent.endpoint.replace(/\/$/, '')}/execute`;
+  let lastError: Error = new Error(`Dispatch to agent ${agent.id} failed before first attempt`);
+
+  for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+
+    try {
+      const response = await fetchImpl(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nodeId, node, context }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+
+      if (isRetryableStatus(response.status)) {
+        lastError = new Error(
+          `Agent ${agent.id} returned ${response.status}: ${response.statusText}`,
+        );
+        // Fall through to retry logic below.
+      } else if (!response.ok) {
+        // 4xx (except 429) — not retryable, fail immediately.
+        throw new Error(
+          `Agent ${agent.id} returned non-retryable ${response.status}: ${response.statusText}`,
+        );
+      } else {
+        const text = await response.text();
+        return text ? (JSON.parse(text) as unknown) : {};
+      }
+    } catch (err) {
+      clearTimeout(timer);
+
+      if (err instanceof Error && err.name === 'AbortError') {
+        lastError = new Error(
+          `Agent ${agent.id} timed out after ${options.timeoutMs}ms (node: ${nodeId})`,
+        );
+      } else if (
+        err instanceof Error &&
+        !err.message.startsWith('Agent ') // already our own error
+      ) {
+        // Network-level errors (ECONNREFUSED, etc.) are retryable.
+        lastError = err;
+      } else if (err instanceof Error) {
+        // Preserve errors we already constructed above or non-retryable 4xx.
+        const isNonRetryable =
+          err.message.includes('non-retryable') || err.message.includes('returned non-retryable');
+        if (isNonRetryable) throw err;
+        lastError = err;
+      } else {
+        lastError = new Error(String(err));
+      }
+    }
+
+    // Don't sleep after the last attempt.
+    if (attempt < options.maxRetries) {
+      const delay = options.retryDelayMs * Math.pow(2, attempt);
+      await new Promise<void>(r => setTimeout(r, delay));
+    }
+  }
+
+  throw lastError;
+}

--- a/backend/tests/e2e/pipeline.test.ts
+++ b/backend/tests/e2e/pipeline.test.ts
@@ -14,6 +14,7 @@
  * the live testnet (requires STELLAR_TEST_SECRET in env).
  */
 
+import http from 'http';
 import request from 'supertest';
 import { WebSocket } from 'ws';
 import type { AddressInfo } from 'net';
@@ -271,4 +272,146 @@ describe('Full pipeline E2E', () => {
       .send({ walletPublicKey: 'GFAKE' });
     expect(res.status).toBe(400);
   });
+});
+
+// ─── HTTP Dispatch Integration ────────────────────────────────────────────────
+
+/**
+ * Verifies that the real `httpDispatch` path works end-to-end: spin up a
+ * minimal HTTP server that acts as a mock agent, wire it into `createApp` via
+ * the `agentRegistry` option, and confirm the task completes successfully.
+ */
+describe('HTTP dispatch integration (mock agent server)', () => {
+  let appServer: HttpServer;
+  let agentServer: http.Server;
+  let appBaseUrl: string;
+  let closeTestApp: () => void;
+
+  /** Tracks calls received by the mock agent server */
+  const agentCalls: Array<{ nodeId: string; nodeType: string }> = [];
+
+  beforeAll(done => {
+    agentCalls.length = 0;
+
+    // ── Minimal mock agent HTTP server ──────────────────────────────────────
+    // Responds to POST /execute with a fixture result keyed by node.type.
+    agentServer = http.createServer((req, res) => {
+      if (req.method !== 'POST' || req.url !== '/execute') {
+        res.writeHead(404).end();
+        return;
+      }
+
+      let body = '';
+      req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+      req.on('end', () => {
+        try {
+          const { node } = JSON.parse(body) as { nodeId: string; node: { type: string; nodeId: string } };
+          agentCalls.push({ nodeId: node.nodeId, nodeType: node.type });
+
+          const fixture = fixtureByType[node.type] ?? { summary: `Result for ${node.type}` };
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(fixture));
+        } catch {
+          res.writeHead(400).end(JSON.stringify({ error: 'bad request' }));
+        }
+      });
+    });
+
+    agentServer.listen(0, '127.0.0.1', () => {
+      const agentAddr = agentServer.address() as AddressInfo;
+      const agentEndpoint = `http://127.0.0.1:${agentAddr.port}`;
+
+      // ── AgentRegistry backed by mock agent server ───────────────────────
+      const agentRegistry = {
+        getAgents: (agentType: string) => [
+          { id: `mock-${agentType}`, type: agentType, endpoint: agentEndpoint, cost: 1 },
+        ],
+      };
+
+      // ── Create app with registry and no custom dispatch ─────────────────
+      const { httpServer: srv, close } = createApp({
+        agentRegistry,
+        releasePayment: mockReleasePayment,
+      });
+
+      appServer = srv;
+      closeTestApp = close;
+
+      appServer.listen(0, '127.0.0.1', () => {
+        const appAddr = appServer.address() as AddressInfo;
+        appBaseUrl = `http://127.0.0.1:${appAddr.port}`;
+        done();
+      });
+    });
+  }, 15_000);
+
+  afterAll(done => {
+    closeTestApp();
+    agentServer.close(done);
+  });
+
+  it('submits a task and all nodes complete via real HTTP dispatch', async () => {
+    // POST task
+    const postRes = await request(appServer)
+      .post('/api/tasks')
+      .send({ prompt: PROMPT, walletPublicKey: 'GFAKEWALLETPUBLICKEY' });
+
+    expect(postRes.status).toBe(201);
+    const { taskId } = postRes.body as { taskId: string };
+    expect(taskId).toMatch(/^task_/);
+
+    // Poll until completed
+    const deadline = Date.now() + 120_000;
+    let finalTask: Record<string, unknown> | null = null;
+
+    while (Date.now() < deadline) {
+      const getRes = await request(appServer).get(`/api/tasks/${taskId}`);
+      if (getRes.status === 200 && getRes.body.status === 'completed') {
+        finalTask = getRes.body as Record<string, unknown>;
+        break;
+      }
+      if (getRes.body.status === 'failed') {
+        throw new Error(`Task failed unexpectedly: ${JSON.stringify(getRes.body)}`);
+      }
+      await new Promise(r => setTimeout(r, 200));
+    }
+
+    expect(finalTask).not.toBeNull();
+    expect(finalTask!.status).toBe('completed');
+
+    // All 5 nodes should be completed
+    const dag = finalTask!.dag as Array<{ nodeId: string; status: string }>;
+    for (const nodeId of AGENT_NODE_IDS) {
+      const node = dag.find(n => n.nodeId === nodeId);
+      expect(node).toBeDefined();
+      expect(node!.status).toBe('completed');
+    }
+
+    // Agent server should have received one request per node
+    expect(agentCalls.length).toBeGreaterThanOrEqual(AGENT_NODE_IDS.length);
+  }, 130_000);
+
+  it('returns an error when no agent registry is configured and no dispatch provided', async () => {
+    const { httpServer: bareServer, close } = createApp({ releasePayment: mockReleasePayment });
+    await new Promise<void>(resolve => bareServer.listen(0, '127.0.0.1', resolve));
+
+    const postRes = await request(bareServer)
+      .post('/api/tasks')
+      .send({ prompt: PROMPT, walletPublicKey: 'GFAKEWALLETPUBLICKEY' });
+
+    expect(postRes.status).toBe(201);
+    const { taskId } = postRes.body as { taskId: string };
+
+    // Task should eventually fail because no registry/dispatch is available
+    const deadline = Date.now() + 15_000;
+    let status = 'queued';
+    while (Date.now() < deadline && status !== 'failed') {
+      await new Promise(r => setTimeout(r, 100));
+      const getRes = await request(bareServer).get(`/api/tasks/${taskId}`);
+      status = (getRes.body as { status: string }).status;
+    }
+
+    expect(status).toBe('failed');
+    close();
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary

Fixes #163 — replaces the always-throwing `defaultDispatch` stub with a real HTTP dispatch layer so task execution actually works.

## Changes

### `backend/src/coordinator/dispatch.ts` (new)
- `httpDispatch()` POSTs a DAG node to `<agent.endpoint>/execute`
- Configurable timeout via `AbortController` (default 60 s)
- Exponential back-off retry up to `maxRetries` (default 3 extra attempts)
- Retries on 5xx and 429; immediately throws on non-retryable 4xx
- Injectable `fetch` for testability

### `backend/src/coordinator/dispatch.test.ts` (new)
13 unit tests covering:
- Successful dispatch, request shape, empty body, slash normalisation
- Retry on 503 / 429 / network errors, retry exhaustion
- Non-retryable 4xx bypass (400, 404)
- Timeout → `AbortError` wrapping and retry count
- `DEFAULT_DISPATCH_OPTIONS` values

### `backend/src/api/app.ts` (modified)
- Removed always-throwing `defaultDispatch`
- Added `agentRegistry?: AgentRegistry` to `AppOptions`
- New `makeHttpDispatch(registry?)` selects cheapest matching agent and calls `httpDispatch`; throws a clear config error if no registry is provided

### `backend/tests/e2e/pipeline.test.ts` (modified)
- New **HTTP dispatch integration** suite
  - Spins up a real `http.Server` acting as every agent type
  - Wires it into `createApp` via `agentRegistry` (no custom dispatch)
  - Asserts all 5 DAG nodes complete via real HTTP round-trips
  - Asserts tasks fail gracefully when no registry/dispatch is configured

### `backend/jest.config.js` (modified)
- Added `src/` to Jest `roots` so co-located `*.test.ts` files are discovered

## Testing

```bash
cd backend
npx jest src/coordinator/dispatch.test.ts --no-coverage
# 13 passed
```

All 188 pre-existing tests continue to pass (1 pre-existing failure in `agents.test.ts` is unrelated to this PR).