### PR TITLE
fix: add missing @tailwind base and @tailwind components directives

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,3 +1,5 @@
+@tailwind base;
+@tailwind components;
 @tailwind utilities;
 
 :root {


### PR DESCRIPTION
## 🎯 Objective
Add the missing `@tailwind base` and `@tailwind components` directives to the global CSS file so that Tailwind CSS reset (preflight), base styles, and component utility classes are properly loaded.

## 📁 Changes
- **Modified**: `frontend/src/styles/global.css`
  - Added `@tailwind base;` as the first directive
  - Added `@tailwind components;` as the second directive
  - Kept `@tailwind utilities;` as the third directive

## ✅ Acceptance Criteria
- [x] Added `@tailwind base;` as the first directive
- [x] Added `@tailwind components;` as the second directive
- [x] Kept `@tailwind utilities;` as the third directive

Closes #142