### PR TITLE
feat(frontend): add 404 catch-all route and NotFoundPage component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { WalletProvider } from './context/WalletContext'
+import { NotFoundPage } from './pages/NotFoundPage';
 import AppShell from './components/layout/AppShell'
 import LandingPage from './pages/LandingPage'
 import AgentsPage from './pages/AgentsPage'
@@ -25,13 +26,15 @@ const AppContent: React.FC = () => {
               <Route path="/tasks/new" element={<NewTaskPage />} />
               <Route path="/tasks/:id" element={<TaskDetailPage />} />
               <Route path="/renderer-demo" element={<RendererDemoPage />} />
+              <Route path="*" element={<NotFoundPage />} />
             </Routes>
           </AppShell>
         } />
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </Router>
-  )
-}
+  );
+};
 
 const App: React.FC = () => {
   return (

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export const NotFoundPage: React.FC = () => {
+    return (
+        <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '60vh',
+            padding: '2rem',
+            textAlign: 'center',
+            color: 'var(--text-primary)',
+            backgroundColor: 'var(--bg-primary)'
+        }}>
+
+            <h1 style={{
+                fontSize: '2.5rem',
+                fontWeight: 'bold',
+                marginBottom: '1rem',
+                color: 'var(--text-primary)'
+            }}>
+            404 — Page Not Found
+            </h1>
+
+            <p style={{
+                fontSize: '1rem',
+                color: 'var(--text-secondary)',
+                maxWidth: '480px',
+                marginBottom: '2rem',
+                lineHeight: '1.5'
+            }}>
+            The page you are looking for does not exist or has been moved.
+            </p>
+
+            <div style={{
+                display: 'flex',
+                gap: '1rem',
+                flexWrap: 'wrap',
+                justifyContent: 'center'
+            }}>
+
+                <Link to="/dashboard" style={{
+                padding: '0.6rem 1.25rem',
+                borderRadius: '6px',
+                backgroundColor: 'var(--accent-color, var(--primary-color, #3b82f6))',
+                color: 'var(--text-primary, #ffffff)',
+                fontWeight: '500',
+                fontSize: '0.9rem',
+                textDecoration: 'none',
+                display: 'inline-block'
+            }}>
+            Go to Dashboard
+            </Link>
+
+            <Link to="/" style={{
+                padding: '0.6rem 1.25rem',
+                borderRadius: '6px',
+                border: '1px solid var(--border-color, #374151)',
+                backgroundColor: 'transparent',
+                color: 'var(--text-primary)',
+                fontWeight: '500',
+                fontSize: '0.9rem',
+                textDecoration: 'none',
+                display: 'inline-block'
+            }}>
+            Go Home
+            </Link>
+        </div>
+    </div>
+    );
+};
+
+export default NotFoundPage;


### PR DESCRIPTION

Closes #144

## Summary
Adds a custom 404 Not Found page component (`NotFoundPage.tsx`) and configures catch-all wildcard routes in `App.tsx` so users navigating to undefined URLs receive clear feedback and navigation options instead of a blank screen inside `AppShell`.

## Changes
- Created `frontend/src/pages/NotFoundPage.tsx` with a primary "404 — Page Not Found" heading, brief explanation, and styled action links ("Go to Dashboard" and "Go Home").
- Used project CSS variables (`var(--text-primary)`, `var(--text-secondary)`, `var(--bg-primary)`, etc.) for consistent dark theme styling.
- Updated `frontend/src/App.tsx` with wildcard `<Route path="*" element={<NotFoundPage />} />` both inside `AppShell` (for app sub-routes) and outside (for root-level unknown routes).

## Testing
- Verified navigation to undefined routes (e.g., `/random`) renders the styled 404 page within the `AppShell` layout.
- Tested "Go to Dashboard" button navigation to `/dashboard`.
- Tested "Go Home" button navigation to `/`.
- Confirmed responsive layout across desktop and mobile viewports.

## Related Issue
#144

## Checklist
- [x] Tests pass
- [x] Lint is clean
- [x] Documentation updated if needed