### PR TITLE
fix(frontend): eliminate all any types and unsafe casts (#180)

### DIFF
--- a/frontend/src/components/agents/AgentOutputRenderer.tsx
+++ b/frontend/src/components/agents/AgentOutputRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { Capability, AgentResult } from '../../types/agent';
+import { Capability, AgentResult, ResearchReportResult, CodingResult, RiskResult, DesignResult } from '../../types/agent';
 import RiskMatrix from './RiskMatrix';
 import DesignRenderer from './DesignRenderer';
 
@@ -51,19 +51,19 @@ const AgentOutputRenderer: React.FC<Props> = ({ agentType, result }) => {
     case 'report':
       return (
         <Suspense fallback={<LoadingFallback />}>
-          <ResearchReportRenderer result={result as any} />
+          <ResearchReportRenderer result={result as ResearchReportResult} />
         </Suspense>
       );
     case 'coding':
       return (
         <Suspense fallback={<LoadingFallback />}>
-          <CodingRenderer result={result as any} />
+          <CodingRenderer result={result as CodingResult} />
         </Suspense>
       );
     case 'risk':
-      return <RiskMatrix result={result as any} />;
+      return <RiskMatrix result={result as RiskResult} />;
     case 'design':
-      return <DesignRenderer result={result as any} />;
+      return <DesignRenderer result={result as DesignResult} />;
     default:
       return (
         <div style={{ color: 'var(--danger)', padding: '12px' }}>

--- a/frontend/src/components/agents/DAGPreview.tsx
+++ b/frontend/src/components/agents/DAGPreview.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import ReactFlow, { Background, Controls, ConnectionLineType, Edge, MarkerType, Node, Position, Handle } from 'reactflow';
+import ReactFlow, { Background, Controls, ConnectionLineType, Edge, MarkerType, Node, NodeProps, Position, Handle } from 'reactflow';
 import 'reactflow/dist/style.css';
 import type { DagEdge, DagNode } from '../../services/taskService';
 
@@ -10,7 +10,11 @@ export type DAGPreviewProps = {
   };
 };
 
-const PreviewNode = ({ id, data }: any) => {
+interface PreviewNodeData {
+  label: string;
+}
+
+const PreviewNode = ({ id, data }: NodeProps<PreviewNodeData>) => {
   return (
     <div id={id} className="dag-node p-3 rounded-xl border border-slate-700 bg-slate-800 text-slate-100 min-w-[140px] text-center font-semibold shadow-md">
       <Handle type="target" position={Position.Left} style={{ background: '#475569', width: 6, height: 6 }} />

--- a/frontend/src/hooks/useTaskMonitor.ts
+++ b/frontend/src/hooks/useTaskMonitor.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import type { TaskResponse, DAGNode, DAGEvent, PaymentEvent } from '../types/api';
+import type { TaskResponse, DAGNode, DAGEvent, DAGEventPayload, PaymentEvent } from '../types/api';
 import { apiClient } from '../services/api';
 
 // Helper to determine payment amount based on agent type or node ID
@@ -42,10 +42,15 @@ export const useTaskMonitor = (taskId: string | undefined) => {
         data.dag.forEach(node => {
           if (node.status === 'completed') {
             if (node.result) {
-              const res = node.result as any;
-              initialOutputs[node.nodeId] = res.summary || res.content || res.markdown || (typeof res === 'string' ? res : JSON.stringify(res));
+              const res = node.result as Record<string, unknown> | string;
+              if (typeof res === 'string') {
+                initialOutputs[node.nodeId] = res;
+              } else {
+                initialOutputs[node.nodeId] = (res.summary as string) || (res.content as string) || (res.markdown as string) || JSON.stringify(res);
+              }
             }
-            const txHash = (node.result as any)?.txHash || 'mock-hash';
+            const resultObj = node.result as Record<string, unknown> | undefined;
+            const txHash = (resultObj?.txHash as string) || 'mock-hash';
             initialPayments.push({
               amount: getAmountForAgent(node.agentType),
               direction: 'out',
@@ -70,7 +75,7 @@ export const useTaskMonitor = (taskId: string | undefined) => {
         setPayments(initialPayments);
       }
       setError(null);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Failed to fetch task details:', err);
       // Resilient fallback for E2E tests
       if (id === 'mock-task-e2e-123') {
@@ -81,7 +86,7 @@ export const useTaskMonitor = (taskId: string | undefined) => {
         ];
         setNodes(mockDag);
       } else {
-        setError(err);
+        setError(err instanceof Error ? err : new Error(String(err)));
       }
     } finally {
       setLoading(false);
@@ -119,8 +124,13 @@ export const useTaskMonitor = (taskId: string | undefined) => {
           } 
           
           else if (data.type === 'node_completed' && data.nodeId) {
-            const payload = data.payload as any;
-            const outputText = payload?.summary || payload?.content || payload?.markdown || (typeof payload === 'string' ? payload : '');
+            const payload = data.payload;
+            const outputText = payload && typeof payload === 'string'
+              ? payload
+              : ((payload as DAGEventPayload)?.summary ||
+                 (payload as DAGEventPayload)?.content ||
+                 (payload as DAGEventPayload)?.markdown ||
+                 '');
             
             setNodes(prev => prev.map(n => n.nodeId === data.nodeId ? { ...n, status: 'completed', result: payload } : n));
             
@@ -133,7 +143,7 @@ export const useTaskMonitor = (taskId: string | undefined) => {
           } 
           
           else if (data.type === 'node_failed' && data.nodeId) {
-            const errMessage = (data.payload as any)?.error || 'Node execution failed';
+            const errMessage = (data.payload as DAGEventPayload | undefined)?.error || 'Node execution failed';
             setNodes(prev => prev.map(n => n.nodeId === data.nodeId ? { ...n, status: 'failed', error: errMessage } : n));
           } 
           
@@ -153,7 +163,7 @@ export const useTaskMonitor = (taskId: string | undefined) => {
           } 
           
           else if (data.type === 'payment_released' && data.nodeId) {
-            const txHash = (data.payload as any)?.txHash || 'mock-hash';
+            const txHash = (data.payload as DAGEventPayload | undefined)?.txHash || 'mock-hash';
             const agentType = data.nodeId.replace('node_', '').replace('node-', '');
             setPayments(prev => {
               // check if there's already a locked payment for this nodeId to update it

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -91,11 +91,26 @@ export type DAGEventType =
   | 'task_completed'
   | 'task_failed';
 
+// Covers all known shapes of DAG event payloads
+// Each event type may carry different fields, so we allow additional properties
+// while still providing type safety for the common fields.
+export interface DAGEventPayload {
+  status?: string;
+  message?: string;
+  error?: string;
+  txHash?: string;
+  summary?: string;
+  content?: string;
+  markdown?: string;
+  output?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 export interface DAGEvent {
   type: DAGEventType;
   taskId: string;
   nodeId?: string;
   timestamp: string;
-  payload?: any;
+  payload?: DAGEventPayload | string;
 }
 


### PR DESCRIPTION
## Description

CRITICAL / URGENT — Eliminates all `any` types, unsafe casts, and TypeScript strict mode violations across the frontend to prevent runtime errors and improve developer experience.

## Changes

- **types/api.ts**: Replace `payload?: any` with properly typed `DAGEventPayload` interface (includes `summary`, `content`, `markdown`, `error`, `txHash`, `status`, `message`, `output`, plus index signature)
- **DAGPreview.tsx**: Fix component props from `({ id, data }: any)` to `NodeProps<PreviewNodeData>`
- **useTaskMonitor.ts**: Remove all 6 `as any` casts — replaced with `Record<string, unknown>`, `DAGEventPayload` casts, and `catch (err: unknown)` with proper type guard
- **AgentOutputRenderer.tsx**: Remove all 4 `as any` casts — replaced with specific types: `ResearchReportResult`, `CodingResult`, `RiskResult`, `DesignResult`

## Verification
- ✅ `npx tsc --noEmit` — zero errors
- ✅ `grep -r "as any" frontend/src/ --include=*.ts --include=*.tsx --exclude=*.test.*` — zero results

Closes #180