### PR TITLE
feat(ui): implement skeleton loading states for all pages

### DIFF
--- a/frontend/src/components/common/Skeleton.module.css
+++ b/frontend/src/components/common/Skeleton.module.css
@@ -1,11 +1,95 @@
 .skeleton {
-  background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
+  display: block;
+  background-color: var(--skeleton-base);
+  background-image: linear-gradient(
+    90deg,
+    var(--skeleton-base) 25%,
+    var(--skeleton-shine) 50%,
+    var(--skeleton-base) 75%
+  );
   background-size: 200% 100%;
-  animation: shimmer 1.5s infinite;
+  background-repeat: no-repeat;
+  animation: shimmer 1.5s ease-in-out infinite;
   border-radius: 4px;
+  color: transparent;
+  user-select: none;
+  pointer-events: none;
 }
 
 @keyframes shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Variants */
+.text {
+  border-radius: 4px;
+}
+
+.pill {
+  border-radius: 9999px;
+}
+
+.circular {
+  border-radius: 50%;
+}
+
+.rectangular {
+  border-radius: 0;
+}
+
+/* Composable primitives */
+.card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.textLines {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tableRow {
+  display: grid;
+  gap: 1rem;
+}
+
+/* Fade-in helper so loaded content eases in over a skeleton. */
+.fadeIn {
+  animation: fadeIn 200ms ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Respect users who prefer reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    background-image: none;
+    background-color: var(--skeleton-base);
+  }
+
+  .fadeIn {
+    animation: none;
+  }
 }

--- a/frontend/src/components/common/Skeleton.test.tsx
+++ b/frontend/src/components/common/Skeleton.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import {
+  Skeleton,
+  SkeletonText,
+  SkeletonCard,
+  SkeletonTable,
+  SkeletonAvatar,
+} from './Skeleton'
+
+describe('Skeleton', () => {
+  it('renders an aria-hidden block with the requested dimensions', () => {
+    render(<Skeleton width="50%" height="2rem" data-testid="skeleton" />)
+
+    const el = screen.getByTestId('skeleton')
+    expect(el).toHaveAttribute('aria-hidden', 'true')
+    expect(el).toHaveStyle({ width: '50%', height: '2rem' })
+  })
+
+  it('applies the circular variant class for round placeholders', () => {
+    render(<Skeleton variant="circular" data-testid="skeleton" />)
+    expect(screen.getByTestId('skeleton').className).toContain('circular')
+  })
+
+  it('applies the pill variant class for chip placeholders', () => {
+    render(<Skeleton variant="pill" data-testid="skeleton" />)
+    expect(screen.getByTestId('skeleton').className).toContain('pill')
+  })
+})
+
+describe('SkeletonText', () => {
+  it('renders the requested number of lines', () => {
+    render(<SkeletonText lines={4} />)
+    expect(screen.getAllByTestId('skeleton-text-line')).toHaveLength(4)
+  })
+
+  it('renders the final line shorter than the rest', () => {
+    render(<SkeletonText lines={3} lastLineWidth="40%" />)
+
+    const lines = screen.getAllByTestId('skeleton-text-line')
+    expect(lines[0]).toHaveStyle({ width: '100%' })
+    expect(lines[2]).toHaveStyle({ width: '40%' })
+  })
+})
+
+describe('SkeletonAvatar', () => {
+  it('renders a circular skeleton at the given size', () => {
+    render(<SkeletonAvatar size={64} data-testid="avatar" />)
+
+    const el = screen.getByTestId('avatar')
+    expect(el).toHaveStyle({ width: '64px', height: '64px' })
+    expect(el.className).toContain('circular')
+  })
+})
+
+describe('SkeletonTable', () => {
+  it('renders the requested number of rows', () => {
+    render(<SkeletonTable rows={3} columns={4} />)
+    expect(screen.getAllByTestId('skeleton-table-row')).toHaveLength(3)
+  })
+})
+
+describe('SkeletonCard', () => {
+  it('renders children inside a card', () => {
+    render(
+      <SkeletonCard data-testid="card">
+        <span data-testid="child" />
+      </SkeletonCard>
+    )
+
+    expect(screen.getByTestId('card')).toContainElement(screen.getByTestId('child'))
+  })
+})

--- a/frontend/src/components/common/Skeleton.tsx
+++ b/frontend/src/components/common/Skeleton.tsx
@@ -2,10 +2,134 @@
 import React from 'react';
 import styles from './Skeleton.module.css';
 
-export const Skeleton: React.FC<{ width?: string; height?: string }> = ({ width = '100%', height = '1rem' }) => (
+export type SkeletonVariant = 'text' | 'pill' | 'circular' | 'rectangular';
+
+export interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  variant?: SkeletonVariant;
+  className?: string;
+  style?: React.CSSProperties;
+  'data-testid'?: string;
+}
+
+const variantClass = (variant: SkeletonVariant): string => {
+  switch (variant) {
+    case 'pill':
+      return styles.pill;
+    case 'circular':
+      return styles.circular;
+    case 'rectangular':
+      return styles.rectangular;
+    case 'text':
+    default:
+      return styles.text;
+  }
+};
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  width = '100%',
+  height = '1rem',
+  variant = 'text',
+  className,
+  style,
+  'data-testid': testId,
+}) => (
   <div
-    className={styles.skeleton}
-    style={{ width, height }}
+    className={[styles.skeleton, variantClass(variant), className].filter(Boolean).join(' ')}
+    style={{ width, height, ...style }}
     aria-hidden="true"
+    data-testid={testId}
   />
+);
+
+export interface SkeletonTextProps {
+  lines?: number;
+  width?: string | number;
+  height?: string | number;
+  /** Width of the final line, which is typically shorter to mimic prose. */
+  lastLineWidth?: string | number;
+  className?: string;
+  'data-testid'?: string;
+}
+
+export const SkeletonText: React.FC<SkeletonTextProps> = ({
+  lines = 3,
+  width = '100%',
+  height = '1rem',
+  lastLineWidth = '60%',
+  className,
+  'data-testid': testId,
+}) => (
+  <div className={[styles.textLines, className].filter(Boolean).join(' ')} data-testid={testId}>
+    {Array.from({ length: lines }, (_, i) => (
+      <Skeleton
+        key={i}
+        width={i === lines - 1 ? lastLineWidth : width}
+        height={height}
+        data-testid="skeleton-text-line"
+      />
+    ))}
+  </div>
+);
+
+export interface SkeletonCardProps {
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  'data-testid'?: string;
+}
+
+export const SkeletonCard: React.FC<SkeletonCardProps> = ({
+  children,
+  className,
+  style,
+  'data-testid': testId,
+}) => (
+  <div className={[styles.card, className].filter(Boolean).join(' ')} style={style} data-testid={testId}>
+    {children}
+  </div>
+);
+
+export interface SkeletonAvatarProps {
+  size?: number;
+  className?: string;
+  'data-testid'?: string;
+}
+
+export const SkeletonAvatar: React.FC<SkeletonAvatarProps> = ({
+  size = 40,
+  className,
+  'data-testid': testId,
+}) => (
+  <Skeleton variant="circular" width={size} height={size} className={className} data-testid={testId} />
+);
+
+export interface SkeletonTableProps {
+  rows?: number;
+  columns?: number;
+  className?: string;
+  'data-testid'?: string;
+}
+
+export const SkeletonTable: React.FC<SkeletonTableProps> = ({
+  rows = 5,
+  columns = 4,
+  className,
+  'data-testid': testId,
+}) => (
+  <div className={[styles.table, className].filter(Boolean).join(' ')} data-testid={testId}>
+    {Array.from({ length: rows }, (_, r) => (
+      <div
+        key={r}
+        className={styles.tableRow}
+        style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+        data-testid="skeleton-table-row"
+      >
+        {Array.from({ length: columns }, (_, c) => (
+          <Skeleton key={c} width="100%" height="1rem" />
+        ))}
+      </div>
+    ))}
+  </div>
 );

--- a/frontend/src/components/dashboard/DashboardLayout.tsx
+++ b/frontend/src/components/dashboard/DashboardLayout.tsx
@@ -4,8 +4,9 @@ import styles from './DashboardLayout.module.css';
 
 interface Props {
   children: ReactNode;
+  className?: string;
 }
 
-export const DashboardLayout: React.FC<Props> = ({ children }) => {
-  return <section className={styles.container}>{children}</section>;
+export const DashboardLayout: React.FC<Props> = ({ children, className }) => {
+  return <section className={[styles.container, className].filter(Boolean).join(' ')}>{children}</section>;
 };

--- a/frontend/src/pages/AgentsPage.module.css
+++ b/frontend/src/pages/AgentsPage.module.css
@@ -56,3 +56,43 @@
   transform: none;
   box-shadow: none;
 }
+
+/* Page skeleton */
+.filterSkeleton {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 24px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+}
+
+.filterGroupSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tableSkeleton {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tableHeaderRow {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1rem;
+  padding: 0 16px;
+}

--- a/frontend/src/pages/AgentsPage.test.tsx
+++ b/frontend/src/pages/AgentsPage.test.tsx
@@ -70,10 +70,10 @@ describe('AgentsPage - rendering', () => {
     expect(screen.getByTestId('agent-row-agent-audit-003')).toBeInTheDocument()
   })
 
-  it('shows a 5-row skeleton while loading', () => {
+  it('shows the dedicated page skeleton while loading', () => {
     getAgents.mockReturnValue(new Promise(() => {})) // never resolves
     renderPage()
-    expect(screen.getAllByTestId('agent-skeleton-row')).toHaveLength(5)
+    expect(screen.getByTestId('agents-page-skeleton')).toBeInTheDocument()
   })
 
   it('renders the empty state when the API returns []', async () => {
@@ -213,6 +213,7 @@ describe('AgentsPage - auto-refresh', () => {
       expect(screen.getByTestId('agent-row-agent-new-004')).toBeInTheDocument()
     })
     // Refresh must not flash the loading skeleton.
+    expect(screen.queryByTestId('agents-page-skeleton')).not.toBeInTheDocument()
     expect(screen.queryByTestId('agent-skeleton-row')).not.toBeInTheDocument()
     expect(getAgents).toHaveBeenCalledTimes(2)
   })

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -4,6 +4,7 @@ import { useAgentRegistry } from '../hooks/useAgentRegistry'
 import { AgentTable } from '../components/agents/AgentTable'
 import { AgentFilterBar } from '../components/agents/AgentFilterBar'
 import { AgentDetailModal } from '../components/agents/AgentDetailModal'
+import { Skeleton, SkeletonTable } from '../components/common/Skeleton'
 import type { AgentRecord } from '../types/api'
 import {
   allCapabilities,
@@ -15,6 +16,43 @@ import {
   type SortKey,
 } from '../utils/agentRegistry'
 import styles from './AgentsPage.module.css'
+
+const TABLE_COLUMNS = 6
+const SKELETON_ROWS = 5
+
+/**
+ * Context-aware skeleton that mirrors the filter bar and agent table layout
+ * so there is no layout shift between the loading and loaded states.
+ */
+export function AgentsPageSkeleton() {
+  return (
+    <div data-testid="agents-page-skeleton" aria-busy="true" aria-label="Loading agent registry">
+      <div className={styles.filterSkeleton}>
+        <div className={styles.filterGroupSkeleton}>
+          <Skeleton width="6rem" height="0.75rem" />
+          <div className={styles.chipRow}>
+            <Skeleton variant="pill" width="5rem" height="1.5rem" />
+            <Skeleton variant="pill" width="5rem" height="1.5rem" />
+            <Skeleton variant="pill" width="5rem" height="1.5rem" />
+          </div>
+        </div>
+        <div className={styles.filterGroupSkeleton}>
+          <Skeleton width="8rem" height="0.75rem" />
+          <Skeleton width="10rem" height="0.4rem" />
+        </div>
+      </div>
+
+      <div className={styles.tableSkeleton}>
+        <div className={styles.tableHeaderRow} aria-hidden="true">
+          {Array.from({ length: TABLE_COLUMNS }, (_, i) => (
+            <Skeleton key={i} height="1rem" />
+          ))}
+        </div>
+        <SkeletonTable rows={SKELETON_ROWS} columns={TABLE_COLUMNS} />
+      </div>
+    </div>
+  )
+}
 
 function AgentsPage() {
   const { agents, loading, error, refetch } = useAgentRegistry()
@@ -80,8 +118,10 @@ function AgentsPage() {
             Retry
           </button>
         </div>
+      ) : loading && agents.length === 0 ? (
+        <AgentsPageSkeleton />
       ) : (
-        <>
+        <div className="fade-in">
           <AgentFilterBar
             filters={filters}
             availableCapabilities={capabilities}
@@ -99,7 +139,7 @@ function AgentsPage() {
             onSort={handleSort}
             onRowClick={setSelected}
           />
-        </>
+        </div>
       )}
 
       <AgentDetailModal agent={selected} onClose={() => setSelected(null)} />

--- a/frontend/src/pages/TaskDetailPage.tsx
+++ b/frontend/src/pages/TaskDetailPage.tsx
@@ -5,7 +5,8 @@ import 'reactflow/dist/style.css';
 import { useTaskMonitor } from '../hooks/useTaskMonitor';
 import { AgentOutputPanel } from '../components/dashboard/AgentOutputPanel';
 import { PaymentTimeline } from '../components/dashboard/PaymentTimeline';
-import { AlertCircle, CheckCircle2, Loader2, Play, RefreshCw } from 'lucide-react';
+import { Skeleton, SkeletonText } from '../components/common/Skeleton';
+import { AlertCircle, CheckCircle2, Play, RefreshCw } from 'lucide-react';
 
 const CustomNode: React.FC<{ id: string; data: { label: string; status: string } }> = ({ id, data }) => {
   return (
@@ -28,6 +29,48 @@ const CustomNode: React.FC<{ id: string; data: { label: string; status: string }
 const nodeTypes = {
   custom: CustomNode,
 };
+
+/**
+ * Context-aware skeleton that mirrors the task detail layout (header, DAG
+ * panel, output/payment panels) so there is no layout shift on load.
+ */
+export const TaskDetailSkeleton: React.FC = () => (
+  <div className="space-y-6" data-testid="task-detail-skeleton" aria-busy="true" aria-label="Loading task details">
+    {/* Details Header */}
+    <div className="glass-panel flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+      <div className="w-full md:w-2/3">
+        <div className="flex items-center gap-3">
+          <Skeleton width="12rem" height="1.75rem" />
+          <Skeleton variant="pill" width="6rem" height="1.25rem" />
+        </div>
+        <Skeleton width="16rem" height="0.75rem" className="mt-2" />
+        <Skeleton width="80%" height="1rem" className="mt-3" />
+      </div>
+      <div className="flex items-center gap-3">
+        <Skeleton width="6rem" height="2.5rem" />
+        <Skeleton width="4rem" height="2.5rem" />
+      </div>
+    </div>
+
+    {/* DAG Graph Panel */}
+    <div className="glass-panel relative flex flex-col">
+      <div className="flex items-center gap-2 mb-3">
+        <Skeleton width="12rem" height="1rem" />
+      </div>
+      <Skeleton variant="rectangular" width="100%" height="280px" className="rounded-xl" />
+    </div>
+
+    {/* Combined Panels */}
+    <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+      <div className="glass-panel lg:col-span-3">
+        <SkeletonText lines={6} />
+      </div>
+      <div className="glass-panel lg:col-span-2">
+        <SkeletonText lines={4} />
+      </div>
+    </div>
+  </div>
+);
 
 const TaskDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -129,12 +172,7 @@ const TaskDetailPage: React.FC = () => {
   }, [nodes]);
 
   if (loading && !nodes.length) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[400px]">
-        <Loader2 className="animate-spin text-indigo-500 mb-4" size={40} />
-        <p className="text-slate-400">Loading live task execution status...</p>
-      </div>
-    );
+    return <TaskDetailSkeleton />;
   }
 
   if (error) {
@@ -183,7 +221,7 @@ const TaskDetailPage: React.FC = () => {
   const wsBadge = getWsStatusBadge();
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 fade-in">
       {/* Task failed banner */}
       {failedNode && (
         <div className="p-4 bg-rose-950/60 border border-rose-500/50 rounded-xl flex items-start gap-3 text-rose-200 animate-fadeIn" role="alert">

--- a/frontend/src/pages/WalletPage.module.css
+++ b/frontend/src/pages/WalletPage.module.css
@@ -325,6 +325,42 @@
   gap: 24px;
 }
 
+/* Page skeleton */
+.balanceCardSkeleton {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 28px;
+  margin-bottom: 32px;
+}
+
+.balanceSkeletonSection {
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.publicKeySkeleton {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-color);
+}
+
+.publicKeySkeletonDetails {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.panelSkeleton {
+  min-height: 240px;
+}
+
 .sendSection {
   min-width: 0;
 }

--- a/frontend/src/pages/WalletPage.tsx
+++ b/frontend/src/pages/WalletPage.tsx
@@ -6,9 +6,51 @@ import { useWalletBalance } from '../hooks/useWalletBalance'
 import { useTransactionHistory } from '../hooks/useTransactionHistory'
 import { SendXLMForm } from '../components/wallet/SendXLMForm'
 import { TransactionTable } from '../components/wallet/TransactionTable'
+import { Skeleton, SkeletonAvatar, SkeletonCard, SkeletonText } from '../components/common/Skeleton'
 import styles from './WalletPage.module.css'
 
 const STELLAR_EXPLORER = 'https://stellar.expert/explorer/testnet'
+
+/**
+ * Context-aware skeleton that mirrors the connected wallet layout so there is
+ * no layout shift between the loading and loaded states.
+ */
+export function WalletPageSkeleton() {
+  return (
+    <div className={styles.page} data-testid="wallet-page-skeleton" aria-busy="true" aria-label="Loading wallet">
+      <div className={styles.header}>
+        <h1 className={styles.title}>
+          <Wallet size={24} />
+          Wallet
+        </h1>
+      </div>
+
+      <div className={styles.balanceCardSkeleton}>
+        <div className={styles.balanceSkeletonSection}>
+          <Skeleton width="10rem" height="0.75rem" />
+          <Skeleton width="14rem" height="2rem" />
+        </div>
+        <div className={styles.publicKeySkeleton}>
+          <SkeletonAvatar size={116} data-testid="wallet-qr-skeleton" />
+          <div className={styles.publicKeySkeletonDetails}>
+            <Skeleton width="6rem" height="0.75rem" />
+            <Skeleton width="16rem" height="1.25rem" />
+            <Skeleton variant="pill" width="10rem" height="1.25rem" />
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.contentGrid}>
+        <SkeletonCard className={styles.panelSkeleton}>
+          <SkeletonText lines={4} />
+        </SkeletonCard>
+        <SkeletonCard className={styles.panelSkeleton}>
+          <SkeletonText lines={3} />
+        </SkeletonCard>
+      </div>
+    </div>
+  )
+}
 
 function WalletPage() {
   const { publicKey, connected, ready, connectionMethod, freighterAvailable, connect, connectFreighter, disconnect } = useWallet()
@@ -227,6 +269,12 @@ function WalletPage() {
         </div>
       </div>
     )
+  }
+
+  // Initial balance fetch: show the dedicated page skeleton instead of
+  // partially-populated content so there is no layout shift on load.
+  if (balanceLoading) {
+    return <WalletPageSkeleton />
   }
 
   return (

--- a/frontend/src/pages/dashboard.module.css
+++ b/frontend/src/pages/dashboard.module.css
@@ -4,6 +4,14 @@
   gap: 1rem;
 }
 
+.kpiSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 80px;
+  border-radius: 8px;
+}
+
 .health {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -7,7 +7,34 @@ import { DashboardLayout } from '../components/dashboard/DashboardLayout';
 import { KpiCard } from '../components/dashboard/KpiCard';
 import { NetworkHealthBadge } from '../components/dashboard/NetworkHealthBadge';
 import { RecentTasksTable } from '../components/dashboard/RecentTasksTable';
+import { Skeleton, SkeletonAvatar, SkeletonCard, SkeletonTable } from '../components/common/Skeleton';
 import styles from './dashboard.module.css';
+
+/**
+ * Context-aware skeleton that mirrors the dashboard layout so there is no
+ * layout shift between the loading and loaded states.
+ */
+export const DashboardSkeleton: React.FC = () => (
+  <div data-testid="dashboard-skeleton" aria-busy="true" aria-label="Loading dashboard">
+    <section className={styles.kpis}>
+      {Array.from({ length: 4 }, (_, i) => (
+        <SkeletonCard key={i} className={styles.kpiSkeleton} data-testid="dashboard-kpi-skeleton">
+          <Skeleton width="60%" height="0.875rem" />
+          <Skeleton width="70%" height="1.75rem" />
+          <Skeleton variant="rectangular" width="100%" height="2.5rem" />
+        </SkeletonCard>
+      ))}
+    </section>
+    <section className={styles.health}>
+      <SkeletonAvatar size={10} />
+      <Skeleton width="4rem" height="0.875rem" />
+    </section>
+    <section className={styles.recentTasks}>
+      <h2 className={styles.heading}>Recent Tasks</h2>
+      <SkeletonTable rows={5} columns={4} />
+    </section>
+  </div>
+);
 
 export const DashboardPage: React.FC = () => {
   const { address } = useWallet();
@@ -30,6 +57,14 @@ export const DashboardPage: React.FC = () => {
 
   if (!address) return null; // render nothing while redirecting
 
+  if (loading) {
+    return (
+      <DashboardLayout>
+        <DashboardSkeleton />
+      </DashboardLayout>
+    );
+  }
+
   const kpiData = data || {
     totalAgents: 0,
     totalTasks: 0,
@@ -40,7 +75,7 @@ export const DashboardPage: React.FC = () => {
   const sparkline = [kpiData.totalAgents, kpiData.totalTasks, kpiData.totalXLMTransacted]; // placeholder data
 
   return (
-    <DashboardLayout>
+    <DashboardLayout className="fade-in">
       <section className={styles.kpis}>
         <KpiCard title="Total Agents" value={kpiData.totalAgents} sparklineData={sparkline} loading={loading} />
         <KpiCard title="Total Tasks Run" value={kpiData.totalTasks} sparklineData={sparkline} loading={loading} />

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -23,6 +23,8 @@
   --success: var(--accent-green);
   --danger: #ef4444;
   --accent: var(--accent-cyan);
+  --skeleton-base: #1a1f2e;
+  --skeleton-shine: #2a3040;
 }
 
 * {
@@ -43,6 +45,26 @@ body {
 html, body {
   max-width: 100vw;
   overflow-x: hidden;
+}
+
+/* Skeleton fade-in: transitions from skeleton to loaded content over 200ms. */
+.fade-in {
+  animation: skeletonFadeIn 200ms ease-in-out;
+}
+
+@keyframes skeletonFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    animation: none;
+  }
 }
 
 .glass-panel {


### PR DESCRIPTION
## Summary

Replaces generic loading spinners with context-aware skeleton placeholders that match each page's layout, improving perceived performance.

## Changes

- Extends `Skeleton` with composable primitives: `SkeletonText`, `SkeletonCard`, `SkeletonTable`, `SkeletonAvatar`
- Adds page-specific skeletons: `DashboardSkeleton`, `AgentsPageSkeleton`, `WalletPageSkeleton`, `TaskDetailSkeleton`
- Shimmer now uses `--skeleton-base` / `--skeleton-shine` CSS variables defined in `global.css`
- Skeletons match loaded content dimensions to prevent layout shift
- 200ms opacity fade from skeleton to loaded content
- Respects `prefers-reduced-motion`
- Adds `Skeleton.test.tsx` rendering tests

## Acceptance criteria

- [x] Each page has a dedicated skeleton component matching its layout
- [x] Shimmer uses `--skeleton-base` and `--skeleton-shine`
- [x] Skeleton matches loaded content dimensions (no layout shift)
- [x] 200ms opacity fade transition
- [x] Error state replaces skeleton (not shown after error)
- [x] Reusable primitives: SkeletonText, SkeletonCard, SkeletonTable, SkeletonAvatar
- [x] Respects `prefers-reduced-motion`

## Testing

- `npm run build` (tsc + vite) passes
- `npm test` passes (124 tests)

Closes #227
