### PR TITLE
feat(frontend): add SEO meta tags, favicon, and Open Graph tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,8 +3,28 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    
+    <!-- SEO -->
+    <meta name="description" content="ai-net: A decentralized agent coordination network on Stellar where AI agents discover, hire, and pay each other autonomously.">
+    <meta name="theme-color" content="#0A0E14">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="ai-net — AI Agent Coordination Network">
+    <meta property="og:description" content="A decentralized network where AI agents discover, hire, and pay each other on Stellar.">
+    <meta property="og:image" content="/og-image.png">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="ai-net — AI Agent Coordination Network">
+    <meta name="twitter:description" content="A decentralized network where AI agents discover, hire, and pay each other on Stellar.">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
     <title>AI Net</title>
   </head>
+
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,7 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-    <rect width="64" height="64" rx="12" fill="#0A0E14"/>
+    <defs>
+        <linearGradient id="brandGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#3B82F6" />
+            <stop offset="100%" stop-color="#8B5CF6" />
+        </linearGradient>
+    </defs>
 
-    <g stroke="#4FD1C5" stroke-width="2" fill="none">
+    <rect width="64" height="64" rx="14" fill="#0A0E14"/>
+
+    <g stroke="url(#brandGrad)" stroke-width="2" fill="none" opacity="0.8">
         <line x1="16" y1="16" x2="24" y2="10"/>
         <line x1="24" y1="10" x2="40" y2="14"/>
         <line x1="40" y1="14" x2="50" y2="26"/>
@@ -10,7 +17,7 @@
         <line x1="24" y1="50" x2="46" y2="46"/>
     </g>
 
-    <g fill="#4FD1C5">
+    <g fill="url(#brandGrad)">
         <circle cx="16" cy="16" r="2.5"/>
         <circle cx="24" cy="10" r="2.5"/>
         <circle cx="40" cy="14" r="2.5"/>
@@ -19,9 +26,9 @@
         <circle cx="24" cy="50" r="2.5"/>
         <circle cx="46" cy="46" r="2.5"/>
     </g>
-
-    <text x="50%" y="58%" text-anchor="middle" font-family="Arial, sans-serif"
-    font-size="20" font-weight="700" fill="white">
+    
+    <text x="50%" y="58%" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif"
+    font-size="20" font-weight="800" fill="#FFFFFF">
         AI
     </text>
 </svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <rect width="64" height="64" rx="12" fill="#0A0E14"/>
+
+    <g stroke="#4FD1C5" stroke-width="2" fill="none">
+        <line x1="16" y1="16" x2="24" y2="10"/>
+        <line x1="24" y1="10" x2="40" y2="14"/>
+        <line x1="40" y1="14" x2="50" y2="26"/>
+        <line x1="16" y1="16" x2="14" y2="34"/>
+        <line x1="14" y1="34" x2="24" y2="50"/>
+        <line x1="24" y1="50" x2="46" y2="46"/>
+    </g>
+
+    <g fill="#4FD1C5">
+        <circle cx="16" cy="16" r="2.5"/>
+        <circle cx="24" cy="10" r="2.5"/>
+        <circle cx="40" cy="14" r="2.5"/>
+        <circle cx="50" cy="26" r="2.5"/>
+        <circle cx="14" cy="34" r="2.5"/>
+        <circle cx="24" cy="50" r="2.5"/>
+        <circle cx="46" cy="46" r="2.5"/>
+    </g>
+
+    <text x="50%" y="58%" text-anchor="middle" font-family="Arial, sans-serif"
+    font-size="20" font-weight="700" fill="white">
+        AI
+    </text>
+</svg>


### PR DESCRIPTION
Closes #146

## Summary
Added essential SEO meta tags, Open Graph metadata, Twitter card properties, theme color, and a custom SVG favicon to the root HTML structure to improve brand representation and social sharing previews.

## Changes
* **`frontend/public/favicon.svg`**: Created a custom dark-mode SVG favicon featuring network nodes and "AI" typography.
* **`frontend/index.html`**: 
  * Added `<link rel="icon">` pointing to the new SVG favicon.
  * Added meta description and theme-color (`#0A0E14`).
  * Added Open Graph tags (`og:type`, `og:title`, `og:description`, `og:image`).
  * Added Twitter card tags (`twitter:card`, `twitter:title`, `twitter:description`).

## Testing
* Launched dev server locally at `localhost:3000` and confirmed the new SVG favicon displays properly in the browser tab.
* Inspected the page source and `<head>` elements in Chrome DevTools to verify all meta properties, values, and syntax are correctly rendered.

## Related Issue
#146

## Checklist
- [x] Tests pass
- [x] Lint is clean
- [x] Documentation updated if needed