### PR TITLE
fix: add responsive design breakpoints for TransactionTable, DAGPreview, RendererDemoPage, and DashboardLayout (Closes #153)

### DIFF
--- a/frontend/src/components/agents/DAGPreview.module.css
+++ b/frontend/src/components/agents/DAGPreview.module.css
@@ -1,0 +1,19 @@
+.container {
+  width: 100%;
+  min-height: 240px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e2e8f0;
+}
+
+@media (min-width: 768px) {
+  .container {
+    min-height: 320px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    min-height: 400px;
+  }
+}

--- a/frontend/src/components/agents/DAGPreview.tsx
+++ b/frontend/src/components/agents/DAGPreview.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import ReactFlow, { Background, Controls, ConnectionLineType, Edge, MarkerType, Node, NodeProps, Position, Handle } from 'reactflow';
 import 'reactflow/dist/style.css';
 import type { DagEdge, DagNode } from '../../services/taskService';
+import styles from './DAGPreview.module.css';
 
 export type DAGPreviewProps = {
   dagPreview?: {
@@ -82,7 +83,7 @@ export function DAGPreview({ dagPreview }: DAGPreviewProps) {
   }
 
   return (
-    <div style={{ width: '100%', height: 320, borderRadius: 12, overflow: 'hidden', border: '1px solid #e2e8f0' }}>
+    <div className={styles.container}>
       <ReactFlow
         nodes={flowNodes}
         edges={flowEdges}

--- a/frontend/src/components/dashboard/DashboardLayout.module.css
+++ b/frontend/src/components/dashboard/DashboardLayout.module.css
@@ -6,3 +6,17 @@
   max-width: 1200px;
   margin: 0 auto;
 }
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 0.75rem;
+    gap: 1rem;
+  }
+}

--- a/frontend/src/components/wallet/TransactionTable.module.css
+++ b/frontend/src/components/wallet/TransactionTable.module.css
@@ -33,6 +33,22 @@
   letter-spacing: 0.05em;
 }
 
+@media (max-width: 768px) {
+  .header {
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    padding: 8px 10px;
+  }
+}
+
+@media (max-width: 480px) {
+  .header {
+    grid-template-columns: 1fr;
+    gap: 4px;
+    padding: 6px 8px;
+  }
+}
+
 .row {
   display: grid;
   grid-template-columns: 60px 1fr 1fr 1fr 80px 40px;
@@ -42,6 +58,22 @@
   border-bottom: 1px solid #f1f5f9;
   font-size: 0.8125rem;
   transition: background 0.1s;
+}
+
+@media (max-width: 768px) {
+  .row {
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    padding: 10px;
+  }
+}
+
+@media (max-width: 480px) {
+  .row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+    padding: 8px;
+  }
 }
 
 .row:last-child {

--- a/frontend/src/pages/RendererDemoPage.tsx
+++ b/frontend/src/pages/RendererDemoPage.tsx
@@ -96,7 +96,7 @@ const RendererDemoPage: React.FC = () => {
       <h1 style={{ fontSize: '2rem', marginBottom: '10px' }}>Agent Output Renderer Demo</h1>
       <p style={{ color: 'var(--text-secondary)' }}>This page renders all 5 output types simultaneously to verify styling, tooltips, copy buttons, and performance.</p>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '30px' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '30px' }}>
         {/* Research */}
         <div className="glass-panel" style={{ padding: '24px' }}>
           <h2 style={{ fontSize: '1.25rem', marginBottom: '16px', color: 'var(--primary)' }}>Research Output</h2>


### PR DESCRIPTION
## Summary
Adds responsive design breakpoints to components that currently use fixed layouts, ensuring the UI adapts properly on mobile (375px) and tablet (768px) screens.

## Changes

### TransactionTable.module.css
- Added  breakpoint — collapses grid to 2 columns
- Added  breakpoint — collapses grid to 1 column
- Applies to both  and  grid containers

### DAGPreview.tsx + DAGPreview.module.css
- Created new CSS module with responsive :
  - Mobile (<768px): 240px
  - Tablet (768px+): 320px
  - Desktop (1024px+): 400px
- Replaced fixed inline  with responsive class

### RendererDemoPage.tsx
- Changed grid from fixed `1fr 1fr` to `repeat(auto-fit, minmax(300px, 1fr))`
- Items automatically reflow from 2-column → 1-column on narrow screens

### DashboardLayout.module.css
- Added mobile-responsive padding and gap:
  - Tablet (<768px): padding 1rem, gap 1.5rem
  - Mobile (<480px): padding 0.75rem, gap 1rem

Closes #153