### PR TITLE
[Frontend] Add @utils Path Alias to tsconfig.json and vite.config.ts

### DIFF
--- a/frontend/src/hooks/useAgentRegistry.ts
+++ b/frontend/src/hooks/useAgentRegistry.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getAgents } from '../services/api'
 import type { AgentRecord } from '../types/api'
-import { normalizeAgent } from '../utils/agentRegistry'
+import { normalizeAgent } from '@utils/agentRegistry'
 
 const REFRESH_INTERVAL = 30_000
 

--- a/frontend/src/utils/agentRegistry.test.ts
+++ b/frontend/src/utils/agentRegistry.test.ts
@@ -8,7 +8,7 @@ import {
   priceDomain,
   DEFAULT_FILTERS,
   type AgentFilters,
-} from './agentRegistry'
+} from '@utils/agentRegistry'
 import type { AgentRecord } from '../types/api'
 
 const agents: AgentRecord[] = [

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -27,7 +27,8 @@
       "@hooks/*": ["src/hooks/*"],
       "@services/*": ["src/services/*"],
       "@types/*": ["src/types/*"],
-      "@context/*": ["src/context/*"]
+      "@context/*": ["src/context/*"],
+      "@utils/*": ["src/utils/*"]
     }
   },
   "include": ["src", "vitest.setup.ts"],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       '@services': path.resolve(__dirname, './src/services'),
       '@types': path.resolve(__dirname, './src/types'),
       '@context': path.resolve(__dirname, './src/context'),
+      '@utils': path.resolve(__dirname, './src/utils'),
     },
   },
   server: {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       '@services': path.resolve(__dirname, './src/services'),
       '@types': path.resolve(__dirname, './src/types'),
       '@context': path.resolve(__dirname, './src/context'),
+      '@utils': path.resolve(__dirname, './src/utils'),
     },
   },
   test: {


### PR DESCRIPTION
Closes #145

## Changes
- Added `@utils/*` to `frontend/tsconfig.json` `compilerOptions.paths`
- Added `@utils` to `frontend/vite.config.ts` `resolve.alias`
- Also added it to `frontend/vitest.config.ts` — this config isn't listed in
  the issue, but vitest reads it independently of `vite.config.ts`. Without
  this, the required test-import conversion below would fail to resolve at
  test-run time even though `tsc` and `vite build` would look fine.
- Converted relative imports to the alias in:
  - `frontend/src/hooks/useAgentRegistry.ts`
  - `frontend/src/utils/agentRegistry.test.ts`

## Testing
- `npx tsc --noEmit` — no new errors introduced (repo has 17 pre-existing
  `lucide-react` TS7016 errors, confirmed identical on unmodified `main`,
  unrelated to this change)
- `npx vite build` — 4310 modules transformed, alias resolves correctly
- `npx vitest run src/utils/agentRegistry.test.ts` — 18/18 passing