### PR TITLE
feat(backend): document 403 response for GET /api/tasks/{id}

### DIFF
--- a/backend/src/api/routes/tasks.ts
+++ b/backend/src/api/routes/tasks.ts
@@ -261,6 +261,12 @@ export function createTasksRouter(dispatch: DispatchFn, releasePayment: PaymentR
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Task'
+   *       403:
+   *         description: Access denied — walletpublickey header is missing or does not match the task owner
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       404:
    *         description: Task not found
    *         content:


### PR DESCRIPTION
## Summary

The ownership check for `GET /api/tasks/:id` and `DELETE /api/tasks/:id` was already implemented in the route handlers (the `walletpublickey` header is required and must match the task owner, returning HTTP 403 otherwise). This PR adds the missing `403` response entry to the OpenAPI JSDoc annotation for `GET /api/tasks/{id}` so the generated spec accurately documents the auth behaviour for API consumers.

Closes #161

## What changed

**`backend/src/api/routes/tasks.ts`** — added `403` response block to the `GET /api/tasks/{id}` JSDoc:
```yaml
403:
  description: Access denied — walletpublickey header is missing or does not match the task owner
```

## Tests

All 34 tasks tests pass (the 8 pre-existing WebSocket stream failures in `tests/e2e/stream.test.ts` are unrelated to this PR and exist on `main` before this change):

```
PASS tests/tasks.test.ts
Tests: 34 passed, 34 total
```

Auth coverage in `tests/tasks.test.ts`:

| Scenario | Expected |
|---|---|
| GET own task with correct wallet key | 200 ✅ |
| GET task with wrong wallet key | 403 ✅ |
| GET task with missing wallet key | 403 ✅ |
| GET unknown task | 404 ✅ |
| DELETE own task (queued) | 200 ✅ |
| DELETE with wrong wallet key | 403 ✅ |
| DELETE with missing wallet key | 403 ✅ |
| DELETE non-queued task | 409 ✅ |
| DELETE unknown task | 404 ✅ |