### PR TITLE
fix(stats): correct hourly bucket timezone parsing in stats module

### DIFF
--- a/backend/src/db/stats.ts
+++ b/backend/src/db/stats.ts
@@ -62,7 +62,7 @@ async function getUptimePercent(db: DbClient, since: Date): Promise<number> {
 
 async function getTasksHourlyCounts(db: DbClient, since: Date): Promise<Array<{ hour: string; value: number }>> {
   const rows = db.prepare(
-    "SELECT strftime('%Y-%m-%d %H:00:00', \"createdAt\") AS hour, COUNT(*) AS count FROM tasks WHERE \"createdAt\" >= ? GROUP BY hour ORDER BY hour"
+    "SELECT strftime('%Y-%m-%d %H:00:00Z', \"createdAt\") AS hour, COUNT(*) AS count FROM tasks WHERE \"createdAt\" >= ? GROUP BY hour ORDER BY hour"
   ).all(since.toISOString()) as Array<{ hour: string; count: string | number }>;
 
   return rows.map((row) => ({ hour: row.hour, value: Number(row.count ?? 0) }));
@@ -70,7 +70,7 @@ async function getTasksHourlyCounts(db: DbClient, since: Date): Promise<Array<{ 
 
 async function getXLMHourlyTotals(db: DbClient, since: Date): Promise<Array<{ hour: string; value: number }>> {
   const rows = db.prepare(
-    "SELECT strftime('%Y-%m-%d %H:00:00', \"createdAt\") AS hour, COALESCE(SUM(amount), 0) AS sum FROM payments WHERE status = 'released' AND \"createdAt\" >= ? GROUP BY hour ORDER BY hour"
+    "SELECT strftime('%Y-%m-%d %H:00:00Z', \"createdAt\") AS hour, COALESCE(SUM(amount), 0) AS sum FROM payments WHERE status = 'released' AND \"createdAt\" >= ? GROUP BY hour ORDER BY hour"
   ).all(since.toISOString()) as Array<{ hour: string; sum: string | number }>;
 
   return rows.map((row) => ({ hour: row.hour, value: normalizeDecimal(Number(row.sum ?? 0) / STROOP_FACTOR) }));


### PR DESCRIPTION
## Summary

Closes #164.

The stats module's SQL (`?` placeholders, `strftime`, `status = 'completed'`) had already been converted to SQLite syntax in a prior fix for the duplicate issue #175, but `backend/src/db/stats.test.ts` was still failing:

```
Expected: 2
Received: 0
```

Root cause: `strftime('%Y-%m-%d %H:00:00', "createdAt")` returns a naive, space-separated datetime string with no timezone marker (e.g. `"2026-06-16 13:00:00"`). Since `createdAt` is stored as UTC ISO strings, this value represents UTC time — but `new Date("2026-06-16 13:00:00")` in JS parses zone-less, space-separated strings as **local time**, not UTC. On any host not running in the UTC timezone, the hourly bucket keys drift by the host's UTC offset and no longer match the UTC-based series timestamps built in `buildHourlySeries`, so `tasksLast24h` / `xlmLast24h` values silently come back as `0`.

## Fix

Append a literal `Z` to the `strftime` format string in `getTasksHourlyCounts` and `getXLMHourlyTotals` (`backend/src/db/stats.ts`), so SQLite returns a valid UTC ISO8601 string (e.g. `"2026-06-16 13:00:00Z"`) that `Date` parses correctly regardless of host timezone.

## Test plan

- [x] `npx jest src/db/stats.test.ts` — both tests pass (previously 1 failing)
- [x] `npx jest --runInBand --forceExit` — full backend suite passes (251 passed, 2 skipped, unrelated)
- [x] `npx tsc -p tsconfig.json --noEmit` — no type errors