### PR TITLE
feat(backend): add event sourcing with event store and replay capability

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -40,5 +40,8 @@
     "ts-jest": "29.1.4",
     "ts-node": "10.9.2",
     "typescript": "^5.4.5"
+  },
+  "allowScripts": {
+    "better-sqlite3@11.10.0": true
   }
 }

--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -11,7 +11,7 @@ import { httpDispatch } from "../coordinator/dispatch";
 import type { AgentRegistry } from "../types/agent";
 import { getTask } from "../coordinator/taskStore";
 import { eventBus } from "../coordinator/eventBus";
-import { createEventStore, type EventStore } from "../coordinator/eventStore";
+import type { EventStore } from "../events/eventStore";
 import { attachTaskStream, type TaskStreamOptions } from "./routes/stream";
 import type { DAGNode } from "../types/task";
 import {
@@ -38,7 +38,14 @@ export interface AppOptions {
   dispatch?: DispatchFn;
   /** Called after each node completes; defaults to no-op (returns 'mock-hash') */
   releasePayment?: PaymentReleaseFn;
-  /** Event log for stream replay; defaults to an in-memory SQLite store */
+  /**
+   * Override the EventStore used for stream replay.  When omitted, the store
+   * owned by `eventBus` is used — which is the canonical single store that the
+   * EventBus persists to.  Only provide this in tests that need an isolated
+   * store; production code should leave it unset.
+   *
+   * @deprecated Pass a custom EventBus instance (with its own store) instead.
+   */
   eventStore?: EventStore;
   /** Heartbeat / auth timing for the WebSocket stream */
   stream?: TaskStreamOptions;
@@ -121,13 +128,12 @@ export function createApp(opts: AppOptions = {}): {
   const httpServer = createServer(app);
 
   // ── Event persistence ──────────────────────────────────────────────────────
-  // Record every Coordinator event (with its EventBus-assigned per-task seq) so
-  // a (re)connecting client can replay history before live streaming begins —
-  // either the full history, or only events past a `?lastEventId` cursor.
-  const eventStore = opts.eventStore ?? createEventStore();
-  const stopRecording = eventBus.subscribeAll((event) =>
-    eventStore.append(event),
-  );
+  // The EventBus already persists every event to its own EventStore (wired in
+  // the EventBus constructor).  We use that same store as the single canonical
+  // source for stream replay so there is exactly one DB and one writer.
+  // opts.eventStore is kept for backward compatibility with tests that inject
+  // a custom store; in production it will always be undefined here.
+  const eventStore = opts.eventStore ?? eventBus.store;
 
   // ── WebSocket: /tasks/:id/stream ───────────────────────────────────────────
   const detachStream = attachTaskStream({
@@ -144,8 +150,6 @@ export function createApp(opts: AppOptions = {}): {
   function close(callback?: () => void): void {
     heartbeatService.stop();
     detachStream();
-    stopRecording();
-    eventStore.close();
     httpServer.close(callback);
   }
 

--- a/backend/src/api/routes/stream.ts
+++ b/backend/src/api/routes/stream.ts
@@ -5,11 +5,45 @@ import { WebSocketServer, WebSocket } from 'ws';
 
 import { eventBus as defaultEventBus } from '../../coordinator/eventBus';
 import { getTask as defaultGetTask } from '../../coordinator/taskStore';
-import type { EventStore } from '../../coordinator/eventStore';
+import type { EventStore, StoredEvent } from '../../events/eventStore';
 import type { Task } from '../../types/task';
 import { WS_CLOSE } from '../../types/stream';
 
 const STREAM_PATH = /^\/tasks\/([^/?]+)\/stream(?:\?.*)?$/;
+
+// ---------------------------------------------------------------------------
+// Wire-format normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a stored event to the wire shape expected by WebSocket clients:
+ *  • `type` is in snake_case  (the coordinator's original DAGEventType)
+ *  • `seq`  is the per-task cursor (mapped from `taskSeq`)
+ *
+ * Clients use `event.type === 'task_completed'` / `event.seq` as a resume
+ * cursor, so this mapping must be stable.
+ */
+function toWireEvent(event: StoredEvent): Record<string, unknown> {
+  const snakeType = event.type
+    // PascalCase → snake_case: "NodeStarted" → "node_started"
+    .replace(/([A-Z])/g, (_match, _p1, offset: number) =>
+      offset === 0 ? _match.toLowerCase() : `_${_match.toLowerCase()}`
+    );
+
+  const { taskSeq, globalSeq, occurredAt, version, ...rest } = event as StoredEvent & {
+    taskSeq: number;
+    globalSeq: number;
+    occurredAt: string;
+    version: number;
+  };
+
+  return {
+    ...rest,
+    type: snakeType,
+    seq: taskSeq,
+    timestamp: occurredAt,
+  };
+}
 
 /**
  * Parse the optional `?lastEventId=<number>` cursor from a stream URL. Returns
@@ -132,10 +166,10 @@ export function attachTaskStream(deps: TaskStreamDeps): () => void {
     const flush = (): void => {
       const events = eventStore.listByTaskSince(taskId, lastSentSeq);
       for (const event of events) {
-        // Send the full event including its seq so the client can record a
-        // cursor and resume from it via ?lastEventId on a later reconnect.
-        send(event);
-        lastSentSeq = event.seq;
+        // Normalise to the wire format (snake_case type, seq cursor) before
+        // sending so clients see the same shape regardless of internal storage.
+        send(toWireEvent(event));
+        lastSentSeq = event.taskSeq;
       }
     };
 

--- a/backend/src/coordinator/eventBus.ts
+++ b/backend/src/coordinator/eventBus.ts
@@ -1,11 +1,98 @@
+/**
+ * In-process pub/sub bus with integrated event-store persistence.
+ *
+ * Every event emitted on the bus is:
+ *  1. Stamped with a per-task monotonic `taskSeq` (starts at 0 per taskId).
+ *  2. Persisted to the SQLite-backed EventStore BEFORE any per-task subscriber
+ *     receives it — guaranteeing that the row exists by the time WebSocket
+ *     handlers replay "events since cursor".
+ *  3. Delivered to per-task subscribers.
+ *
+ * The EventStore is injected at construction time so it can be replaced with a
+ * custom instance (e.g. a file-backed DB for production, or a fresh in-memory
+ * DB in tests).  If no store is supplied the bus creates a default in-memory
+ * instance — this preserves the zero-config behaviour used throughout the test
+ * suite.
+ *
+ * Backward compatibility
+ * ──────────────────────
+ * The exported `eventBus` singleton is still the primary integration point for
+ * the coordinator, stream routes, and tests.  The `subscribe`, `subscribeAll`,
+ * and `emit` signatures are unchanged.
+ *
+ * The coordinator's legacy `createEventStore` import path
+ * (`../coordinator/eventStore`) is kept as a re-export so the existing
+ * `tests/replay.test.ts` and any other consumers continue to compile and pass
+ * without modification.
+ */
+
 import { EventEmitter } from 'events';
 import type { DAGEvent } from '../types/task';
+import { createEventStore } from '../events/eventStore';
+import type { EventStore } from '../events/eventStore';
+import type { AppEvent } from '../events/eventTypes';
+import { CURRENT_EVENT_VERSION } from '../events/eventTypes';
+
+// ---------------------------------------------------------------------------
+// Adapter — convert a legacy DAGEvent to AppEvent
+// ---------------------------------------------------------------------------
 
 /**
- * In-process pub/sub bus.  Coordinator emits events; WebSocket handlers
- * subscribe per taskId, and a persistence recorder subscribes to *all* events
- * via {@link EventBus.subscribeAll} so they can be replayed on reconnect.
+ * Map a coordinator `DAGEvent` to the richer `AppEvent` shape expected by the
+ * new EventStore.  The mapping uses PascalCase type names to match the
+ * EventType union in eventTypes.ts.
  */
+const TYPE_MAP: Record<string, AppEvent['type']> = {
+  node_started: 'NodeStarted',
+  node_completed: 'NodeCompleted',
+  node_failed: 'NodeFailed',
+  payment_locked: 'PaymentLocked',
+  payment_released: 'PaymentReleased',
+  task_completed: 'TaskCompleted',
+  task_failed: 'TaskFailed',
+};
+
+function dagEventToAppEvent(event: DAGEvent): AppEvent {
+  const mapped = TYPE_MAP[event.type] ?? (event.type as AppEvent['type']);
+
+  const base = {
+    type: mapped,
+    taskId: event.taskId,
+    occurredAt: event.timestamp,
+    version: CURRENT_EVENT_VERSION,
+    taskSeq: event.seq,
+  } as const;
+
+  // Attach nodeId only for node-level events so TypeScript narrowing stays
+  // accurate on the stored events side.
+  if (event.nodeId) {
+    return {
+      ...base,
+      nodeId: event.nodeId,
+      payload: (event.payload ?? {}) as never,
+    } as AppEvent;
+  }
+
+  return {
+    ...base,
+    payload: (event.payload ?? undefined) as never,
+  } as AppEvent;
+}
+
+// ---------------------------------------------------------------------------
+// EventBus
+// ---------------------------------------------------------------------------
+
+export interface EventBusOptions {
+  /**
+   * Provide a pre-configured EventStore.  When omitted the bus creates a
+   * default in-memory SQLite store.
+   */
+  store?: EventStore;
+  /** Maximum number of listeners (default: 100). */
+  maxListeners?: number;
+}
+
 class EventBus extends EventEmitter {
   /** Internal channel that receives every event regardless of taskId. */
   private static readonly ALL = '__all__';
@@ -13,18 +100,39 @@ class EventBus extends EventEmitter {
   /** Next sequence number to assign per taskId (counter starts at 0). */
   private readonly nextSeqByTask = new Map<string, number>();
 
+  /** Underlying append-only event store. */
+  readonly store: EventStore;
+
+  constructor(options: EventBusOptions = {}) {
+    super();
+    this.store = options.store ?? createEventStore();
+    this.setMaxListeners(options.maxListeners ?? 100);
+
+    // Wire the persistence recorder: every event is persisted BEFORE per-task
+    // subscribers see it so the DB row exists during their handlers.
+    this.on(EventBus.ALL, (event: DAGEvent) => {
+      try {
+        this.store.append(dagEventToAppEvent(event));
+      } catch (err) {
+        // Persistence failures must not crash the process — log and continue.
+        // The event has already been emitted to live subscribers.
+        console.error('[eventBus] failed to persist event:', err);
+      }
+    });
+  }
+
   emit(taskId: string, event: DAGEvent): boolean {
-    // Stamp a per-task monotonic sequence number BEFORE any subscriber sees the
-    // event, so the persistence recorder and every live handler observe the
-    // same seq. seq starts at 0 for each taskId and increments by 1 per event,
-    // giving clients a stable cursor to resume a stream from (?lastEventId).
+    // Stamp a per-task monotonic sequence number BEFORE any subscriber sees
+    // the event, so the persistence recorder and every live handler observe
+    // the same taskSeq.  Starts at 0 for each taskId.
     const seq = this.nextSeqByTask.get(taskId) ?? 0;
     this.nextSeqByTask.set(taskId, seq + 1);
     event.seq = seq;
 
-    // Notify the persistence recorder FIRST so the event is durably stored
-    // before any per-task subscriber reacts to it.  Live WebSocket handlers
-    // drain newly-persisted rows, so the row must exist by the time they run.
+    // Notify the persistence recorder FIRST (see constructor), then per-task
+    // subscribers.  The ALL channel listener runs synchronously here before
+    // the per-task emit below, ensuring the row is committed before any
+    // WebSocket handler drains "events since cursor".
     super.emit(EventBus.ALL, event);
     return super.emit(taskId, event);
   }
@@ -41,5 +149,8 @@ class EventBus extends EventEmitter {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
 export const eventBus = new EventBus();
-eventBus.setMaxListeners(100);

--- a/backend/src/coordinator/eventBus.ts
+++ b/backend/src/coordinator/eventBus.ts
@@ -108,6 +108,24 @@ class EventBus extends EventEmitter {
     this.store = options.store ?? createEventStore();
     this.setMaxListeners(options.maxListeners ?? 100);
 
+    // ── Rehydrate seq counters from the DB ──────────────────────────────────
+    // On restart the in-memory Map is empty, so the first event for any
+    // in-progress task would be stamped seq=0 — colliding with the
+    // UNIQUE(task_id, task_seq) constraint and getting silently swallowed.
+    // Seed each counter from the highest task_seq already stored so that
+    // post-restart events continue from where the previous run left off.
+    try {
+      const maxSeqs = this.store.maxTaskSeqPerTask();
+      for (const [taskId, maxSeq] of maxSeqs) {
+        // next seq to assign = max already stored + 1
+        this.nextSeqByTask.set(taskId, maxSeq + 1);
+      }
+    } catch (err) {
+      // Surface rehydration errors — a silent failure here means duplicate
+      // seq=0 events after restart, which is worse than a startup warning.
+      console.error('[eventBus] failed to rehydrate taskSeq counters from DB:', err);
+    }
+
     // Wire the persistence recorder: every event is persisted BEFORE per-task
     // subscribers see it so the DB row exists during their handlers.
     this.on(EventBus.ALL, (event: DAGEvent) => {

--- a/backend/src/coordinator/eventStore.ts
+++ b/backend/src/coordinator/eventStore.ts
@@ -1,108 +1,110 @@
-import Database from 'better-sqlite3';
+/**
+ * Legacy shim — re-exports the canonical event store implementation.
+ *
+ * All code that previously imported from `../coordinator/eventStore` continues
+ * to compile and behave correctly without modification.  New code should
+ * import directly from `../events/eventStore`.
+ *
+ * Compatibility notes
+ * ───────────────────
+ * • `StoredEvent` here wraps the coordinator's `DAGEvent` shape (seq / taskId /
+ *   type / nodeId / timestamp / payload).  The new EventStore returns the richer
+ *   `AppEvent`-based `StoredEvent` (globalSeq / taskSeq / …).  Because the
+ *   existing tests only assert on `seq`, `taskId`, `type`, and `listByTask` /
+ *   `listByTaskSince`, this thin adapter satisfies them without breaking
+ *   anything.
+ * • `createEventStore` delegates to the new implementation — both share the
+ *   same in-memory SQLite instance strategy.
+ */
+
+import {
+  createEventStore as newCreateEventStore,
+} from '../events/eventStore';
+import type Database from 'better-sqlite3';
 import type { DAGEvent, DAGEventType } from '../types/task';
 
-/**
- * A persisted event with its per-task sequence id.  The `seq` is assigned by
- * the EventBus (monotonic per taskId, starting at 0) and defines the canonical
- * chronological order used for replay and for streaming "events newer than X".
- */
+// ---------------------------------------------------------------------------
+// Legacy types (kept for backward compat with replay.test.ts)
+// ---------------------------------------------------------------------------
+
 export interface StoredEvent extends DAGEvent {
   seq: number;
 }
 
-/**
- * Durable, ordered log of {@link DAGEvent}s keyed by taskId.  Used to replay a
- * task's history to a (re)connecting WebSocket client before streaming live
- * events.  Append order is preserved by an autoincrement primary key, so
- * replay is always chronological.
- */
 export interface EventStore {
-  /** Append an event and return it with its assigned sequence id. */
   append(event: DAGEvent): StoredEvent;
-  /** All events for a task in chronological order. */
   listByTask(taskId: string): StoredEvent[];
-  /** Events for a task with seq strictly greater than `afterSeq`, ordered. */
   listByTaskSince(taskId: string, afterSeq: number): StoredEvent[];
-  /** Release underlying resources. */
   close(): void;
 }
 
+// ---------------------------------------------------------------------------
+// Adapter — maps between DAGEvent and the new AppEvent-backed store
+// ---------------------------------------------------------------------------
+
 /**
- * Create a SQLite-backed {@link EventStore}.
+ * Create a SQLite-backed {@link EventStore} using the canonical event store
+ * implementation under the hood.
  *
- * @param db  An existing better-sqlite3 database, or a file path.  Defaults to
- *            an in-memory database scoped to the process — sufficient for a
- *            single long-running server and for tests, while still exercising
- *            the real "replay from DB" code path.
+ * @param db  An existing better-sqlite3 Database instance, or a file path
+ *            string.  Defaults to an in-memory database.
  */
 export function createEventStore(db?: Database.Database | string): EventStore {
-  const database =
-    typeof db === 'string' ? new Database(db) : db ?? new Database(':memory:');
+  const inner = newCreateEventStore(db);
 
-  database.exec(`
-    CREATE TABLE IF NOT EXISTS task_events (
-      id          INTEGER PRIMARY KEY AUTOINCREMENT,
-      seq         INTEGER NOT NULL,
-      taskId      TEXT NOT NULL,
-      type        TEXT NOT NULL,
-      nodeId      TEXT,
-      timestamp   TEXT NOT NULL,
-      payloadJson TEXT
-    );
-    CREATE INDEX IF NOT EXISTS idx_task_events_task ON task_events (taskId, seq);
-  `);
-
-  const insertStmt = database.prepare(`
-    INSERT INTO task_events (seq, taskId, type, nodeId, timestamp, payloadJson)
-    VALUES (@seq, @taskId, @type, @nodeId, @timestamp, @payloadJson)
-  `);
-  const listStmt = database.prepare(
-    'SELECT * FROM task_events WHERE taskId = ? ORDER BY seq ASC'
-  );
-  const listSinceStmt = database.prepare(
-    'SELECT * FROM task_events WHERE taskId = ? AND seq > ? ORDER BY seq ASC'
-  );
-
-  function rowToEvent(row: Record<string, unknown>): StoredEvent {
-    const payloadJson = row.payloadJson as string | null;
+  function storedToDAG(stored: ReturnType<typeof inner.listByTask>[number]): StoredEvent {
     return {
-      seq: row.seq as number,
-      type: row.type as DAGEventType,
-      taskId: row.taskId as string,
-      nodeId: (row.nodeId as string | null) ?? undefined,
-      timestamp: row.timestamp as string,
-      payload: payloadJson != null ? JSON.parse(payloadJson) : undefined,
+      seq: stored.taskSeq,
+      type: stored.type.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase() as DAGEventType,
+      taskId: stored.taskId,
+      nodeId: ('nodeId' in stored ? (stored as { nodeId?: string }).nodeId : undefined),
+      timestamp: stored.occurredAt,
+      payload: ('payload' in stored ? (stored as { payload?: unknown }).payload : undefined),
     };
   }
 
   return {
     append(event: DAGEvent): StoredEvent {
-      // seq is assigned upstream by the EventBus; default to 0 only for events
-      // that never passed through the bus (defensive — should not happen).
       const seq = event.seq ?? 0;
-      insertStmt.run({
-        seq,
+
+      // Build the minimal AppEvent shape the new store expects.
+      const appEvent = {
+        type: (() => {
+          // PascalCase conversion: node_started → NodeStarted
+          const map: Record<string, string> = {
+            node_started: 'NodeStarted',
+            node_completed: 'NodeCompleted',
+            node_failed: 'NodeFailed',
+            payment_locked: 'PaymentLocked',
+            payment_released: 'PaymentReleased',
+            task_completed: 'TaskCompleted',
+            task_failed: 'TaskFailed',
+          };
+          return (map[event.type] ?? event.type) as ReturnType<typeof inner.append>['type'];
+        })(),
         taskId: event.taskId,
-        type: event.type,
-        nodeId: event.nodeId ?? null,
-        timestamp: event.timestamp,
-        payloadJson: event.payload !== undefined ? JSON.stringify(event.payload) : null,
-      });
+        occurredAt: event.timestamp,
+        version: 1,
+        taskSeq: seq,
+        ...(event.nodeId ? { nodeId: event.nodeId } : {}),
+        ...(event.payload !== undefined ? { payload: event.payload as never } : {}),
+      } as Parameters<typeof inner.append>[0];
+
+      inner.append(appEvent);
+
       return { ...event, seq };
     },
 
     listByTask(taskId: string): StoredEvent[] {
-      return (listStmt.all(taskId) as Array<Record<string, unknown>>).map(rowToEvent);
+      return inner.listByTask(taskId).map(storedToDAG);
     },
 
     listByTaskSince(taskId: string, afterSeq: number): StoredEvent[] {
-      return (listSinceStmt.all(taskId, afterSeq) as Array<Record<string, unknown>>).map(
-        rowToEvent
-      );
+      return inner.listByTaskSince(taskId, afterSeq).map(storedToDAG);
     },
 
     close(): void {
-      database.close();
+      inner.close();
     },
   };
 }

--- a/backend/src/db/events.sql
+++ b/backend/src/db/events.sql
@@ -1,0 +1,56 @@
+-- Event store schema for append-only event sourcing log.
+--
+-- This table is the single source of truth for all task lifecycle events.
+-- Rows are never updated or deleted — only appended. The `global_seq` column
+-- (AUTOINCREMENT) provides a globally-ordered cursor across all tasks, while
+-- `task_seq` provides a per-task cursor for stream resume (?lastEventId).
+--
+-- Apply with:
+--   better-sqlite3: db.exec(fs.readFileSync('backend/src/db/events.sql', 'utf8'))
+--   psql:           psql "$DATABASE_URL" -f backend/src/db/events.sql
+
+CREATE TABLE IF NOT EXISTS task_events (
+  -- Globally unique, monotonically-increasing row identifier.
+  -- Used for cross-task ordering and change-data-capture.
+  global_seq   INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  -- Per-task monotonic cursor starting at 0. Assigned by the EventBus before
+  -- the event is stored so WebSocket clients can resume from ?lastEventId.
+  task_seq     INTEGER NOT NULL,
+
+  -- Schema version for this event record. Increment when the payload shape
+  -- changes; readers can branch on version for backward compatibility.
+  version      INTEGER NOT NULL DEFAULT 1,
+
+  -- Discriminator — one of the EventType literals defined in eventTypes.ts.
+  type         TEXT    NOT NULL,
+
+  -- The task this event belongs to.
+  task_id      TEXT    NOT NULL,
+
+  -- The DAG node this event relates to (NULL for task-level events).
+  node_id      TEXT,
+
+  -- ISO-8601 wall-clock time when the event was created by the emitter.
+  occurred_at  TEXT    NOT NULL,
+
+  -- JSON-serialised event-specific payload (may be NULL for simple signals).
+  payload      TEXT,
+
+  -- Enforce uniqueness of (task_id, task_seq) so duplicate appends are
+  -- detected immediately rather than silently creating duplicate rows.
+  UNIQUE (task_id, task_seq)
+);
+
+-- Primary query: fetch all events for a task in order (full replay).
+CREATE INDEX IF NOT EXISTS idx_events_task_seq
+  ON task_events (task_id, task_seq ASC);
+
+-- Time-range queries: find events within a wall-clock window.
+CREATE INDEX IF NOT EXISTS idx_events_occurred_at
+  ON task_events (occurred_at ASC);
+
+-- Type filter: project a specific event type across all tasks (e.g. all
+-- PaymentLocked events for billing reconciliation).
+CREATE INDEX IF NOT EXISTS idx_events_type
+  ON task_events (type, occurred_at ASC);

--- a/backend/src/db/events.sql
+++ b/backend/src/db/events.sql
@@ -5,9 +5,11 @@
 -- (AUTOINCREMENT) provides a globally-ordered cursor across all tasks, while
 -- `task_seq` provides a per-task cursor for stream resume (?lastEventId).
 --
+-- NOTE: This DDL uses SQLite syntax (AUTOINCREMENT, TEXT for ISO-8601 dates).
+-- It is not compatible with PostgreSQL or other databases without adaptation.
+--
 -- Apply with:
 --   better-sqlite3: db.exec(fs.readFileSync('backend/src/db/events.sql', 'utf8'))
---   psql:           psql "$DATABASE_URL" -f backend/src/db/events.sql
 
 CREATE TABLE IF NOT EXISTS task_events (
   -- Globally unique, monotonically-increasing row identifier.

--- a/backend/src/events/eventStore.test.ts
+++ b/backend/src/events/eventStore.test.ts
@@ -385,6 +385,24 @@ describe('replayTask', () => {
     expect(node.paymentTxHash).toBe('0xabc123');
   });
 
+  it('captures PaymentLocked fields (balanceId, amountStroops, paymentLockedAt)', () => {
+    const taskId = 'replay-locked';
+    const lockedAt = '2026-08-22T10:00:00.000Z';
+    const events = [
+      withSeq(makeTaskCreated(taskId, { prompt: 'p', walletPublicKey: 'G', dagSize: 1 }), 0),
+      withSeq(makeNodeStarted(taskId, 'n1', { agentType: 'research' }), 1),
+      { ...makePaymentLocked(taskId, 'n1', { balanceId: 'BAL-XYZ', amountStroops: 10_000_000 }), taskSeq: 2, occurredAt: lockedAt },
+    ];
+    const state = replayTask(events)!;
+
+    const node = state.nodes.get('n1')!;
+    expect(node.balanceId).toBe('BAL-XYZ');
+    expect(node.amountStroops).toBe(10_000_000);
+    expect(node.paymentLockedAt).toBe(lockedAt);
+    // paymentTxHash not yet set — PaymentReleased hasn't been applied
+    expect(node.paymentTxHash).toBeUndefined();
+  });
+
   it('advances lastTaskSeq and eventCount correctly', () => {
     const events = buildTaskEvents('replay-counts');
     const state = replayTask(events)!;

--- a/backend/src/events/eventStore.test.ts
+++ b/backend/src/events/eventStore.test.ts
@@ -1,0 +1,699 @@
+/**
+ * Unit tests for the event sourcing implementation.
+ *
+ * Coverage
+ * ────────
+ * EventStore
+ *   • append — stores event, returns StoredEvent with globalSeq
+ *   • append — enforces UNIQUE(task_id, task_seq) constraint
+ *   • listByTask — full ordered replay
+ *   • listByTaskSince — cursor-based partial replay
+ *   • listByTimeRange — time-window query
+ *   • listByType — type filter (with and without time range)
+ *   • multi-task isolation
+ *
+ * replay.ts
+ *   • replayTask — reconstructs TaskState from ordered events
+ *   • replayTaskUpTo — snapshot at a given taskSeq
+ *   • applyEventToState — incremental state update
+ *
+ * projection.ts
+ *   • projectTaskSummary — per-task status roll-up
+ *   • projectNodeTimeline — per-node execution timeline + durationMs
+ *   • projectPaymentLedger — locked → released lifecycle
+ *   • projectThroughput — aggregate event-rate stats
+ *   • buildProjection — generic reducer runner
+ *
+ * Versioning
+ *   • stored events carry the emitted version number
+ *   • version round-trips through serialisation intact
+ */
+
+import { createEventStore } from './eventStore';
+import type { StoredEvent } from './eventStore';
+import {
+  makeTaskCreated,
+  makeNodeStarted,
+  makeNodeCompleted,
+  makeNodeFailed,
+  makePaymentLocked,
+  makePaymentReleased,
+  makeTaskCompleted,
+  makeTaskFailed,
+  CURRENT_EVENT_VERSION,
+} from './eventTypes';
+import {
+  replayTask,
+  replayTaskUpTo,
+  applyEventToState,
+} from './replay';
+import {
+  projectTaskSummary,
+  projectNodeTimeline,
+  projectPaymentLedger,
+  projectThroughput,
+  buildProjection,
+} from './projection';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Stamp a taskSeq onto an event so it can be passed to append(). */
+function withSeq<T extends { taskSeq?: number }>(event: T, seq: number): T {
+  return { ...event, taskSeq: seq };
+}
+
+/** Build a minimal task event sequence (TaskCreated + a node lifecycle). */
+function buildTaskEvents(taskId: string, nodeId = 'node-1') {
+  const t0 = '2025-01-01T00:00:00.000Z';
+  const t1 = '2025-01-01T00:00:01.000Z';
+  const t2 = '2025-01-01T00:00:02.000Z';
+  const t3 = '2025-01-01T00:00:03.000Z';
+
+  return [
+    withSeq(makeTaskCreated(taskId, { prompt: 'test', walletPublicKey: 'GABC', dagSize: 1 }, t0), 0),
+    withSeq(makeNodeStarted(taskId, nodeId, { agentType: 'research' }, t1), 1),
+    withSeq(makeNodeCompleted(taskId, nodeId, { result: { ok: true } }, t2), 2),
+    withSeq(makeTaskCompleted(taskId, t3), 3),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// EventStore — append
+// ---------------------------------------------------------------------------
+
+describe('EventStore.append', () => {
+  it('returns a StoredEvent with globalSeq assigned', () => {
+    const store = createEventStore();
+    const event = withSeq(makeTaskCreated('t1', { prompt: 'hi', walletPublicKey: 'GABC', dagSize: 1 }), 0);
+    const stored = store.append(event);
+
+    expect(stored.globalSeq).toBe(1); // SQLite AUTOINCREMENT starts at 1
+    expect(stored.taskSeq).toBe(0);
+    expect(stored.type).toBe('TaskCreated');
+    expect(stored.taskId).toBe('t1');
+    store.close();
+  });
+
+  it('globalSeq is monotonically increasing across tasks', () => {
+    const store = createEventStore();
+
+    const e1 = store.append(withSeq(makeTaskCreated('ta', { prompt: 'a', walletPublicKey: 'GA', dagSize: 1 }), 0));
+    const e2 = store.append(withSeq(makeTaskCreated('tb', { prompt: 'b', walletPublicKey: 'GB', dagSize: 1 }), 0));
+    const e3 = store.append(withSeq(makeNodeStarted('ta', 'n1', { agentType: 'coding' }), 1));
+
+    expect(e1.globalSeq).toBeLessThan(e2.globalSeq);
+    expect(e2.globalSeq).toBeLessThan(e3.globalSeq);
+    store.close();
+  });
+
+  it('stores the event version field and round-trips it', () => {
+    const store = createEventStore();
+    const event = withSeq(makeTaskCreated('tv', { prompt: 'versioned', walletPublicKey: 'GV', dagSize: 2 }), 0);
+    store.append(event);
+
+    const [stored] = store.listByTask('tv');
+    expect(stored.version).toBe(CURRENT_EVENT_VERSION);
+    store.close();
+  });
+
+  it('rejects a duplicate (task_id, task_seq) on the second append', () => {
+    const store = createEventStore();
+    const event = withSeq(makeNodeStarted('dup', 'n1', { agentType: 'risk' }), 0);
+    store.append(event);
+
+    expect(() => store.append(event)).toThrow();
+    store.close();
+  });
+
+  it('stores nodeId for node-level events and null for task-level events', () => {
+    const store = createEventStore();
+    store.append(withSeq(makeTaskCreated('nodetest', { prompt: 'x', walletPublicKey: 'G', dagSize: 1 }), 0));
+    store.append(withSeq(makeNodeStarted('nodetest', 'n42', { agentType: 'design' }), 1));
+
+    const [taskEvt, nodeEvt] = store.listByTask('nodetest');
+    expect((taskEvt as any).nodeId).toBeUndefined();
+    expect((nodeEvt as any).nodeId).toBe('n42');
+    store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventStore — listByTask (full replay)
+// ---------------------------------------------------------------------------
+
+describe('EventStore.listByTask', () => {
+  it('returns events in taskSeq order', () => {
+    const store = createEventStore();
+    const events = buildTaskEvents('replay-order');
+    for (const e of events) store.append(e);
+
+    const stored = store.listByTask('replay-order');
+    expect(stored.map(e => e.taskSeq)).toEqual([0, 1, 2, 3]);
+    store.close();
+  });
+
+  it('returns an empty array for an unknown taskId', () => {
+    const store = createEventStore();
+    expect(store.listByTask('ghost')).toEqual([]);
+    store.close();
+  });
+
+  it('isolates events by taskId', () => {
+    const store = createEventStore();
+    for (const e of buildTaskEvents('task-a')) store.append(e);
+    for (const e of buildTaskEvents('task-b')) store.append(e);
+
+    const a = store.listByTask('task-a');
+    const b = store.listByTask('task-b');
+    expect(a.every(e => e.taskId === 'task-a')).toBe(true);
+    expect(b.every(e => e.taskId === 'task-b')).toBe(true);
+    store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventStore — listByTaskSince (cursor replay)
+// ---------------------------------------------------------------------------
+
+describe('EventStore.listByTaskSince', () => {
+  it('returns only events with taskSeq > afterSeq', () => {
+    const store = createEventStore();
+    for (const e of buildTaskEvents('cursor-task')) store.append(e);
+
+    const resumed = store.listByTaskSince('cursor-task', 1);
+    expect(resumed.map(e => e.taskSeq)).toEqual([2, 3]);
+    store.close();
+  });
+
+  it('returns all events when afterSeq is -1', () => {
+    const store = createEventStore();
+    for (const e of buildTaskEvents('cursor-all')) store.append(e);
+
+    const all = store.listByTaskSince('cursor-all', -1);
+    expect(all.map(e => e.taskSeq)).toEqual([0, 1, 2, 3]);
+    store.close();
+  });
+
+  it('returns an empty array when cursor is at the latest event', () => {
+    const store = createEventStore();
+    for (const e of buildTaskEvents('cursor-end')) store.append(e);
+
+    expect(store.listByTaskSince('cursor-end', 3)).toEqual([]);
+    store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventStore — listByTimeRange
+// ---------------------------------------------------------------------------
+
+describe('EventStore.listByTimeRange', () => {
+  it('returns events within the inclusive [from, to] window', () => {
+    const store = createEventStore();
+    const events = buildTaskEvents('time-range-task');
+    for (const e of events) store.append(e);
+
+    // Events at t1 and t2 fall inside this window
+    const results = store.listByTimeRange({
+      from: '2025-01-01T00:00:01.000Z',
+      to: '2025-01-01T00:00:02.000Z',
+    });
+
+    expect(results.length).toBe(2);
+    expect(results.map(e => e.type)).toEqual(['NodeStarted', 'NodeCompleted']);
+    store.close();
+  });
+
+  it('returns an empty array when no events fall within the window', () => {
+    const store = createEventStore();
+    for (const e of buildTaskEvents('time-range-empty')) store.append(e);
+
+    const results = store.listByTimeRange({
+      from: '2030-01-01T00:00:00.000Z',
+      to: '2030-12-31T23:59:59.000Z',
+    });
+
+    expect(results).toEqual([]);
+    store.close();
+  });
+
+  it('spans multiple tasks when the window encompasses both', () => {
+    const store = createEventStore();
+
+    store.append(withSeq(
+      makeTaskCreated('tA', { prompt: 'A', walletPublicKey: 'GA', dagSize: 1 }, '2025-06-01T10:00:00.000Z'),
+      0,
+    ));
+    store.append(withSeq(
+      makeTaskCreated('tB', { prompt: 'B', walletPublicKey: 'GB', dagSize: 1 }, '2025-06-01T11:00:00.000Z'),
+      0,
+    ));
+
+    const results = store.listByTimeRange({
+      from: '2025-06-01T09:00:00.000Z',
+      to: '2025-06-01T12:00:00.000Z',
+    });
+
+    expect(results.length).toBe(2);
+    expect(results.map(e => e.taskId)).toContain('tA');
+    expect(results.map(e => e.taskId)).toContain('tB');
+    store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventStore — listByType
+// ---------------------------------------------------------------------------
+
+describe('EventStore.listByType', () => {
+  it('filters events by type across all tasks', () => {
+    const store = createEventStore();
+    for (const e of buildTaskEvents('type-filter-a')) store.append(e);
+    for (const e of buildTaskEvents('type-filter-b')) store.append(e);
+
+    const nodeStarted = store.listByType('NodeStarted');
+    expect(nodeStarted.length).toBe(2);
+    expect(nodeStarted.every(e => e.type === 'NodeStarted')).toBe(true);
+    store.close();
+  });
+
+  it('applies optional time range when provided', () => {
+    const store = createEventStore();
+    store.append(withSeq(makeNodeStarted('tr1', 'n1', { agentType: 'report' }, '2025-03-01T08:00:00.000Z'), 0));
+    store.append(withSeq(makeNodeStarted('tr2', 'n1', { agentType: 'report' }, '2025-03-01T09:00:00.000Z'), 0));
+    store.append(withSeq(makeNodeStarted('tr3', 'n1', { agentType: 'report' }, '2025-03-01T10:00:00.000Z'), 0));
+
+    const results = store.listByType('NodeStarted', {
+      from: '2025-03-01T08:30:00.000Z',
+      to: '2025-03-01T09:30:00.000Z',
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0].taskId).toBe('tr2');
+    store.close();
+  });
+
+  it('returns empty array when no events match the type', () => {
+    const store = createEventStore();
+    for (const e of buildTaskEvents('type-empty')) store.append(e);
+
+    expect(store.listByType('PaymentLocked')).toEqual([]);
+    store.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replay.ts — replayTask
+// ---------------------------------------------------------------------------
+
+describe('replayTask', () => {
+  it('returns undefined for an empty event list', () => {
+    expect(replayTask([])).toBeUndefined();
+  });
+
+  it('reconstructs TaskCreated fields', () => {
+    const events = buildTaskEvents('replay-created');
+    const state = replayTask(events)!;
+
+    expect(state.taskId).toBe('replay-created');
+    expect(state.prompt).toBe('test');
+    expect(state.walletPublicKey).toBe('GABC');
+    expect(state.createdAt).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  it('marks task as completed after TaskCompleted event', () => {
+    const events = buildTaskEvents('replay-complete');
+    const state = replayTask(events)!;
+
+    expect(state.status).toBe('completed');
+    expect(state.completedAt).toBe('2025-01-01T00:00:03.000Z');
+  });
+
+  it('marks task as failed after TaskFailed event', () => {
+    const taskId = 'replay-failed';
+    const events = [
+      withSeq(makeTaskCreated(taskId, { prompt: 'fail', walletPublicKey: 'G', dagSize: 1 }, '2025-01-01T00:00:00.000Z'), 0),
+      withSeq(makeTaskFailed(taskId, 'timeout', '2025-01-01T00:00:05.000Z'), 1),
+    ];
+    const state = replayTask(events)!;
+
+    expect(state.status).toBe('failed');
+    expect(state.terminalError).toBe('timeout');
+  });
+
+  it('tracks node status through start → complete lifecycle', () => {
+    const events = buildTaskEvents('replay-node');
+    const state = replayTask(events)!;
+
+    const node = state.nodes.get('node-1')!;
+    expect(node.status).toBe('completed');
+    expect(node.agentType).toBe('research');
+    expect(node.startedAt).toBe('2025-01-01T00:00:01.000Z');
+    expect(node.settledAt).toBe('2025-01-01T00:00:02.000Z');
+  });
+
+  it('tracks node status through start → fail lifecycle', () => {
+    const taskId = 'replay-node-fail';
+    const events = [
+      withSeq(makeTaskCreated(taskId, { prompt: 'x', walletPublicKey: 'G', dagSize: 1 }), 0),
+      withSeq(makeNodeStarted(taskId, 'n1', { agentType: 'risk' }), 1),
+      withSeq(makeNodeFailed(taskId, 'n1', { error: 'network error' }), 2),
+      withSeq(makeTaskFailed(taskId, 'node failed'), 3),
+    ];
+    const state = replayTask(events)!;
+
+    const node = state.nodes.get('n1')!;
+    expect(node.status).toBe('failed');
+    expect(node.error).toBe('network error');
+  });
+
+  it('attaches payment txHash from PaymentReleased event', () => {
+    const taskId = 'replay-payment';
+    const events = [
+      withSeq(makeTaskCreated(taskId, { prompt: 'pay', walletPublicKey: 'G', dagSize: 1 }), 0),
+      withSeq(makeNodeStarted(taskId, 'n1', { agentType: 'coding' }), 1),
+      withSeq(makePaymentLocked(taskId, 'n1', { balanceId: 'BAL1', amountStroops: 5_000_000 }), 2),
+      withSeq(makeNodeCompleted(taskId, 'n1', { result: null }), 3),
+      withSeq(makePaymentReleased(taskId, 'n1', { txHash: '0xabc123' }), 4),
+      withSeq(makeTaskCompleted(taskId), 5),
+    ];
+    const state = replayTask(events)!;
+
+    const node = state.nodes.get('n1')!;
+    expect(node.paymentTxHash).toBe('0xabc123');
+  });
+
+  it('advances lastTaskSeq and eventCount correctly', () => {
+    const events = buildTaskEvents('replay-counts');
+    const state = replayTask(events)!;
+
+    expect(state.eventCount).toBe(4);
+    expect(state.lastTaskSeq).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replay.ts — replayTaskUpTo
+// ---------------------------------------------------------------------------
+
+describe('replayTaskUpTo', () => {
+  it('returns state as of the specified taskSeq snapshot', () => {
+    const events = buildTaskEvents('snapshot-task');
+
+    // After seq 1 (NodeStarted), task should be running with one running node
+    const snap = replayTaskUpTo(events, 1)!;
+    expect(snap.status).toBe('running');
+    expect(snap.nodes.get('node-1')?.status).toBe('running');
+  });
+
+  it('includes the event exactly at targetSeq', () => {
+    const events = buildTaskEvents('snapshot-inclusive');
+
+    // seq 2 is NodeCompleted — node should be completed
+    const snap = replayTaskUpTo(events, 2)!;
+    expect(snap.nodes.get('node-1')?.status).toBe('completed');
+    expect(snap.status).toBe('running'); // TaskCompleted not yet applied
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replay.ts — applyEventToState
+// ---------------------------------------------------------------------------
+
+describe('applyEventToState', () => {
+  it('incrementally updates state without a full replay', () => {
+    const taskId = 'incremental-task';
+    const events = buildTaskEvents(taskId);
+
+    // Bootstrap from first three events, then apply the fourth incrementally
+    let state = replayTask(events.slice(0, 3))!;
+    expect(state.status).toBe('running');
+
+    state = applyEventToState(state, events[3]);
+    expect(state.status).toBe('completed');
+    expect(state.completedAt).toBe('2025-01-01T00:00:03.000Z');
+  });
+
+  it('mutates and returns the same state reference', () => {
+    const taskId = 'ref-task';
+    const events = buildTaskEvents(taskId);
+    let state = replayTask(events.slice(0, 1))!;
+    const ref = state;
+
+    state = applyEventToState(state, events[1]);
+    expect(state).toBe(ref); // same object reference
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projection.ts — projectTaskSummary
+// ---------------------------------------------------------------------------
+
+describe('projectTaskSummary', () => {
+  it('builds a summary for each distinct task', () => {
+    const store = createEventStore();
+    for (const e of buildTaskEvents('sum-a')) store.append(e);
+    for (const e of buildTaskEvents('sum-b')) store.append(e);
+
+    const allEvents = [
+      ...store.listByTask('sum-a'),
+      ...store.listByTask('sum-b'),
+    ];
+    const summaries = projectTaskSummary(allEvents);
+
+    expect(summaries.size).toBe(2);
+    expect(summaries.get('sum-a')!.status).toBe('completed');
+    expect(summaries.get('sum-b')!.status).toBe('completed');
+    store.close();
+  });
+
+  it('counts completed and failed nodes correctly', () => {
+    const taskId = 'sum-counts';
+    const events = [
+      withSeq(makeTaskCreated(taskId, { prompt: 'x', walletPublicKey: 'G', dagSize: 2 }), 0),
+      withSeq(makeNodeStarted(taskId, 'n1', { agentType: 'a' }), 1),
+      withSeq(makeNodeStarted(taskId, 'n2', { agentType: 'b' }), 2),
+      withSeq(makeNodeCompleted(taskId, 'n1', { result: null }), 3),
+      withSeq(makeNodeFailed(taskId, 'n2', { error: 'oops' }), 4),
+      withSeq(makeTaskFailed(taskId, 'node failed'), 5),
+    ];
+
+    const summaries = projectTaskSummary(events);
+    const s = summaries.get(taskId)!;
+
+    expect(s.nodeCount).toBe(2);
+    expect(s.completedNodeCount).toBe(1);
+    expect(s.failedNodeCount).toBe(1);
+    expect(s.status).toBe('failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projection.ts — projectNodeTimeline
+// ---------------------------------------------------------------------------
+
+describe('projectNodeTimeline', () => {
+  it('builds timeline entries with start, settled, and durationMs', () => {
+    const taskId = 'timeline-task';
+    const events = [
+      withSeq(makeNodeStarted(taskId, 'n1', { agentType: 'research' }, '2025-01-01T10:00:00.000Z'), 0),
+      withSeq(makeNodeCompleted(taskId, 'n1', { result: 'done' }, '2025-01-01T10:00:02.500Z'), 1),
+    ];
+
+    const timeline = projectNodeTimeline(events);
+    const entry = timeline.get('n1')!;
+
+    expect(entry.status).toBe('completed');
+    expect(entry.agentType).toBe('research');
+    expect(entry.durationMs).toBe(2500);
+  });
+
+  it('sets status to failed with error message on NodeFailed', () => {
+    const taskId = 'timeline-fail';
+    const events = [
+      withSeq(makeNodeStarted(taskId, 'n2', { agentType: 'risk' }), 0),
+      withSeq(makeNodeFailed(taskId, 'n2', { error: 'API timeout' }), 1),
+    ];
+
+    const timeline = projectNodeTimeline(events);
+    expect(timeline.get('n2')!.status).toBe('failed');
+    expect(timeline.get('n2')!.error).toBe('API timeout');
+  });
+
+  it('ignores task-level events (no nodeId)', () => {
+    const taskId = 'timeline-task-level';
+    const events = [
+      withSeq(makeTaskCreated(taskId, { prompt: 'x', walletPublicKey: 'G', dagSize: 1 }), 0),
+      withSeq(makeTaskCompleted(taskId), 1),
+    ];
+
+    const timeline = projectNodeTimeline(events);
+    expect(timeline.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projection.ts — projectPaymentLedger
+// ---------------------------------------------------------------------------
+
+describe('projectPaymentLedger', () => {
+  it('transitions entry from locked to released', () => {
+    const taskId = 'ledger-task';
+    const nodeId = 'n1';
+    const events = [
+      withSeq(makePaymentLocked(taskId, nodeId, { balanceId: 'BAL42', amountStroops: 10_000_000 }), 0),
+      withSeq(makePaymentReleased(taskId, nodeId, { txHash: 'TX99' }), 1),
+    ];
+
+    const ledger = projectPaymentLedger(events);
+    const entry = ledger.get(`${taskId}:${nodeId}`)!;
+
+    expect(entry.status).toBe('released');
+    expect(entry.balanceId).toBe('BAL42');
+    expect(entry.amountStroops).toBe(10_000_000);
+    expect(entry.txHash).toBe('TX99');
+  });
+
+  it('creates a partial entry when PaymentReleased has no prior PaymentLocked', () => {
+    const taskId = 'ledger-orphan';
+    const events = [
+      withSeq(makePaymentReleased(taskId, 'n99', { txHash: 'TX_ORPHAN' }), 0),
+    ];
+
+    const ledger = projectPaymentLedger(events);
+    const entry = ledger.get(`${taskId}:n99`)!;
+
+    expect(entry.status).toBe('released');
+    expect(entry.txHash).toBe('TX_ORPHAN');
+    expect(entry.balanceId).toBeUndefined();
+  });
+
+  it('tracks multiple (taskId, nodeId) pairs independently', () => {
+    const events = [
+      withSeq(makePaymentLocked('t1', 'n1', { balanceId: 'B1', amountStroops: 1_000 }), 0),
+      withSeq(makePaymentLocked('t1', 'n2', { balanceId: 'B2', amountStroops: 2_000 }), 1),
+      withSeq(makePaymentReleased('t1', 'n1', { txHash: 'TX1' }), 2),
+    ];
+
+    const ledger = projectPaymentLedger(events);
+    expect(ledger.get('t1:n1')!.status).toBe('released');
+    expect(ledger.get('t1:n2')!.status).toBe('locked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projection.ts — projectThroughput
+// ---------------------------------------------------------------------------
+
+describe('projectThroughput', () => {
+  it('counts total events, distinct tasks, and terminal states', () => {
+    const eventsA = buildTaskEvents('thr-a');
+    const eventsB = [
+      withSeq(makeTaskCreated('thr-b', { prompt: 'b', walletPublicKey: 'G', dagSize: 1 }), 0),
+      withSeq(makeTaskFailed('thr-b', 'boom'), 1),
+    ];
+
+    const stats = projectThroughput([...eventsA, ...eventsB]);
+
+    expect(stats.totalEvents).toBe(6);
+    expect(stats.distinctTasks).toBe(2);
+    expect(stats.completedTasks).toBe(1);
+    expect(stats.failedTasks).toBe(1);
+  });
+
+  it('returns zero-values for an empty slice', () => {
+    const stats = projectThroughput([]);
+    expect(stats.totalEvents).toBe(0);
+    expect(stats.distinctTasks).toBe(0);
+    expect(stats.windowStart).toBeUndefined();
+    expect(stats.windowEnd).toBeUndefined();
+  });
+
+  it('sets windowStart and windowEnd from the event timestamps', () => {
+    const events = [
+      withSeq(makeTaskCreated('thr-win', { prompt: 'w', walletPublicKey: 'G', dagSize: 1 }, '2025-05-01T08:00:00.000Z'), 0),
+      withSeq(makeTaskCompleted('thr-win', '2025-05-01T09:30:00.000Z'), 1),
+    ];
+    const stats = projectThroughput(events);
+
+    expect(stats.windowStart).toBe('2025-05-01T08:00:00.000Z');
+    expect(stats.windowEnd).toBe('2025-05-01T09:30:00.000Z');
+  });
+
+  it('populates countByType for every event type in the slice', () => {
+    const events = buildTaskEvents('thr-types');
+    const stats = projectThroughput(events);
+
+    expect(stats.countByType['TaskCreated']).toBe(1);
+    expect(stats.countByType['NodeStarted']).toBe(1);
+    expect(stats.countByType['NodeCompleted']).toBe(1);
+    expect(stats.countByType['TaskCompleted']).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projection.ts — buildProjection (generic reducer)
+// ---------------------------------------------------------------------------
+
+describe('buildProjection', () => {
+  it('accumulates a simple scalar via a custom reducer', () => {
+    const events = buildTaskEvents('bp-task');
+    const count = buildProjection(events, 0, (acc, e) =>
+      e.type === 'NodeStarted' ? acc + 1 : acc
+    );
+
+    expect(count).toBe(1);
+  });
+
+  it('returns the initial state unchanged for an empty slice', () => {
+    const result = buildProjection([], { seen: [] as string[] }, (s, e) => ({
+      seen: [...s.seen, e.type],
+    }));
+
+    expect(result.seen).toEqual([]);
+  });
+
+  it('builds an ordered list of event types', () => {
+    const events = buildTaskEvents('bp-list');
+    const types = buildProjection(events, [] as string[], (acc, e) => [...acc, e.type]);
+
+    expect(types).toEqual(['TaskCreated', 'NodeStarted', 'NodeCompleted', 'TaskCompleted']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventStore — round-trip with replay (integration)
+// ---------------------------------------------------------------------------
+
+describe('EventStore + replayTask (round-trip)', () => {
+  it('persists and reconstructs full task state end-to-end', () => {
+    const store = createEventStore();
+    const taskId = 'e2e-roundtrip';
+
+    const rawEvents = [
+      withSeq(makeTaskCreated(taskId, { prompt: 'full pipeline', walletPublicKey: 'GXYZ', dagSize: 2 }, '2025-02-01T10:00:00.000Z'), 0),
+      withSeq(makeNodeStarted(taskId, 'research', { agentType: 'research' }, '2025-02-01T10:00:01.000Z'), 1),
+      withSeq(makePaymentLocked(taskId, 'research', { balanceId: 'B_RESEARCH', amountStroops: 1_000_000 }, '2025-02-01T10:00:02.000Z'), 2),
+      withSeq(makeNodeCompleted(taskId, 'research', { result: { summary: 'market data' } }, '2025-02-01T10:00:05.000Z'), 3),
+      withSeq(makePaymentReleased(taskId, 'research', { txHash: 'TX_RESEARCH' }, '2025-02-01T10:00:06.000Z'), 4),
+      withSeq(makeNodeStarted(taskId, 'report', { agentType: 'report' }, '2025-02-01T10:00:07.000Z'), 5),
+      withSeq(makeNodeCompleted(taskId, 'report', { result: { pdf: 'report.pdf' } }, '2025-02-01T10:00:10.000Z'), 6),
+      withSeq(makeTaskCompleted(taskId, '2025-02-01T10:00:11.000Z'), 7),
+    ];
+
+    for (const e of rawEvents) store.append(e);
+
+    const stored = store.listByTask(taskId);
+    const state = replayTask(stored)!;
+
+    expect(state.status).toBe('completed');
+    expect(state.prompt).toBe('full pipeline');
+    expect(state.eventCount).toBe(8);
+    expect(state.nodes.get('research')!.paymentTxHash).toBe('TX_RESEARCH');
+    expect(state.nodes.get('report')!.status).toBe('completed');
+
+    store.close();
+  });
+});

--- a/backend/src/events/eventStore.ts
+++ b/backend/src/events/eventStore.ts
@@ -1,0 +1,269 @@
+/**
+ * Append-only SQLite-backed event store.
+ *
+ * Responsibilities
+ * ────────────────
+ * • Persist every {@link AppEvent} with a globally-unique `globalSeq` and a
+ *   per-task `taskSeq` (the per-task cursor assigned upstream by the EventBus).
+ * • Expose read queries needed by replay, projection, and WebSocket resume.
+ * • Own the DDL — the schema in `../../db/events.sql` is the authoritative
+ *   documentation; this module applies an equivalent DDL inline so the store
+ *   can be instantiated without an external migration tool (e.g. in tests).
+ *
+ * Compatibility note
+ * ──────────────────
+ * The coordinator still imports the legacy {@link createEventStore} from
+ * `../coordinator/eventStore`.  That module now re-exports from here so both
+ * import paths resolve to the same implementation without breaking existing
+ * callers or the tests in `tests/replay.test.ts`.
+ */
+
+import Database from 'better-sqlite3';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { AppEvent } from './eventTypes';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** An event that has been committed to the store and carries both seq fields. */
+export type StoredEvent = AppEvent & {
+  /** Globally-ordered sequence number assigned on INSERT. */
+  globalSeq: number;
+  /** Per-task monotonic cursor (matches the value stamped by EventBus). */
+  taskSeq: number;
+  // Re-surface shared BaseEvent fields so callers don't need to narrow
+  // the discriminated union before reading these universally-present fields.
+  type: AppEvent['type'];
+  taskId: string;
+  occurredAt: string;
+  version: number;
+};
+
+/** Options accepted by time-range queries. */
+export interface TimeRangeOptions {
+  /** ISO-8601 start (inclusive). */
+  from: string;
+  /** ISO-8601 end (inclusive). */
+  to: string;
+}
+
+/** The public contract of the event store. */
+export interface EventStore {
+  /**
+   * Atomically append an event.  The `taskSeq` field on the incoming event is
+   * used as the per-task cursor (it must already be stamped by the EventBus).
+   * Returns the stored event with `globalSeq` filled in.
+   */
+  append(event: AppEvent): StoredEvent;
+
+  /** All events for a task in chronological order (full replay). */
+  listByTask(taskId: string): StoredEvent[];
+
+  /**
+   * Events for a task with `taskSeq` strictly greater than `afterSeq`.
+   * Used for cursor-based WebSocket stream resume.
+   */
+  listByTaskSince(taskId: string, afterSeq: number): StoredEvent[];
+
+  /**
+   * All events whose `occurred_at` falls within [from, to] (ISO-8601 strings,
+   * both inclusive).  Ordered by `occurred_at` ascending.
+   */
+  listByTimeRange(options: TimeRangeOptions): StoredEvent[];
+
+  /**
+   * All events of a specific type within an optional time range.
+   * When `options` is omitted the full history is returned.
+   */
+  listByType(type: string, options?: TimeRangeOptions): StoredEvent[];
+
+  /** Release the underlying database connection. */
+  close(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Row → AppEvent mapping
+// ---------------------------------------------------------------------------
+
+interface EventRow {
+  global_seq: number;
+  task_seq: number;
+  version: number;
+  type: string;
+  task_id: string;
+  node_id: string | null;
+  occurred_at: string;
+  payload: string | null;
+}
+
+function rowToStoredEvent(row: EventRow): StoredEvent {
+  const base = {
+    globalSeq: row.global_seq,
+    taskSeq: row.task_seq,
+    version: row.version,
+    type: row.type as AppEvent['type'],
+    taskId: row.task_id,
+    occurredAt: row.occurred_at,
+  };
+
+  const payload = row.payload != null ? JSON.parse(row.payload) : undefined;
+
+  // nodeId is only present on node-level events; omit the key when absent so
+  // the type narrowing in eventTypes.ts stays clean.
+  if (row.node_id != null) {
+    return { ...base, nodeId: row.node_id, payload } as StoredEvent;
+  }
+  return { ...base, payload } as StoredEvent;
+}
+
+// ---------------------------------------------------------------------------
+// DDL — mirrors backend/src/db/events.sql
+// ---------------------------------------------------------------------------
+
+const DDL = `
+  CREATE TABLE IF NOT EXISTS task_events (
+    global_seq  INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_seq    INTEGER NOT NULL,
+    version     INTEGER NOT NULL DEFAULT 1,
+    type        TEXT    NOT NULL,
+    task_id     TEXT    NOT NULL,
+    node_id     TEXT,
+    occurred_at TEXT    NOT NULL,
+    payload     TEXT,
+    UNIQUE (task_id, task_seq)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_events_task_seq
+    ON task_events (task_id, task_seq ASC);
+
+  CREATE INDEX IF NOT EXISTS idx_events_occurred_at
+    ON task_events (occurred_at ASC);
+
+  CREATE INDEX IF NOT EXISTS idx_events_type
+    ON task_events (type, occurred_at ASC);
+`;
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a SQLite-backed {@link EventStore}.
+ *
+ * @param db  An existing better-sqlite3 `Database` instance, or a file path
+ *            string.  Defaults to an in-memory database — suitable for a
+ *            long-running server and for unit tests alike.
+ */
+export function createEventStore(db?: Database.Database | string): EventStore {
+  const database =
+    typeof db === 'string'
+      ? new Database(db)
+      : db ?? new Database(':memory:');
+
+  database.pragma('journal_mode = WAL');
+  database.pragma('busy_timeout = 5000');
+  database.exec(DDL);
+
+  // ---------------------------------------------------------------------------
+  // Prepared statements
+  // ---------------------------------------------------------------------------
+
+  const insertStmt = database.prepare(`
+    INSERT INTO task_events
+      (task_seq, version, type, task_id, node_id, occurred_at, payload)
+    VALUES
+      (@task_seq, @version, @type, @task_id, @node_id, @occurred_at, @payload)
+  `);
+
+  const listByTaskStmt = database.prepare(`
+    SELECT * FROM task_events
+    WHERE task_id = ?
+    ORDER BY task_seq ASC
+  `);
+
+  const listByTaskSinceStmt = database.prepare(`
+    SELECT * FROM task_events
+    WHERE task_id = ? AND task_seq > ?
+    ORDER BY task_seq ASC
+  `);
+
+  const listByTimeRangeStmt = database.prepare(`
+    SELECT * FROM task_events
+    WHERE occurred_at >= ? AND occurred_at <= ?
+    ORDER BY occurred_at ASC
+  `);
+
+  const listByTypeStmt = database.prepare(`
+    SELECT * FROM task_events
+    WHERE type = ?
+    ORDER BY occurred_at ASC
+  `);
+
+  const listByTypeRangeStmt = database.prepare(`
+    SELECT * FROM task_events
+    WHERE type = ? AND occurred_at >= ? AND occurred_at <= ?
+    ORDER BY occurred_at ASC
+  `);
+
+  // ---------------------------------------------------------------------------
+  // Store implementation
+  // ---------------------------------------------------------------------------
+
+  return {
+    append(event: AppEvent): StoredEvent {
+      // taskSeq is stamped by the EventBus before this is called; fall back to
+      // 0 only as a defensive measure so the insert never fails on a missing
+      // value.
+      const taskSeq = event.taskSeq ?? 0;
+
+      const nodeId =
+        'nodeId' in event && event.nodeId != null ? (event.nodeId as string) : null;
+
+      const result = insertStmt.run({
+        task_seq: taskSeq,
+        version: event.version ?? 1,
+        type: event.type,
+        task_id: event.taskId,
+        node_id: nodeId,
+        occurred_at: event.occurredAt,
+        payload:
+          'payload' in event && event.payload !== undefined
+            ? JSON.stringify(event.payload)
+            : null,
+      });
+
+      return {
+        ...event,
+        taskSeq,
+        globalSeq: result.lastInsertRowid as number,
+      } as StoredEvent;
+    },
+
+    listByTask(taskId: string): StoredEvent[] {
+      return (listByTaskStmt.all(taskId) as EventRow[]).map(rowToStoredEvent);
+    },
+
+    listByTaskSince(taskId: string, afterSeq: number): StoredEvent[] {
+      return (listByTaskSinceStmt.all(taskId, afterSeq) as EventRow[]).map(rowToStoredEvent);
+    },
+
+    listByTimeRange({ from, to }: TimeRangeOptions): StoredEvent[] {
+      return (listByTimeRangeStmt.all(from, to) as EventRow[]).map(rowToStoredEvent);
+    },
+
+    listByType(type: string, options?: TimeRangeOptions): StoredEvent[] {
+      if (options) {
+        return (listByTypeRangeStmt.all(type, options.from, options.to) as EventRow[]).map(
+          rowToStoredEvent
+        );
+      }
+      return (listByTypeStmt.all(type) as EventRow[]).map(rowToStoredEvent);
+    },
+
+    close(): void {
+      database.close();
+    },
+  };
+}

--- a/backend/src/events/eventStore.ts
+++ b/backend/src/events/eventStore.ts
@@ -79,6 +79,16 @@ export interface EventStore {
    */
   listByType(type: string, options?: TimeRangeOptions): StoredEvent[];
 
+  /**
+   * Return the highest `taskSeq` stored for every taskId that has at least one
+   * event.  Used by the EventBus on startup to rehydrate its per-task sequence
+   * counters so that post-restart events continue from where the previous run
+   * left off rather than resetting to 0 and hitting the UNIQUE constraint.
+   *
+   * Returns a Map keyed by taskId, value = max taskSeq stored for that task.
+   */
+  maxTaskSeqPerTask(): Map<string, number>;
+
   /** Release the underlying database connection. */
   close(): void;
 }
@@ -207,6 +217,12 @@ export function createEventStore(db?: Database.Database | string): EventStore {
     ORDER BY occurred_at ASC
   `);
 
+  const maxTaskSeqStmt = database.prepare(`
+    SELECT task_id, MAX(task_seq) AS max_seq
+    FROM task_events
+    GROUP BY task_id
+  `);
+
   // ---------------------------------------------------------------------------
   // Store implementation
   // ---------------------------------------------------------------------------
@@ -260,6 +276,15 @@ export function createEventStore(db?: Database.Database | string): EventStore {
         );
       }
       return (listByTypeStmt.all(type) as EventRow[]).map(rowToStoredEvent);
+    },
+
+    maxTaskSeqPerTask(): Map<string, number> {
+      const rows = maxTaskSeqStmt.all() as Array<{ task_id: string; max_seq: number }>;
+      const result = new Map<string, number>();
+      for (const { task_id, max_seq } of rows) {
+        result.set(task_id, max_seq);
+      }
+      return result;
     },
 
     close(): void {

--- a/backend/src/events/eventTypes.ts
+++ b/backend/src/events/eventTypes.ts
@@ -1,0 +1,268 @@
+/**
+ * Canonical event-type definitions for the ai-net event sourcing system.
+ *
+ * Design decisions
+ * ────────────────
+ * • Every event is a discriminated union on the `type` field so TypeScript can
+ *   narrow payload shapes without casting.
+ * • `version` travels with every event record so consumers can handle schema
+ *   evolution without a separate schema-registry lookup.
+ * • `globalSeq` and `taskSeq` are assigned by the EventStore and are absent
+ *   (undefined) on events that have not yet been persisted.
+ * • All monetary amounts are in stroops (integer) to avoid floating-point
+ *   rounding when dealing with Stellar payments.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared schema
+// ---------------------------------------------------------------------------
+
+/** Current schema version emitted by this code.  Increment when a payload
+ *  shape changes in a backward-incompatible way. */
+export const CURRENT_EVENT_VERSION = 1 as const;
+
+/** Base fields carried by every event. */
+export interface BaseEvent {
+  /** Discriminator — identifies the concrete event shape. */
+  type: EventType;
+  /** The task this event belongs to. */
+  taskId: string;
+  /** ISO-8601 wall-clock time when the event occurred. */
+  occurredAt: string;
+  /** Schema version (defaults to CURRENT_EVENT_VERSION if omitted). */
+  version: number;
+  /**
+   * Globally-ordered sequence number across all tasks. Assigned by the
+   * EventStore on append; absent before persistence.
+   */
+  globalSeq?: number;
+  /**
+   * Per-task monotonic cursor starting at 0. Assigned by the EventBus before
+   * any subscriber sees the event; absent on events not yet emitted.
+   */
+  taskSeq?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Payload shapes — one interface per event type
+// ---------------------------------------------------------------------------
+
+export interface TaskCreatedPayload {
+  prompt: string;
+  walletPublicKey: string;
+  /** DAG node count at creation time. */
+  dagSize: number;
+}
+
+export interface NodeStartedPayload {
+  agentType: string;
+}
+
+export interface NodeCompletedPayload {
+  /** Arbitrary result returned by the agent. */
+  result: unknown;
+}
+
+export interface NodeFailedPayload {
+  error: string;
+}
+
+export interface PaymentLockedPayload {
+  /** Stellar claimable-balance ID. */
+  balanceId: string;
+  /** Amount in stroops. */
+  amountStroops: number;
+}
+
+export interface PaymentReleasedPayload {
+  /** Stellar transaction hash. */
+  txHash: string;
+}
+
+// task_completed and task_failed carry no additional payload beyond BaseEvent.
+
+// ---------------------------------------------------------------------------
+// Discriminated union
+// ---------------------------------------------------------------------------
+
+export type EventType =
+  | 'TaskCreated'
+  | 'NodeStarted'
+  | 'NodeCompleted'
+  | 'NodeFailed'
+  | 'PaymentLocked'
+  | 'PaymentReleased'
+  | 'TaskCompleted'
+  | 'TaskFailed';
+
+export interface TaskCreatedEvent extends BaseEvent {
+  type: 'TaskCreated';
+  payload: TaskCreatedPayload;
+}
+
+export interface NodeStartedEvent extends BaseEvent {
+  type: 'NodeStarted';
+  /** DAG node this event relates to. */
+  nodeId: string;
+  payload: NodeStartedPayload;
+}
+
+export interface NodeCompletedEvent extends BaseEvent {
+  type: 'NodeCompleted';
+  nodeId: string;
+  payload: NodeCompletedPayload;
+}
+
+export interface NodeFailedEvent extends BaseEvent {
+  type: 'NodeFailed';
+  nodeId: string;
+  payload: NodeFailedPayload;
+}
+
+export interface PaymentLockedEvent extends BaseEvent {
+  type: 'PaymentLocked';
+  nodeId: string;
+  payload: PaymentLockedPayload;
+}
+
+export interface PaymentReleasedEvent extends BaseEvent {
+  type: 'PaymentReleased';
+  nodeId: string;
+  payload: PaymentReleasedPayload;
+}
+
+export interface TaskCompletedEvent extends BaseEvent {
+  type: 'TaskCompleted';
+  payload?: Record<string, never>;
+}
+
+export interface TaskFailedEvent extends BaseEvent {
+  type: 'TaskFailed';
+  payload?: { error?: string };
+}
+
+/** Union of all typed event variants. */
+export type AppEvent =
+  | TaskCreatedEvent
+  | NodeStartedEvent
+  | NodeCompletedEvent
+  | NodeFailedEvent
+  | PaymentLockedEvent
+  | PaymentReleasedEvent
+  | TaskCompletedEvent
+  | TaskFailedEvent;
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+export function isTaskCreated(e: AppEvent): e is TaskCreatedEvent {
+  return e.type === 'TaskCreated';
+}
+
+export function isNodeStarted(e: AppEvent): e is NodeStartedEvent {
+  return e.type === 'NodeStarted';
+}
+
+export function isNodeCompleted(e: AppEvent): e is NodeCompletedEvent {
+  return e.type === 'NodeCompleted';
+}
+
+export function isNodeFailed(e: AppEvent): e is NodeFailedEvent {
+  return e.type === 'NodeFailed';
+}
+
+export function isPaymentLocked(e: AppEvent): e is PaymentLockedEvent {
+  return e.type === 'PaymentLocked';
+}
+
+export function isPaymentReleased(e: AppEvent): e is PaymentReleasedEvent {
+  return e.type === 'PaymentReleased';
+}
+
+export function isTaskCompleted(e: AppEvent): e is TaskCompletedEvent {
+  return e.type === 'TaskCompleted';
+}
+
+export function isTaskFailed(e: AppEvent): e is TaskFailedEvent {
+  return e.type === 'TaskFailed';
+}
+
+// ---------------------------------------------------------------------------
+// Factory helpers — enforce required fields and stamp the current version
+// ---------------------------------------------------------------------------
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function makeTaskCreated(
+  taskId: string,
+  payload: TaskCreatedPayload,
+  occurredAt = nowIso()
+): TaskCreatedEvent {
+  return { type: 'TaskCreated', taskId, occurredAt, version: CURRENT_EVENT_VERSION, payload };
+}
+
+export function makeNodeStarted(
+  taskId: string,
+  nodeId: string,
+  payload: NodeStartedPayload,
+  occurredAt = nowIso()
+): NodeStartedEvent {
+  return { type: 'NodeStarted', taskId, nodeId, occurredAt, version: CURRENT_EVENT_VERSION, payload };
+}
+
+export function makeNodeCompleted(
+  taskId: string,
+  nodeId: string,
+  payload: NodeCompletedPayload,
+  occurredAt = nowIso()
+): NodeCompletedEvent {
+  return { type: 'NodeCompleted', taskId, nodeId, occurredAt, version: CURRENT_EVENT_VERSION, payload };
+}
+
+export function makeNodeFailed(
+  taskId: string,
+  nodeId: string,
+  payload: NodeFailedPayload,
+  occurredAt = nowIso()
+): NodeFailedEvent {
+  return { type: 'NodeFailed', taskId, nodeId, occurredAt, version: CURRENT_EVENT_VERSION, payload };
+}
+
+export function makePaymentLocked(
+  taskId: string,
+  nodeId: string,
+  payload: PaymentLockedPayload,
+  occurredAt = nowIso()
+): PaymentLockedEvent {
+  return { type: 'PaymentLocked', taskId, nodeId, occurredAt, version: CURRENT_EVENT_VERSION, payload };
+}
+
+export function makePaymentReleased(
+  taskId: string,
+  nodeId: string,
+  payload: PaymentReleasedPayload,
+  occurredAt = nowIso()
+): PaymentReleasedEvent {
+  return { type: 'PaymentReleased', taskId, nodeId, occurredAt, version: CURRENT_EVENT_VERSION, payload };
+}
+
+export function makeTaskCompleted(taskId: string, occurredAt = nowIso()): TaskCompletedEvent {
+  return { type: 'TaskCompleted', taskId, occurredAt, version: CURRENT_EVENT_VERSION };
+}
+
+export function makeTaskFailed(
+  taskId: string,
+  error?: string,
+  occurredAt = nowIso()
+): TaskFailedEvent {
+  return {
+    type: 'TaskFailed',
+    taskId,
+    occurredAt,
+    version: CURRENT_EVENT_VERSION,
+    payload: error !== undefined ? { error } : undefined,
+  };
+}

--- a/backend/src/events/projection.ts
+++ b/backend/src/events/projection.ts
@@ -1,0 +1,350 @@
+/**
+ * Event projections — derive read models from a stream of stored events.
+ *
+ * What is a projection?
+ * ─────────────────────
+ * A projection is a read-model built by scanning and aggregating events.  It
+ * answers a specific query efficiently (e.g. "how many tasks completed today?")
+ * without requiring a full task replay or a join-heavy SQL query.
+ *
+ * Each projection function in this module is a pure transform that takes a
+ * slice of `StoredEvent[]` (retrieved via the EventStore) and returns the
+ * derived model.  Callers are responsible for fetching and caching the events;
+ * the projections themselves have no I/O.
+ *
+ * Available projections
+ * ──────────────────────
+ * • `projectTaskSummary`   — lightweight status view per task
+ * • `projectNodeTimeline`  — per-node execution timeline for a single task
+ * • `projectPaymentLedger` — payment records across tasks
+ * • `projectThroughput`    — event-rate stats over a time window
+ * • `buildProjection`      — generic incremental projection runner
+ */
+
+import type { StoredEvent } from './eventStore';
+import type { AppEvent } from './eventTypes';
+import {
+  isNodeCompleted,
+  isNodeFailed,
+  isNodeStarted,
+  isPaymentLocked,
+  isPaymentReleased,
+  isTaskCompleted,
+  isTaskCreated,
+  isTaskFailed,
+} from './eventTypes';
+
+// ---------------------------------------------------------------------------
+// Task summary projection
+// ---------------------------------------------------------------------------
+
+export type TaskSummaryStatus = 'queued' | 'running' | 'completed' | 'failed';
+
+export interface TaskSummary {
+  taskId: string;
+  status: TaskSummaryStatus;
+  prompt?: string;
+  walletPublicKey?: string;
+  nodeCount: number;
+  completedNodeCount: number;
+  failedNodeCount: number;
+  createdAt?: string;
+  completedAt?: string;
+}
+
+/**
+ * Build a lightweight summary view for each distinct task found in `events`.
+ * Suitable for listing pages that show status without full DAG details.
+ *
+ * @param events  Any ordered slice from the event store (may span multiple tasks).
+ */
+export function projectTaskSummary(
+  events: ReadonlyArray<StoredEvent | AppEvent>
+): Map<string, TaskSummary> {
+  const summaries = new Map<string, TaskSummary>();
+
+  function ensure(taskId: string): TaskSummary {
+    let s = summaries.get(taskId);
+    if (!s) {
+      s = {
+        taskId,
+        status: 'queued',
+        nodeCount: 0,
+        completedNodeCount: 0,
+        failedNodeCount: 0,
+      };
+      summaries.set(taskId, s);
+    }
+    return s;
+  }
+
+  for (const event of events as AppEvent[]) {
+    const s = ensure(event.taskId);
+
+    if (isTaskCreated(event)) {
+      s.prompt = event.payload.prompt;
+      s.walletPublicKey = event.payload.walletPublicKey;
+      s.createdAt = event.occurredAt;
+      s.status = 'queued';
+      continue;
+    }
+
+    if (isNodeStarted(event)) {
+      s.status = 'running';
+      s.nodeCount += 1;
+      continue;
+    }
+
+    if (isNodeCompleted(event)) {
+      s.completedNodeCount += 1;
+      continue;
+    }
+
+    if (isNodeFailed(event)) {
+      s.failedNodeCount += 1;
+      continue;
+    }
+
+    if (isTaskCompleted(event)) {
+      s.status = 'completed';
+      s.completedAt = event.occurredAt;
+      continue;
+    }
+
+    if (isTaskFailed(event)) {
+      s.status = 'failed';
+      s.completedAt = event.occurredAt;
+    }
+  }
+
+  return summaries;
+}
+
+// ---------------------------------------------------------------------------
+// Node timeline projection
+// ---------------------------------------------------------------------------
+
+export interface NodeTimelineEntry {
+  nodeId: string;
+  agentType?: string;
+  startedAt?: string;
+  settledAt?: string;
+  durationMs?: number;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  error?: string;
+}
+
+/**
+ * Build an execution timeline for every node in a single task.
+ * Nodes appear in the map ordered by first-seen event.
+ *
+ * @param events  Events for a single task (e.g. from `store.listByTask(taskId)`).
+ */
+export function projectNodeTimeline(
+  events: ReadonlyArray<StoredEvent | AppEvent>
+): Map<string, NodeTimelineEntry> {
+  const timeline = new Map<string, NodeTimelineEntry>();
+
+  function ensure(nodeId: string): NodeTimelineEntry {
+    let entry = timeline.get(nodeId);
+    if (!entry) {
+      entry = { nodeId, status: 'pending' };
+      timeline.set(nodeId, entry);
+    }
+    return entry;
+  }
+
+  for (const event of events as AppEvent[]) {
+    if (!('nodeId' in event) || !event.nodeId) continue;
+
+    const entry = ensure(event.nodeId);
+
+    if (isNodeStarted(event)) {
+      entry.status = 'running';
+      entry.agentType = event.payload.agentType;
+      entry.startedAt = event.occurredAt;
+      continue;
+    }
+
+    if (isNodeCompleted(event)) {
+      entry.status = 'completed';
+      entry.settledAt = event.occurredAt;
+      if (entry.startedAt) {
+        entry.durationMs =
+          new Date(entry.settledAt).getTime() - new Date(entry.startedAt).getTime();
+      }
+      continue;
+    }
+
+    if (isNodeFailed(event)) {
+      entry.status = 'failed';
+      entry.error = event.payload.error;
+      entry.settledAt = event.occurredAt;
+      if (entry.startedAt) {
+        entry.durationMs =
+          new Date(entry.settledAt).getTime() - new Date(entry.startedAt).getTime();
+      }
+    }
+  }
+
+  return timeline;
+}
+
+// ---------------------------------------------------------------------------
+// Payment ledger projection
+// ---------------------------------------------------------------------------
+
+export type PaymentEntryStatus = 'locked' | 'released';
+
+export interface PaymentEntry {
+  taskId: string;
+  nodeId: string;
+  balanceId?: string;
+  amountStroops?: number;
+  txHash?: string;
+  status: PaymentEntryStatus;
+  lockedAt?: string;
+  releasedAt?: string;
+}
+
+/**
+ * Build a payment ledger across all tasks in the provided event slice.
+ * Each entry represents a single (taskId, nodeId) payment lifecycle.
+ *
+ * @param events  Any ordered event slice (may span multiple tasks).
+ */
+export function projectPaymentLedger(
+  events: ReadonlyArray<StoredEvent | AppEvent>
+): Map<string, PaymentEntry> {
+  // Key: `${taskId}:${nodeId}`
+  const ledger = new Map<string, PaymentEntry>();
+
+  for (const event of events as AppEvent[]) {
+    if (!('nodeId' in event) || !event.nodeId) continue;
+
+    const key = `${event.taskId}:${event.nodeId}`;
+
+    if (isPaymentLocked(event)) {
+      ledger.set(key, {
+        taskId: event.taskId,
+        nodeId: event.nodeId,
+        balanceId: event.payload.balanceId,
+        amountStroops: event.payload.amountStroops,
+        status: 'locked',
+        lockedAt: event.occurredAt,
+      });
+      continue;
+    }
+
+    if (isPaymentReleased(event)) {
+      const existing = ledger.get(key);
+      if (existing) {
+        existing.status = 'released';
+        existing.txHash = event.payload.txHash;
+        existing.releasedAt = event.occurredAt;
+      } else {
+        // PaymentReleased arrived without a preceding PaymentLocked (e.g. in
+        // a partial replay window) — create a partial entry.
+        ledger.set(key, {
+          taskId: event.taskId,
+          nodeId: event.nodeId,
+          txHash: event.payload.txHash,
+          status: 'released',
+          releasedAt: event.occurredAt,
+        });
+      }
+    }
+  }
+
+  return ledger;
+}
+
+// ---------------------------------------------------------------------------
+// Throughput projection
+// ---------------------------------------------------------------------------
+
+export interface ThroughputStats {
+  /** Total events processed. */
+  totalEvents: number;
+  /** Distinct tasks seen. */
+  distinctTasks: number;
+  /** Tasks that reached TaskCompleted. */
+  completedTasks: number;
+  /** Tasks that reached TaskFailed. */
+  failedTasks: number;
+  /** Count per EventType. */
+  countByType: Record<string, number>;
+  /** Earliest occurredAt in the slice (ISO-8601). */
+  windowStart?: string;
+  /** Latest occurredAt in the slice (ISO-8601). */
+  windowEnd?: string;
+}
+
+/**
+ * Compute throughput statistics for an event slice.
+ * Useful for dashboards and alerting.
+ *
+ * @param events  Any ordered event slice.
+ */
+export function projectThroughput(
+  events: ReadonlyArray<StoredEvent | AppEvent>
+): ThroughputStats {
+  const tasks = new Set<string>();
+  let completedTasks = 0;
+  let failedTasks = 0;
+  const countByType: Record<string, number> = {};
+  let windowStart: string | undefined;
+  let windowEnd: string | undefined;
+
+  for (const event of events as AppEvent[]) {
+    tasks.add(event.taskId);
+    countByType[event.type] = (countByType[event.type] ?? 0) + 1;
+
+    if (!windowStart || event.occurredAt < windowStart) windowStart = event.occurredAt;
+    if (!windowEnd || event.occurredAt > windowEnd) windowEnd = event.occurredAt;
+
+    if (isTaskCompleted(event)) completedTasks += 1;
+    if (isTaskFailed(event)) failedTasks += 1;
+  }
+
+  return {
+    totalEvents: events.length,
+    distinctTasks: tasks.size,
+    completedTasks,
+    failedTasks,
+    countByType,
+    windowStart,
+    windowEnd,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Generic incremental projection runner
+// ---------------------------------------------------------------------------
+
+/**
+ * A reducer function that takes the current state and an event, and returns
+ * the next state.  Must be a pure function (no mutations of `state`).
+ */
+export type ProjectionReducer<S> = (state: S, event: AppEvent) => S;
+
+/**
+ * Run a custom {@link ProjectionReducer} over an event slice, starting from
+ * an optional initial state.
+ *
+ * @example
+ * const nodeCount = buildProjection(events, 0, (count, e) =>
+ *   e.type === 'NodeStarted' ? count + 1 : count
+ * );
+ */
+export function buildProjection<S>(
+  events: ReadonlyArray<StoredEvent | AppEvent>,
+  initialState: S,
+  reducer: ProjectionReducer<S>
+): S {
+  let state = initialState;
+  for (const event of events) {
+    state = reducer(state, event as AppEvent);
+  }
+  return state;
+}

--- a/backend/src/events/replay.ts
+++ b/backend/src/events/replay.ts
@@ -25,6 +25,7 @@ import {
   isNodeCompleted,
   isNodeFailed,
   isNodeStarted,
+  isPaymentLocked,
   isPaymentReleased,
   isTaskCompleted,
   isTaskCreated,
@@ -59,6 +60,12 @@ export interface ReplayedNode {
   startedAt?: string;
   /** ISO-8601 timestamp of the NodeCompleted or NodeFailed event. */
   settledAt?: string;
+  /** ISO-8601 timestamp of the PaymentLocked event. */
+  paymentLockedAt?: string;
+  /** Stellar claimable-balance ID from the PaymentLocked event. */
+  balanceId?: string;
+  /** Locked amount in stroops from the PaymentLocked event. */
+  amountStroops?: number;
   /** Stellar transaction hash from the matching PaymentReleased event. */
   paymentTxHash?: string;
 }
@@ -138,6 +145,14 @@ function applyEvent(state: ReplayedTaskState, event: AppEvent): void {
     node.status = 'failed';
     node.error = p.error;
     node.settledAt = event.occurredAt;
+    return;
+  }
+
+  if (isPaymentLocked(event)) {
+    const node = ensureNode(state, event.nodeId);
+    node.paymentLockedAt = event.occurredAt;
+    node.balanceId = event.payload.balanceId;
+    node.amountStroops = event.payload.amountStroops;
     return;
   }
 

--- a/backend/src/events/replay.ts
+++ b/backend/src/events/replay.ts
@@ -1,0 +1,232 @@
+/**
+ * Event replay — reconstruct task state from a stored event history.
+ *
+ * Usage
+ * ─────
+ *   const store = createEventStore();
+ *   const state = replayTask(store.listByTask(taskId));
+ *
+ * The replay fold is a pure function: it takes an ordered list of events and
+ * returns the current `TaskState`.  This means it can be used for debugging
+ * (inspect any historical snapshot), hydration (bootstrap the in-memory
+ * coordinator state on server restart), and testing (drive state with
+ * hand-crafted event sequences without touching the DB).
+ */
+
+import type { StoredEvent } from './eventStore';
+import type {
+  AppEvent,
+  NodeCompletedPayload,
+  NodeFailedPayload,
+  NodeStartedPayload,
+  TaskCreatedPayload,
+} from './eventTypes';
+import {
+  isNodeCompleted,
+  isNodeFailed,
+  isNodeStarted,
+  isPaymentReleased,
+  isTaskCompleted,
+  isTaskCreated,
+  isTaskFailed,
+} from './eventTypes';
+
+// ---------------------------------------------------------------------------
+// Reconstructed state shapes
+// ---------------------------------------------------------------------------
+
+export type ReplayedTaskStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'unknown';
+
+export type ReplayedNodeStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'failed';
+
+export interface ReplayedNode {
+  nodeId: string;
+  /** Agent type derived from NodeStarted payload. */
+  agentType?: string;
+  status: ReplayedNodeStatus;
+  result?: unknown;
+  error?: string;
+  /** ISO-8601 timestamp of the NodeStarted event. */
+  startedAt?: string;
+  /** ISO-8601 timestamp of the NodeCompleted or NodeFailed event. */
+  settledAt?: string;
+  /** Stellar transaction hash from the matching PaymentReleased event. */
+  paymentTxHash?: string;
+}
+
+export interface ReplayedTaskState {
+  taskId: string;
+  status: ReplayedTaskStatus;
+  /** Reconstructed prompt — only available if a TaskCreated event was stored. */
+  prompt?: string;
+  walletPublicKey?: string;
+  /** Node states keyed by nodeId. */
+  nodes: Map<string, ReplayedNode>;
+  /** ISO-8601 creation time from TaskCreated event. */
+  createdAt?: string;
+  /** ISO-8601 time of the terminal event (TaskCompleted / TaskFailed). */
+  completedAt?: string;
+  /** Error message from the terminal TaskFailed event (if present). */
+  terminalError?: string;
+  /** Sequence number of the last event applied to this state. */
+  lastTaskSeq: number;
+  /** Total number of events applied. */
+  eventCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ensureNode(state: ReplayedTaskState, nodeId: string): ReplayedNode {
+  let node = state.nodes.get(nodeId);
+  if (!node) {
+    node = { nodeId, status: 'pending' };
+    state.nodes.set(nodeId, node);
+  }
+  return node;
+}
+
+function applyEvent(state: ReplayedTaskState, event: AppEvent): void {
+  // Advance the cursor regardless of event type.
+  state.eventCount += 1;
+  const seq = event.taskSeq;
+  if (seq !== undefined && seq > state.lastTaskSeq) {
+    state.lastTaskSeq = seq;
+  }
+
+  if (isTaskCreated(event)) {
+    const p = event.payload as TaskCreatedPayload;
+    state.prompt = p.prompt;
+    state.walletPublicKey = p.walletPublicKey;
+    state.createdAt = event.occurredAt;
+    state.status = 'queued';
+    return;
+  }
+
+  if (isNodeStarted(event)) {
+    const node = ensureNode(state, event.nodeId);
+    const p = event.payload as NodeStartedPayload;
+    node.status = 'running';
+    node.agentType = p.agentType;
+    node.startedAt = event.occurredAt;
+    if (state.status === 'queued') state.status = 'running';
+    return;
+  }
+
+  if (isNodeCompleted(event)) {
+    const node = ensureNode(state, event.nodeId);
+    const p = event.payload as NodeCompletedPayload;
+    node.status = 'completed';
+    node.result = p.result;
+    node.settledAt = event.occurredAt;
+    return;
+  }
+
+  if (isNodeFailed(event)) {
+    const node = ensureNode(state, event.nodeId);
+    const p = event.payload as NodeFailedPayload;
+    node.status = 'failed';
+    node.error = p.error;
+    node.settledAt = event.occurredAt;
+    return;
+  }
+
+  if (isPaymentReleased(event)) {
+    const node = ensureNode(state, event.nodeId);
+    node.paymentTxHash = event.payload.txHash;
+    return;
+  }
+
+  if (isTaskCompleted(event)) {
+    state.status = 'completed';
+    state.completedAt = event.occurredAt;
+    return;
+  }
+
+  if (isTaskFailed(event)) {
+    state.status = 'failed';
+    state.completedAt = event.occurredAt;
+    state.terminalError = event.payload?.error;
+    return;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconstruct the full task state by folding an ordered event history.
+ *
+ * @param events  Ordered slice of stored events (typically the result of
+ *                `store.listByTask(taskId)`).
+ * @returns       The task state as of the last event in the slice.
+ *                Returns `undefined` when `events` is empty.
+ */
+export function replayTask(
+  events: ReadonlyArray<AppEvent | StoredEvent>
+): ReplayedTaskState | undefined {
+  if (events.length === 0) return undefined;
+
+  const first = events[0];
+  const state: ReplayedTaskState = {
+    taskId: first.taskId,
+    status: 'unknown',
+    nodes: new Map(),
+    lastTaskSeq: -1,
+    eventCount: 0,
+  };
+
+  for (const event of events) {
+    applyEvent(state, event as AppEvent);
+  }
+
+  return state;
+}
+
+/**
+ * Replay events up to (and including) the event at `targetSeq`.
+ *
+ * Useful for debugging: "what did the task look like after event 5?".
+ *
+ * @param events     Full ordered event history for the task.
+ * @param targetSeq  The `taskSeq` value to stop at (inclusive).
+ */
+export function replayTaskUpTo(
+  events: ReadonlyArray<AppEvent | StoredEvent>,
+  targetSeq: number
+): ReplayedTaskState | undefined {
+  const slice = events.filter(
+    e => e.taskSeq === undefined || e.taskSeq <= targetSeq
+  );
+  return replayTask(slice);
+}
+
+/**
+ * Incrementally apply a single new event onto an existing `ReplayedTaskState`.
+ * Mutates `state` in place and returns it.
+ *
+ * Use this to keep an in-memory view current as new events arrive, rather than
+ * replaying the full history from scratch on every event.
+ *
+ * @param state  The current task state (must have been created by
+ *               {@link replayTask} or a previous call to this function).
+ * @param event  The new event to apply.
+ */
+export function applyEventToState(
+  state: ReplayedTaskState,
+  event: AppEvent | StoredEvent
+): ReplayedTaskState {
+  applyEvent(state, event as AppEvent);
+  return state;
+}


### PR DESCRIPTION
## Summary

Closes #278

Formalizes the event system into a proper event store with full event sourcing semantics: append-only log, typed events, state reconstruction via replay, read-model projections, and SQLite persistence with proper indexing.

---

## What was built

### New files

| File | Description |
|------|-------------|
| `backend/src/events/eventTypes.ts` | Typed discriminated union (`TaskCreated`, `NodeStarted`, `NodeCompleted`, `NodeFailed`, `PaymentLocked`, `PaymentReleased`, `TaskCompleted`, `TaskFailed`) with factory helpers, type guards, and schema versioning |
| `backend/src/events/eventStore.ts` | Append-only SQLite-backed `EventStore`: `listByTask`, `listByTaskSince` (cursor resume), `listByTimeRange`, `listByType`; globally-ordered `globalSeq` + per-task `taskSeq`; WAL mode; DDL auto-applied on construction |
| `backend/src/events/replay.ts` | Pure `replayTask` / `replayTaskUpTo` / `applyEventToState` — reconstruct full `TaskState` from any event slice; supports point-in-time snapshots for debugging |
| `backend/src/events/projection.ts` | Four read-model projections: `projectTaskSummary`, `projectNodeTimeline` (with `durationMs`), `projectPaymentLedger` (locked → released lifecycle), `projectThroughput`; plus generic `buildProjection` reducer runner |
| `backend/src/db/events.sql` | Canonical DDL with three indexes: `(task_id, task_seq)`, `occurred_at`, `(type, occurred_at)` |
| `backend/src/events/eventStore.test.ts` | 47 unit tests covering: append + `globalSeq` monotonicity, `UNIQUE(task_id, task_seq)` constraint, cursor replay, time-range query, type filter, full replay, point-in-time snapshots, incremental state update, all four projections, and a full store + replay round-trip |

### Modified files

| File | Change |
|------|--------|
| `backend/src/coordinator/eventBus.ts` | Injects `EventStore`; stamps per-task monotonic `taskSeq` before any subscriber sees the event; persists every `DAGEvent` to the store **before** delivering to live WebSocket handlers (guarantees DB row exists when stream handlers query `listByTaskSince`) |
| `backend/src/coordinator/eventStore.ts` | Replaced legacy standalone impl with a compatibility shim delegating to the canonical store — legacy `DAGEvent`-based import path stays intact for existing tests |

---

## Acceptance criteria checklist

- [x] Event store with append-only log structure
- [x] Events typed: `TaskCreated`, `NodeStarted`, `NodeCompleted`, `NodeFailed`, `PaymentLocked`, `PaymentReleased`
- [x] Event replay: reconstruct task state from event history
- [x] Event projection: derive read models from event stream
- [x] Event versioning for backward compatibility (`version` field on every event, `CURRENT_EVENT_VERSION` constant)
- [x] Event store backed by SQLite with proper indexing
- [x] Query: get all events for a task, get events in time range
- [x] Unit tests for event append, replay, and projection

---

## Testing

```bash
cd backend
npm test
# 301 tests pass, 0 new failures introduced
```

The 4 pre-existing failures in `tests/agents.test.ts` (heartbeat 204 vs 200, Stellar key validation) are unrelated to this PR and existed on `main` before these changes.

---

## Notes for maintainers / @GrantFox

- All monetary amounts in events use **stroops** (integers) to avoid floating-point rounding on Stellar payment values.
- The `EventStore` is injected into `EventBus` so it can be swapped for a file-backed DB in production or a fresh in-memory DB in tests — zero-config by default.
- Projections are pure functions (no I/O) so they compose freely with any event slice from the store.
- The compatibility shim in `coordinator/eventStore.ts` means **no existing callers need updating** — both import paths work.