### PR TITLE
fix: replace hardcoded light-mode colors with CSS variables for consistent dark theme (Closes #152)

### DIFF
--- a/frontend/src/components/agents/TaskSubmissionForm.tsx
+++ b/frontend/src/components/agents/TaskSubmissionForm.tsx
@@ -90,7 +90,7 @@ export function TaskSubmissionForm() {
             {...register('prompt')}
             rows={6}
             maxLength={1000}
-            style={{ width: '100%', padding: 12, borderRadius: 10, border: '1px solid #cbd5e1' }}
+            style={{ width: '100%', padding: 12, borderRadius: 10, border: '1px solid var(--border-color)' }}
             aria-invalid={Boolean(errors.prompt)}
             aria-describedby="prompt-error"
           />
@@ -109,7 +109,7 @@ export function TaskSubmissionForm() {
             step="0.1"
             min="0.1"
             {...register('maxBudgetXLM', { valueAsNumber: true })}
-            style={{ width: 180, padding: 12, borderRadius: 10, border: '1px solid #cbd5e1' }}
+            style={{ width: 180, padding: 12, borderRadius: 10, border: '1px solid var(--border-color)' }}
             aria-invalid={Boolean(errors.maxBudgetXLM)}
             aria-describedby="budget-error"
           />
@@ -143,7 +143,7 @@ export function TaskSubmissionForm() {
                       gap: 10,
                       padding: 12,
                       borderRadius: 10,
-                      border: '1px solid #cbd5e1',
+                      border: '1px solid var(--border-color)',
                       cursor: 'pointer',
                     }}
                   >
@@ -198,10 +198,10 @@ export function TaskSubmissionForm() {
       <section style={{ marginBottom: 24 }}>
         <h2>Execution DAG preview</h2>
         {isLoading && (
-          <div aria-busy="true" style={{ padding: 24, background: '#f8fafc', borderRadius: 12 }}>
-            <div style={{ height: 18, width: '45%', background: '#e2e8f0', borderRadius: 8, marginBottom: 12 }} />
-            <div style={{ height: 18, width: '70%', background: '#e2e8f0', borderRadius: 8, marginBottom: 12 }} />
-            <div style={{ height: 18, width: '55%', background: '#e2e8f0', borderRadius: 8 }} />
+          <div aria-busy="true" style={{ padding: 24, background: 'var(--bg-secondary)', borderRadius: 12 }}>
+            <div style={{ height: 18, width: '45%', background: 'var(--bg-surface-alt)', borderRadius: 8, marginBottom: 12 }} />
+            <div style={{ height: 18, width: '70%', background: 'var(--bg-surface-alt)', borderRadius: 8, marginBottom: 12 }} />
+            <div style={{ height: 18, width: '55%', background: 'var(--bg-surface-alt)', borderRadius: 8 }} />
           </div>
         )}
         {!isLoading && <DAGPreview dagPreview={previewData ?? undefined} />}

--- a/frontend/src/components/dashboard/KpiCard.module.css
+++ b/frontend/src/components/dashboard/KpiCard.module.css
@@ -1,6 +1,6 @@
 .card {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 1rem;
   display: flex;
@@ -10,7 +10,7 @@
 
 .skeleton {
   height: 80px;
-  background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
+  background: linear-gradient(90deg, var(--bg-surface-alt) 25%, var(--bg-surface) 50%, var(--bg-surface-alt) 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
   border-radius: 4px;
@@ -23,12 +23,12 @@
 
 .title {
   font-size: 0.875rem;
-  color: #64748b;
+  color: var(--text-secondary);
   font-weight: 500;
 }
 
 .value {
   font-size: 1.75rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text-primary);
 }

--- a/frontend/src/components/dashboard/NetworkHealthBadge.module.css
+++ b/frontend/src/components/dashboard/NetworkHealthBadge.module.css
@@ -18,5 +18,5 @@
 .label {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
 }

--- a/frontend/src/components/dashboard/RecentTasksTable.module.css
+++ b/frontend/src/components/dashboard/RecentTasksTable.module.css
@@ -8,31 +8,31 @@
 .table td {
   text-align: left;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .table th {
   font-weight: 600;
-  color: #64748b;
-  background: #f8fafc;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
 }
 
 .row {
   display: flex;
   gap: 1rem;
   padding: 0.75rem 0;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .empty {
   padding: 2rem;
   text-align: center;
-  color: #94a3b8;
+  color: var(--text-secondary);
   font-size: 0.875rem;
 }
 
 .viewLink {
-  color: #6366f1;
+  color: var(--primary);
   text-decoration: none;
   font-weight: 500;
 }

--- a/frontend/src/components/wallet/SendXLMForm.module.css
+++ b/frontend/src/components/wallet/SendXLMForm.module.css
@@ -1,6 +1,6 @@
 .container {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 24px;
   margin-bottom: 24px;
@@ -10,11 +10,11 @@
   font-size: 1.125rem;
   font-weight: 600;
   margin: 0 0 16px;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .disconnected {
-  color: #64748b;
+  color: var(--text-secondary);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -27,18 +27,18 @@
   display: block;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #334155;
+  color: var(--text-secondary);
   margin-bottom: 6px;
 }
 
 .input {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   font-size: 0.875rem;
-  color: #0f172a;
-  background: #f8fafc;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
   transition: border-color 0.15s, box-shadow 0.15s;
   box-sizing: border-box;
 }
@@ -70,7 +70,7 @@
 }
 
 .helper {
-  color: #64748b;
+  color: var(--text-secondary);
   font-size: 0.75rem;
   margin: 4px 0 0;
 }
@@ -141,7 +141,7 @@
 }
 
 .modal {
-  background: #ffffff;
+  background: var(--bg-primary);
   border-radius: 16px;
   padding: 24px;
   max-width: 440px;
@@ -153,7 +153,7 @@
   font-size: 1.125rem;
   font-weight: 600;
   margin: 0 0 16px;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .modalBody {
@@ -165,7 +165,7 @@
   justify-content: space-between;
   align-items: flex-start;
   padding: 8px 0;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .confirmRow:last-child {
@@ -174,7 +174,7 @@
 
 .confirmLabel {
   font-size: 0.875rem;
-  color: #64748b;
+  color: var(--text-secondary);
   font-weight: 500;
   flex-shrink: 0;
   margin-right: 12px;
@@ -182,7 +182,7 @@
 
 .confirmValue {
   font-size: 0.875rem;
-  color: #0f172a;
+  color: var(--text-primary);
   font-weight: 500;
   text-align: right;
   word-break: break-all;
@@ -196,9 +196,9 @@
 
 .cancelButton {
   padding: 8px 16px;
-  background: #f1f5f9;
-  color: #334155;
-  border: 1px solid #e2e8f0;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   font-size: 0.875rem;
   cursor: pointer;
@@ -206,7 +206,7 @@
 }
 
 .cancelButton:hover:not(:disabled) {
-  background: #e2e8f0;
+  background: var(--border-color);
 }
 
 .confirmButton {

--- a/frontend/src/components/wallet/TransactionTable.module.css
+++ b/frontend/src/components/wallet/TransactionTable.module.css
@@ -1,6 +1,6 @@
 .container {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 24px;
   margin-bottom: 24px;
@@ -10,11 +10,11 @@
   font-size: 1.125rem;
   font-weight: 600;
   margin: 0 0 16px;
-  color: #0f172a;
+  color: var(--text-primary);
 }
 
 .table {
-  border: 1px solid #f1f5f9;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -24,11 +24,11 @@
   grid-template-columns: 60px 1fr 1fr 1fr 80px 40px;
   gap: 8px;
   padding: 10px 12px;
-  background: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
   font-size: 0.75rem;
   font-weight: 600;
-  color: #64748b;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -39,7 +39,7 @@
   gap: 8px;
   padding: 12px;
   align-items: center;
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--border-color);
   font-size: 0.8125rem;
   transition: background 0.1s;
 }
@@ -49,7 +49,7 @@
 }
 
 .row:hover {
-  background: #f8fafc;
+  background: var(--bg-secondary);
 }
 
 .incoming,
@@ -81,7 +81,7 @@
 
 .memoText {
   font-size: 0.75rem;
-  color: #475569;
+  color: var(--text-secondary);
   max-width: 100px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -90,7 +90,7 @@
 }
 
 .noMemo {
-  color: #cbd5e1;
+  color: var(--border-color);
 }
 
 .txLink {
@@ -112,23 +112,23 @@
   align-items: center;
   justify-content: center;
   padding: 40px 20px;
-  color: #64748b;
+  color: var(--text-secondary);
   text-align: center;
 }
 
 .emptyIcon {
-  color: #94a3b8;
+  color: var(--text-secondary);
   margin-bottom: 12px;
 }
 
 .emptySubtext {
   font-size: 0.8125rem;
-  color: #94a3b8;
+  color: var(--text-secondary);
   margin-top: 4px;
 }
 
 .empty {
-  color: #64748b;
+  color: var(--text-secondary);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -151,14 +151,14 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #e2e8f0;
+  background: var(--bg-surface-alt);
   animation: pulse 1.5s infinite;
 }
 
 .skeletonLine {
   flex: 1;
   height: 12px;
-  background: #e2e8f0;
+  background: var(--bg-surface-alt);
   border-radius: 4px;
   animation: pulse 1.5s infinite;
 }

--- a/frontend/src/pages/WalletPage.module.css
+++ b/frontend/src/pages/WalletPage.module.css
@@ -14,20 +14,20 @@
   gap: 10px;
   font-size: 1.5rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text-primary);
   margin: 0;
 }
 
 .subtitle {
-  color: #64748b;
+  color: var(--text-secondary);
   font-size: 0.875rem;
   margin: 8px 0 0;
 }
 
 /* Connect card (when not connected) */
 .connectCard {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 32px;
   max-width: 440px;
@@ -37,18 +37,18 @@
   display: block;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #334155;
+  color: var(--text-secondary);
   margin-bottom: 8px;
 }
 
 .secretInput {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   font-size: 0.875rem;
   font-family: monospace;
-  background: #f8fafc;
+  background: var(--bg-secondary);
   transition: border-color 0.15s, box-shadow 0.15s;
   box-sizing: border-box;
 }
@@ -125,7 +125,7 @@
   align-items: center;
   gap: 12px;
   margin: 20px 0;
-  color: #94a3b8;
+  color: var(--text-secondary);
   font-size: 0.8125rem;
 }
 
@@ -134,7 +134,7 @@
   content: '';
   flex: 1;
   height: 1px;
-  background: #e2e8f0;
+  background: var(--border-color);
 }
 
 /* Helper text */
@@ -142,7 +142,7 @@
   display: flex;
   align-items: center;
   font-size: 0.8125rem;
-  color: #64748b;
+  color: var(--text-secondary);
   margin: 8px 0 0;
 }
 
@@ -242,7 +242,7 @@
 }
 
 .qrCode {
-  background: #ffffff;
+  background: var(--bg-primary);
   padding: 8px;
   border-radius: 8px;
   flex-shrink: 0;
@@ -334,7 +334,7 @@
 }
 
 .error {
-  color: #dc2626;
+  color: var(--danger);
   font-size: 0.8125rem;
   margin: 4px 0 0;
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -5,6 +5,8 @@
   --bg-primary: #0A0E14;
   --bg-surface: #11151D;
   --bg-surface-alt: #161B24;
+  --bg-secondary: #1A1F2E;
+  --border-color: #2A3040;
   --border-subtle: #1F2630;
   --text-primary: #F5F7FA;
   --text-secondary: #8A93A3;


### PR DESCRIPTION
## Summary

Fixes the dark/light theme inconsistency where dashboard and wallet components rendered with light-mode colors inside a dark-themed layout shell.

## Changes

### Added CSS variables (global.css)
- `--bg-secondary: #1A1F2E` — secondary background color for surfaces
- `--border-color: #2A3040` — border color for cards and dividers

### Updated CSS module files
Replaced hardcoded light-mode colors with theme-aware CSS variables across 7 CSS module files:

| File | Changes |
|------|---------|
| `KpiCard.module.css` | `#ffffff` → `var(--bg-primary)`, `#0f172a` → `var(--text-primary)`, skeleton shimmer colors |
| `NetworkHealthBadge.module.css` | `#374151` → `var(--text-secondary)` |
| `RecentTasksTable.module.css` | `#f8fafc` → `var(--bg-secondary)`, `#e2e8f0` → `var(--border-color)`, `#64748b` → `var(--text-secondary)` |
| `SendXLMForm.module.css` | `#ffffff` → `var(--bg-primary)`, `#f8fafc` → `var(--bg-secondary)`, border colors, text colors |
| `TransactionTable.module.css` | `#ffffff` → `var(--bg-primary)`, `#f8fafc` → `var(--bg-secondary)`, skeleton colors |
| `WalletPage.module.css` | `#ffffff` → `var(--bg-primary)`, `#f8fafc` → `var(--bg-secondary)`, border/text colors |
| `TaskSubmissionForm.tsx` | Inline `#cbd5e1` borders → `var(--border-color)`, `#f8fafc` → `var(--bg-secondary)` |

### Color mapping
| Hardcoded | CSS Variable |
|-----------|-------------|
| `#ffffff` | `var(--bg-primary)` |
| `#f8fafc` | `var(--bg-secondary)` |
| `#0f172a` | `var(--text-primary)` |
| `#374151` / `#64748b` | `var(--text-secondary)` |
| `#cbd5e1` / `#e2e8f0` | `var(--border-color)` |

## Testing
- ✅ 39 tests passed across 6 test files
- 2 pre-existing failures unrelated to this change (`@stellar/stellar-sdk` module resolution)
- Verified TypeScript compilation has no new errors

Closes #152