### PR TITLE
fix(backend): tighten agent-not-found coverage in dispatch tests (#173)

### DIFF
--- a/backend/src/coordinator/dispatch.test.ts
+++ b/backend/src/coordinator/dispatch.test.ts
@@ -191,7 +191,6 @@ describe('httpDispatch', () => {
       const expected = { data: 'after rate limit' };
       const mockFetch = failThenSucceedFetch(1, expected);
       // Override the first call to return 429
-      const originalImpl = (mockFetch as jest.Mock).getMockImplementation()!;
       let firstCall = true;
       (mockFetch as jest.Mock).mockImplementation(() => {
         if (firstCall) {

--- a/backend/tests/e2e/pipeline.test.ts
+++ b/backend/tests/e2e/pipeline.test.ts
@@ -423,4 +423,62 @@ describe('HTTP dispatch integration (mock agent server)', () => {
     expect(status).toBe('failed');
     close();
   }, 20_000);
+
+  /**
+   * Literal acceptance test from issue #173: when the registry is provided but
+   * returns no agents for a node's type, every node must fail with a clear,
+   * descriptive error message rather than a generic / silent failure.
+   */
+  it('reports "No agent registered for type:<x>" when registry returns no agents', async () => {
+    const emptyRegistry = {
+      getAgents: (_agentType: string) => [] as Array<{ id: string; type: string; endpoint: string; cost: number }>,
+    };
+
+    const { httpServer: srv, close } = createApp({
+      agentRegistry: emptyRegistry,
+      releasePayment: mockReleasePayment,
+    });
+    await new Promise<void>(resolve => srv.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const postRes = await request(srv)
+        .post('/api/tasks')
+        .send({ prompt: PROMPT, walletPublicKey: 'GFAKEWALLETPUBLICKEY' });
+
+      expect(postRes.status).toBe(201);
+      const { taskId } = postRes.body as { taskId: string };
+
+      // Wait for the task to settle as failed
+      type DagNode = { nodeId: string; type: string; status: string; error?: string };
+      type TaskBody = { status: string; dag: DagNode[] };
+
+      const deadline = Date.now() + 15_000;
+      let body: TaskBody | null = null;
+      while (Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 100));
+        const getRes = await request(srv)
+          .get(`/api/tasks/${taskId}`)
+          .set('walletpublickey', 'GFAKEWALLETPUBLICKEY');
+        body = getRes.body as TaskBody;
+        if (body && body.status === 'failed') break;
+      }
+
+      expect(body).not.toBeNull();
+      expect(body!.status).toBe('failed');
+
+      // At least one failed DAG node must carry the descriptive "No agent
+      // registered for type:" message so an operator can immediately tell
+      // which capability is unconfigured.
+      // (Downstream nodes may carry "upstream_failed" due to the coordinator's
+      //  cascade — that's expected behavior, not the error under test.)
+      const failedNodes = body!.dag.filter(n => n.status === 'failed');
+      expect(failedNodes.length).toBeGreaterThan(0);
+      const withAgentErr = failedNodes.filter(n =>
+        typeof n.error === 'string' && /No agent registered for type: \w+/.test(n.error),
+      );
+      expect(withAgentErr.length).toBeGreaterThan(0);
+    } finally {
+      close();
+    }
+  }, 20_000);
 });


### PR DESCRIPTION
Closes #173

## Summary

Strengthens test coverage for the agent dispatch pipeline that #173 put in place. The original fix replaced the throwing `defaultDispatch` with `makeHttpDispatch` + `httpDispatch`, but was missing a literal acceptance test confirming that the **agent-not-found** error is descriptive and observable end-to-end.

## Changes

- **`backend/tests/e2e/pipeline.test.ts`**: Added a new e2e test, `"reports \"No agent registered for type:<x>\" when registry returns no agents"`, that proves `makeHttpDispatch` propagates a descriptive error to the failed DAG node, observable via `GET /api/tasks/:id`. The assertion is intentionally loose (`expect(withAgentErr.length).toBeGreaterThan(0)`) so it tolerates the coordinator's `upstream_failed` cascade on dependent nodes, while still failing if the descriptive error message ever regresses to a generic `Error('dispatch failed')`.
- **`backend/src/coordinator/dispatch.test.ts`**: Removed a dead `originalImpl` declaration in the *"retries on 429 rate-limit response"* test.

## Testing

- `backend/src/coordinator/dispatch.test.ts` — **13/13** unit tests pass
- `backend/tests/e2e/pipeline.test.ts` — **11/11** e2e tests pass (was 10/10; +1 new)
- `npx tsc --noEmit` — clean

## Related Issue

Closes #173

## Checklist

- [x] Tests pass
- [ ] Lint is clean (not run in this session)
- [x] Documentation updated if needed (n/a — test-only change)
