### PR TITLE
feat(ui): Task History Timeline with Filtering and Comparison View

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import AppShell from './components/layout/AppShell'
 import LandingPage from './pages/LandingPage'
 import AgentsPage from './pages/AgentsPage'
 import NewTaskPage from './pages/tasks/NewTaskPage'
+import TaskHistoryPage from './pages/tasks/TaskHistoryPage'
 import TaskDetailPage from './pages/TaskDetailPage'
 import RendererDemoPage from './pages/RendererDemoPage'
 import WalletPage from './pages/WalletPage'
@@ -26,6 +27,7 @@ const AppContent: React.FC = () => {
               <Route path="/wallet" element={<WalletPage />} />
               <Route path="/agents" element={<AgentsPage />} />
               <Route path="/tasks/new" element={<NewTaskPage />} />
+              <Route path="/tasks/history" element={<TaskHistoryPage />} />
               <Route path="/tasks/:id" element={<TaskDetailPage />} />
               <Route path="/renderer-demo" element={<RendererDemoPage />} />
               <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/components/layout/MobileDrawer.tsx
+++ b/frontend/src/components/layout/MobileDrawer.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { motion } from 'framer-motion'
-import { LayoutDashboard, PlusCircle, Bot, Wallet } from 'lucide-react'
+import { LayoutDashboard, PlusCircle, Bot, Wallet, History } from 'lucide-react'
 import './MobileDrawer.css'
 
 interface MobileDrawerProps {
@@ -17,6 +17,7 @@ const MobileDrawer = forwardRef<HTMLDivElement, MobileDrawerProps>(({
   const navItems = [
     { path: '/', icon: <LayoutDashboard size={20} />, label: 'Dashboard' },
     { path: '/tasks/new', icon: <PlusCircle size={20} />, label: 'New Task' },
+    { path: '/tasks/history', icon: <History size={20} />, label: 'Task History' },
     { path: '/agents', icon: <Bot size={20} />, label: 'Agents' },
     { path: '/wallet', icon: <Wallet size={20} />, label: 'Wallet' },
   ]

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { LayoutDashboard, PlusCircle, Bot, Wallet } from 'lucide-react'
+import { LayoutDashboard, PlusCircle, Bot, Wallet, History } from 'lucide-react'
 import './Sidebar.css'
 
 interface SidebarProps {
@@ -16,6 +16,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   const navItems = [
     { path: '/', icon: <LayoutDashboard size={18} />, label: 'Dashboard' },
     { path: '/tasks/new', icon: <PlusCircle size={18} />, label: 'New Task' },
+    { path: '/tasks/history', icon: <History size={18} />, label: 'Task History' },
     { path: '/agents', icon: <Bot size={18} />, label: 'Agents' },
     { path: '/wallet', icon: <Wallet size={18} />, label: 'Wallet' },
   ]

--- a/frontend/src/components/tasks/TaskComparison.module.css
+++ b/frontend/src/components/tasks/TaskComparison.module.css
@@ -1,0 +1,434 @@
+/* ─── Overlay ────────────────────────────────────────────────────── */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 24px 16px;
+  overflow-y: auto;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+}
+
+/* ─── Panel ──────────────────────────────────────────────────────── */
+
+.panel {
+  position: relative;
+  z-index: 1;
+  background: var(--bg-surface);
+  border: 1px solid var(--panel-border);
+  border-radius: 18px;
+  width: 100%;
+  max-width: 1120px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: calc(100vh - 48px);
+}
+
+/* ─── Header ─────────────────────────────────────────────────────── */
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--panel-border);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.headerIcon {
+  color: var(--primary);
+}
+
+.headerTitle {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.headerSubtitle {
+  font-size: 0.75rem;
+  font-family: ui-monospace, monospace;
+  color: var(--text-secondary);
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* ─── Diff toggle ────────────────────────────────────────────────── */
+
+.diffToggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 0;
+}
+
+.diffToggle input[type='checkbox'] {
+  accent-color: var(--primary);
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.diffLabel {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+/* ─── Export + close buttons ─────────────────────────────────────── */
+
+.exportBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(139, 92, 246, 0.15);
+  border: 1px solid rgba(139, 92, 246, 0.35);
+  color: #c4b5fd;
+  padding: 7px 14px;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  box-shadow: none;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.exportBtn:hover {
+  background: rgba(139, 92, 246, 0.28);
+  transform: none;
+  box-shadow: none;
+}
+
+.closeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  box-shadow: none;
+  transition: background 0.15s, color 0.15s;
+  padding: 0;
+}
+
+.closeBtn:hover {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+  transform: none;
+  box-shadow: none;
+}
+
+/* ─── Split view ─────────────────────────────────────────────────── */
+
+.splitView {
+  display: grid;
+  grid-template-columns: 1fr 1px 1fr;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.divider {
+  background: var(--panel-border);
+  width: 1px;
+}
+
+/* ─── Column ─────────────────────────────────────────────────────── */
+
+.column {
+  padding: 20px 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+.columnA {
+  border-right: none; /* divider handles it */
+}
+
+/* ─── Column header ──────────────────────────────────────────────── */
+
+.colHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.colLabel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: rgba(139, 92, 246, 0.2);
+  border: 1px solid rgba(139, 92, 246, 0.4);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 800;
+  color: #c4b5fd;
+}
+
+.columnB .colLabel {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: #7dd3fc;
+}
+
+.colMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.colStatus {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.colStatusText {
+  font-size: 0.78rem;
+}
+
+.colDate {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.colId {
+  font-size: 0.68rem;
+  font-family: ui-monospace, monospace;
+  color: var(--text-secondary);
+}
+
+/* ─── Section ────────────────────────────────────────────────────── */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionTitle {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.sectionBody {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.promptText {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  line-height: 1.6;
+  margin: 0;
+  word-break: break-word;
+}
+
+/* ─── Stats grid ─────────────────────────────────────────────────── */
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.statCell {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.statLabel {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+
+.statValue {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.statAgents {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.agentPill {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: capitalize;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  border: 1px solid;
+  background: transparent;
+}
+
+/* ─── Agent outputs ──────────────────────────────────────────────── */
+
+.outputList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.outputNode {
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.outputNodeHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid var(--panel-border);
+  gap: 8px;
+}
+
+.outputNodeName {
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-family: ui-monospace, monospace;
+  text-transform: capitalize;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.outputNodeStatus {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.outputPre {
+  font-size: 0.75rem;
+  font-family: ui-monospace, 'Fira Code', monospace;
+  color: var(--text-primary);
+  padding: 10px 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.55;
+  background: transparent;
+  margin: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.outputError {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 12px;
+  font-size: 0.76rem;
+  color: #f87171;
+  background: rgba(239, 68, 68, 0.06);
+}
+
+/* ─── Diff highlight ─────────────────────────────────────────────── */
+
+.diffMark {
+  background: rgba(245, 158, 11, 0.2);
+  border-radius: 3px;
+  color: #fde68a;
+  text-decoration: none;
+  padding: 0 2px;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .splitView {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1px auto;
+  }
+
+  .divider {
+    width: 100%;
+    height: 1px;
+  }
+
+  .column {
+    padding: 16px;
+  }
+
+  .statsGrid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .headerActions {
+    gap: 8px;
+  }
+
+  .exportBtn {
+    padding: 6px 10px;
+    font-size: 0.72rem;
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}

--- a/frontend/src/components/tasks/TaskComparison.tsx
+++ b/frontend/src/components/tasks/TaskComparison.tsx
@@ -1,0 +1,446 @@
+import React, { useState } from 'react';
+import {
+  X,
+  Clock,
+  Download,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  ArrowLeftRight,
+  AlertCircle,
+} from 'lucide-react';
+import type { TaskResponse } from '../../types/api';
+import {
+  getTaskDuration,
+  getTaskCost,
+  getTaskAgentTypes,
+  formatDuration,
+} from '../../hooks/useTaskHistory';
+import styles from './TaskComparison.module.css';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const AGENT_COLORS: Record<string, string> = {
+  research: '#38bdf8',
+  risk: '#f59e0b',
+  coding: '#a78bfa',
+  design: '#f472b6',
+  report: '#34d399',
+};
+
+function statusColor(status: TaskResponse['status']): string {
+  switch (status) {
+    case 'completed': return '#34d399';
+    case 'failed': return '#f87171';
+    case 'running': return '#818cf8';
+    default: return '#fbbf24';
+  }
+}
+
+function statusIcon(status: TaskResponse['status']): React.ReactNode {
+  switch (status) {
+    case 'completed': return <CheckCircle2 size={15} />;
+    case 'failed': return <XCircle size={15} />;
+    case 'running': return <Loader2 size={15} style={{ animation: 'spin 1s linear infinite' }} />;
+    default: return <Clock size={15} />;
+  }
+}
+
+/** Render a DAG node result as a readable string */
+function renderNodeResult(result: unknown): string {
+  if (result === null || result === undefined) return '—';
+  if (typeof result === 'string') return result;
+  if (typeof result === 'object') {
+    const r = result as Record<string, unknown>;
+    if (typeof r.summary === 'string') return r.summary;
+    if (typeof r.markdown === 'string') return r.markdown;
+    if (typeof r.content === 'string') return r.content;
+    if (typeof r.code === 'string') return `\`\`\`\n${r.code}\n\`\`\``;
+    try { return JSON.stringify(result, null, 2); } catch { return String(result); }
+  }
+  return String(result);
+}
+
+// ─── Diff highlight ───────────────────────────────────────────────────────────
+
+/** Simple word-level diff: return JSX with changed words highlighted */
+function DiffText({
+  textA,
+  textB,
+  isA,
+}: {
+  textA: string;
+  textB: string;
+  isA: boolean;
+}): React.ReactElement {
+  const wordsA = textA.split(/\s+/);
+  const wordsB = textB.split(/\s+/);
+  const setA = new Set(wordsA);
+  const setB = new Set(wordsB);
+  const words = isA ? wordsA : wordsB;
+  const other = isA ? setB : setA;
+
+  return (
+    <>
+      {words.map((word, i) => {
+        const isDiff = word.length > 2 && !other.has(word);
+        return isDiff ? (
+          <mark key={i} className={styles.diffMark}>
+            {word}{' '}
+          </mark>
+        ) : (
+          <React.Fragment key={i}>{word} </React.Fragment>
+        );
+      })}
+    </>
+  );
+}
+
+// ─── Comparison column ────────────────────────────────────────────────────────
+
+interface ComparisonColumnProps {
+  task: TaskResponse;
+  label: 'A' | 'B';
+  otherTask: TaskResponse;
+  showDiff: boolean;
+}
+
+const ComparisonColumn: React.FC<ComparisonColumnProps> = ({
+  task,
+  label,
+  otherTask,
+  showDiff,
+}) => {
+  const taskId = task.taskId || task.id || '';
+  const duration = getTaskDuration(task);
+  const cost = getTaskCost(task);
+  const agentTypes = getTaskAgentTypes(task);
+
+  return (
+    <div className={`${styles.column} ${label === 'A' ? styles.columnA : styles.columnB}`}>
+      {/* Column header */}
+      <div className={styles.colHeader}>
+        <span className={styles.colLabel}>{label}</span>
+        <div className={styles.colMeta}>
+          <span
+            className={styles.colStatus}
+            style={{ color: statusColor(task.status) }}
+            aria-label={`Status: ${task.status}`}
+          >
+            {statusIcon(task.status)}
+            <span className={styles.colStatusText}>{task.status}</span>
+          </span>
+          <span className={styles.colDate}>
+            {new Date(task.createdAt).toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })}
+          </span>
+        </div>
+        <span className={styles.colId} title={taskId}>
+          #{taskId.slice(-12)}
+        </span>
+      </div>
+
+      {/* Prompt */}
+      <section className={styles.section} aria-labelledby={`prompt-${label}`}>
+        <h4 id={`prompt-${label}`} className={styles.sectionTitle}>Prompt</h4>
+        <div className={styles.sectionBody}>
+          {showDiff ? (
+            <p className={styles.promptText}>
+              <DiffText
+                textA={task.prompt || ''}
+                textB={otherTask.prompt || ''}
+                isA={label === 'A'}
+              />
+            </p>
+          ) : (
+            <p className={styles.promptText}>{task.prompt || '—'}</p>
+          )}
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className={styles.section} aria-labelledby={`stats-${label}`}>
+        <h4 id={`stats-${label}`} className={styles.sectionTitle}>Metrics</h4>
+        <div className={styles.statsGrid}>
+          <div className={styles.statCell}>
+            <span className={styles.statLabel}>Duration</span>
+            <span className={styles.statValue}>
+              {duration !== undefined ? formatDuration(duration) : '—'}
+            </span>
+          </div>
+          <div className={styles.statCell}>
+            <span className={styles.statLabel}>Est. Cost</span>
+            <span className={styles.statValue}>{cost > 0 ? `${cost.toFixed(2)} XLM` : '—'}</span>
+          </div>
+          <div className={styles.statCell}>
+            <span className={styles.statLabel}>Nodes</span>
+            <span className={styles.statValue}>{task.dag?.length ?? 0}</span>
+          </div>
+          <div className={styles.statCell}>
+            <span className={styles.statLabel}>Agents</span>
+            <div className={styles.statAgents}>
+              {agentTypes.length === 0
+                ? <span className={styles.statValue}>—</span>
+                : agentTypes.map((t) => (
+                  <span
+                    key={t}
+                    className={styles.agentPill}
+                    style={{ color: AGENT_COLORS[t] || '#94a3b8', borderColor: `${AGENT_COLORS[t] || '#94a3b8'}44` }}
+                  >
+                    {t}
+                  </span>
+                ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Agent outputs */}
+      {task.dag && task.dag.length > 0 && (
+        <section className={styles.section} aria-labelledby={`outputs-${label}`}>
+          <h4 id={`outputs-${label}`} className={styles.sectionTitle}>Agent Outputs</h4>
+          <div className={styles.outputList}>
+            {task.dag.map((node, i) => {
+              const resultText = renderNodeResult(node.result);
+              const agentBase = (node.agentType || '').toLowerCase();
+              const agentKey = ['research', 'risk', 'coding', 'design', 'report'].find((k) =>
+                agentBase.includes(k)
+              );
+              const agentColor = agentKey ? AGENT_COLORS[agentKey] : '#94a3b8';
+
+              // Find corresponding node in other task for diff
+              const otherNode = otherTask.dag?.[i];
+              const otherResultText = otherNode ? renderNodeResult(otherNode.result) : '';
+
+              return (
+                <div key={node.nodeId || i} className={styles.outputNode}>
+                  <div className={styles.outputNodeHeader}>
+                    <span
+                      className={styles.outputNodeName}
+                      style={{ color: agentColor }}
+                    >
+                      {node.nodeId.replace(/^node[_-]/, '')} ({node.agentType || 'agent'})
+                    </span>
+                    <span
+                      className={styles.outputNodeStatus}
+                      style={{ color: statusColor(node.status as TaskResponse['status']) }}
+                    >
+                      {node.status}
+                    </span>
+                  </div>
+
+                  {node.error ? (
+                    <div className={styles.outputError}>
+                      <AlertCircle size={12} aria-hidden="true" />
+                      {node.error}
+                    </div>
+                  ) : (
+                    <pre className={styles.outputPre}>
+                      {showDiff && otherResultText ? (
+                        <DiffText
+                          textA={resultText}
+                          textB={otherResultText}
+                          isA={label === 'A'}
+                        />
+                      ) : (
+                        resultText.slice(0, 600) + (resultText.length > 600 ? '…' : '')
+                      )}
+                    </pre>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+};
+
+// ─── Markdown export ──────────────────────────────────────────────────────────
+
+function buildMarkdownReport(taskA: TaskResponse, taskB: TaskResponse): string {
+  const idA = taskA.taskId || taskA.id || 'A';
+  const idB = taskB.taskId || taskB.id || 'B';
+  const durationA = getTaskDuration(taskA);
+  const durationB = getTaskDuration(taskB);
+  const costA = getTaskCost(taskA);
+  const costB = getTaskCost(taskB);
+
+  const lines: string[] = [
+    '# Task Comparison Report',
+    '',
+    `Generated: ${new Date().toISOString()}`,
+    '',
+    '---',
+    '',
+    '## Summary',
+    '',
+    `| | Task A | Task B |`,
+    `|---|---|---|`,
+    `| **ID** | \`${idA}\` | \`${idB}\` |`,
+    `| **Status** | ${taskA.status} | ${taskB.status} |`,
+    `| **Created** | ${new Date(taskA.createdAt).toLocaleString()} | ${new Date(taskB.createdAt).toLocaleString()} |`,
+    `| **Duration** | ${durationA !== undefined ? formatDuration(durationA) : '—'} | ${durationB !== undefined ? formatDuration(durationB) : '—'} |`,
+    `| **Est. Cost** | ${costA > 0 ? `${costA.toFixed(2)} XLM` : '—'} | ${costB > 0 ? `${costB.toFixed(2)} XLM` : '—'} |`,
+    `| **Nodes** | ${taskA.dag?.length ?? 0} | ${taskB.dag?.length ?? 0} |`,
+    '',
+    '---',
+    '',
+    '## Prompts',
+    '',
+    '### Task A',
+    '',
+    taskA.prompt || '—',
+    '',
+    '### Task B',
+    '',
+    taskB.prompt || '—',
+    '',
+    '---',
+    '',
+    '## Agent Outputs',
+    '',
+  ];
+
+  // Output for each task
+  for (const [label, task] of [['A', taskA], ['B', taskB]] as const) {
+    lines.push(`### Task ${label} Outputs`);
+    lines.push('');
+    if (task.dag && task.dag.length > 0) {
+      task.dag.forEach((node) => {
+        lines.push(`#### ${node.nodeId} (${node.agentType || 'agent'}) — ${node.status}`);
+        lines.push('');
+        if (node.error) {
+          lines.push(`**Error:** ${node.error}`);
+        } else {
+          const result = renderNodeResult(node.result);
+          lines.push('```');
+          lines.push(result.slice(0, 1000) + (result.length > 1000 ? '\n…(truncated)' : ''));
+          lines.push('```');
+        }
+        lines.push('');
+      });
+    } else {
+      lines.push('No DAG nodes recorded.');
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function downloadMarkdown(content: string, filename: string) {
+  const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 100);
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface TaskComparisonProps {
+  taskA: TaskResponse;
+  taskB: TaskResponse;
+  onClose: () => void;
+}
+
+export const TaskComparison: React.FC<TaskComparisonProps> = ({
+  taskA,
+  taskB,
+  onClose,
+}) => {
+  const [showDiff, setShowDiff] = useState(false);
+
+  const idA = taskA.taskId || taskA.id || 'A';
+  const idB = taskB.taskId || taskB.id || 'B';
+
+  const handleExport = () => {
+    const md = buildMarkdownReport(taskA, taskB);
+    downloadMarkdown(md, `task-comparison-${idA.slice(-6)}-vs-${idB.slice(-6)}.md`);
+  };
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-label="Task comparison">
+      {/* Backdrop */}
+      <div className={styles.backdrop} onClick={onClose} aria-hidden="true" />
+
+      <div className={styles.panel}>
+        {/* Header */}
+        <div className={styles.header}>
+          <div className={styles.headerLeft}>
+            <ArrowLeftRight size={18} className={styles.headerIcon} aria-hidden="true" />
+            <h2 className={styles.headerTitle}>Comparison</h2>
+            <span className={styles.headerSubtitle}>
+              #{idA.slice(-8)} vs #{idB.slice(-8)}
+            </span>
+          </div>
+
+          <div className={styles.headerActions}>
+            {/* Diff toggle */}
+            <label className={styles.diffToggle}>
+              <input
+                type="checkbox"
+                checked={showDiff}
+                onChange={(e) => setShowDiff(e.target.checked)}
+                aria-label="Highlight differences between tasks"
+              />
+              <span className={styles.diffLabel}>Show diff</span>
+            </label>
+
+            {/* Export */}
+            <button
+              type="button"
+              className={styles.exportBtn}
+              onClick={handleExport}
+              aria-label="Export comparison as markdown"
+            >
+              <Download size={14} />
+              Export MD
+            </button>
+
+            {/* Close */}
+            <button
+              type="button"
+              className={styles.closeBtn}
+              onClick={onClose}
+              aria-label="Close comparison"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+
+        {/* Split view */}
+        <div className={styles.splitView}>
+          <ComparisonColumn
+            task={taskA}
+            label="A"
+            otherTask={taskB}
+            showDiff={showDiff}
+          />
+
+          {/* Divider */}
+          <div className={styles.divider} aria-hidden="true" />
+
+          <ComparisonColumn
+            task={taskB}
+            label="B"
+            otherTask={taskA}
+            showDiff={showDiff}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/tasks/TaskFilterBar.module.css
+++ b/frontend/src/components/tasks/TaskFilterBar.module.css
@@ -1,0 +1,324 @@
+/* Status colour tokens used inline */
+:root {
+  --status-amber: #f59e0b;
+  --status-indigo: #6366f1;
+  --status-emerald: #10b981;
+  --status-rose: #ef4444;
+}
+
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 20px;
+  padding: 16px 20px;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  margin-bottom: 20px;
+}
+
+/* ── Search ── */
+.searchGroup {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 180px;
+  flex: 1 1 180px;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 10px;
+  color: var(--text-secondary);
+  pointer-events: none;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 7px 32px 7px 30px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 0.83rem;
+  transition: border-color 0.15s;
+}
+
+.searchInput::placeholder {
+  color: var(--text-secondary);
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.2);
+}
+
+/* Override global input styling for search */
+input[type='search'].searchInput {
+  font-family: var(--font-sans);
+}
+
+.clearSearch {
+  position: absolute;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  border-radius: 4px;
+  padding: 0;
+  box-shadow: none;
+}
+
+.clearSearch:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.08);
+  transform: none;
+  box-shadow: none;
+}
+
+/* ── Filter groups ── */
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  flex-shrink: 0;
+}
+
+.groupLabel {
+  display: flex;
+  align-items: center;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+/* ── Status toggle ── */
+.toggle {
+  display: inline-flex;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.toggleButton {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  padding: 6px 12px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  box-shadow: none;
+  border-radius: 0;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+
+.toggleButton:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.toggleButtonActive,
+.toggleButtonActive:hover {
+  background: var(--primary);
+  color: #fff;
+}
+
+/* Coloured variants – status active states */
+.toggleButton_amber,
+.toggleButton_amber:hover {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fde68a;
+}
+
+.toggleButton_indigo,
+.toggleButton_indigo:hover {
+  background: rgba(99, 102, 241, 0.25);
+  color: #c7d2fe;
+}
+
+.toggleButton_emerald,
+.toggleButton_emerald:hover {
+  background: rgba(16, 185, 129, 0.2);
+  color: #a7f3d0;
+}
+
+.toggleButton_rose,
+.toggleButton_rose:hover {
+  background: rgba(239, 68, 68, 0.2);
+  color: #fca5a5;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ── Agent chips ── */
+.capList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.capChip {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  color: var(--text-secondary);
+  padding: 4px 11px;
+  border-radius: 9999px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  box-shadow: none;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.capChip:hover {
+  background: rgba(139, 92, 246, 0.1);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.capChipActive,
+.capChipActive:hover {
+  background: rgba(139, 92, 246, 0.25);
+  border-color: var(--primary);
+  color: #c7d2fe;
+}
+
+/* ── Date range ── */
+.dateRange {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dateInput {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--panel-border);
+  border-radius: 7px;
+  color: var(--text-primary);
+  font-size: 0.78rem;
+  padding: 5px 8px;
+  font-family: var(--font-sans);
+  width: 130px;
+  color-scheme: dark;
+  transition: border-color 0.15s;
+}
+
+.dateInput:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.dateSep {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+/* ── Actions ── */
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.iconAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  color: var(--text-secondary);
+  border-radius: 8px;
+  box-shadow: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.iconAction:hover {
+  background: rgba(139, 92, 246, 0.12);
+  color: var(--text-primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.resetButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  color: var(--text-secondary);
+  padding: 6px 11px;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  box-shadow: none;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.resetButton:hover {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+  transform: none;
+  box-shadow: none;
+}
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  .bar {
+    gap: 14px;
+    padding: 12px 14px;
+  }
+
+  .toggle {
+    flex-wrap: wrap;
+  }
+
+  .dateRange {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dateSep {
+    display: none;
+  }
+
+  .actions {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-end;
+  }
+}

--- a/frontend/src/components/tasks/TaskFilterBar.tsx
+++ b/frontend/src/components/tasks/TaskFilterBar.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { RotateCw, X, Search, Calendar } from 'lucide-react';
+import type { TaskHistoryFilters, ZoomLevel } from '../../hooks/useTaskHistory';
+import type { NodeStatus } from '../../types/api';
+import styles from './TaskFilterBar.module.css';
+
+interface TaskFilterBarProps {
+  filters: TaskHistoryFilters;
+  availableAgentTypes: string[];
+  onChange: (next: Partial<TaskHistoryFilters>) => void;
+  onReset: () => void;
+  onRefresh: () => void;
+  totalCount: number;
+  filteredCount: number;
+}
+
+const STATUS_OPTIONS: { value: NodeStatus | 'all'; label: string; color: string }[] = [
+  { value: 'all', label: 'All', color: '' },
+  { value: 'pending', label: 'Pending', color: 'amber' },
+  { value: 'running', label: 'Running', color: 'indigo' },
+  { value: 'completed', label: 'Completed', color: 'emerald' },
+  { value: 'failed', label: 'Failed', color: 'rose' },
+];
+
+const ZOOM_OPTIONS: { value: ZoomLevel; label: string }[] = [
+  { value: 'day', label: 'Today' },
+  { value: 'week', label: 'This Week' },
+  { value: 'month', label: 'This Month' },
+];
+
+const AGENT_LABELS: Record<string, string> = {
+  research: 'Research',
+  risk: 'Risk',
+  coding: 'Coding',
+  design: 'Design',
+  report: 'Report',
+};
+
+export const TaskFilterBar: React.FC<TaskFilterBarProps> = ({
+  filters,
+  availableAgentTypes,
+  onChange,
+  onReset,
+  onRefresh,
+  totalCount,
+  filteredCount,
+}) => {
+  const hasActiveFilters =
+    filters.status !== 'all' ||
+    filters.agentType !== 'all' ||
+    !!filters.dateFrom ||
+    !!filters.dateTo ||
+    !!filters.search;
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ search: e.target.value });
+  };
+
+  const clearSearch = () => onChange({ search: '' });
+
+  return (
+    <div className={styles.bar} role="search" aria-label="Task history filters">
+      {/* Search box */}
+      <div className={styles.searchGroup}>
+        <Search size={14} className={styles.searchIcon} aria-hidden="true" />
+        <input
+          type="search"
+          className={styles.searchInput}
+          placeholder="Search tasks…"
+          value={filters.search}
+          onChange={handleSearchChange}
+          aria-label="Search tasks by prompt or ID"
+        />
+        {filters.search && (
+          <button
+            type="button"
+            className={styles.clearSearch}
+            onClick={clearSearch}
+            aria-label="Clear search"
+          >
+            <X size={12} />
+          </button>
+        )}
+      </div>
+
+      {/* Status filter */}
+      <div className={styles.group}>
+        <span className={styles.groupLabel}>Status</span>
+        <div className={styles.toggle} role="group" aria-label="Filter by task status">
+          {STATUS_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`${styles.toggleButton} ${
+                filters.status === opt.value
+                  ? styles[`toggleButton_${opt.color || 'active'}`] || styles.toggleButtonActive
+                  : ''
+              }`}
+              aria-pressed={filters.status === opt.value}
+              onClick={() => onChange({ status: opt.value })}
+            >
+              {opt.color && (
+                <span
+                  className={styles.statusDot}
+                  style={{ background: `var(--status-${opt.color})` }}
+                  aria-hidden="true"
+                />
+              )}
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Agent type filter */}
+      {availableAgentTypes.length > 0 && (
+        <div className={styles.group}>
+          <span className={styles.groupLabel}>Agent</span>
+          <div className={styles.capList} role="group" aria-label="Filter by agent type">
+            <button
+              type="button"
+              className={`${styles.capChip} ${
+                filters.agentType === 'all' ? styles.capChipActive : ''
+              }`}
+              aria-pressed={filters.agentType === 'all'}
+              onClick={() => onChange({ agentType: 'all' })}
+            >
+              All
+            </button>
+            {availableAgentTypes.map((type) => (
+              <button
+                key={type}
+                type="button"
+                className={`${styles.capChip} ${
+                  filters.agentType === type ? styles.capChipActive : ''
+                }`}
+                aria-pressed={filters.agentType === type}
+                onClick={() => onChange({ agentType: type })}
+              >
+                {AGENT_LABELS[type] ?? type}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Date range */}
+      <div className={styles.group}>
+        <span className={styles.groupLabel}>
+          <Calendar size={11} aria-hidden="true" style={{ display: 'inline', marginRight: 4 }} />
+          Date Range
+        </span>
+        <div className={styles.dateRange}>
+          <input
+            type="date"
+            className={styles.dateInput}
+            value={filters.dateFrom}
+            max={filters.dateTo || undefined}
+            aria-label="Start date"
+            onChange={(e) => onChange({ dateFrom: e.target.value })}
+          />
+          <span className={styles.dateSep}>–</span>
+          <input
+            type="date"
+            className={styles.dateInput}
+            value={filters.dateTo}
+            min={filters.dateFrom || undefined}
+            aria-label="End date"
+            onChange={(e) => onChange({ dateTo: e.target.value })}
+          />
+        </div>
+      </div>
+
+      {/* Zoom */}
+      <div className={styles.group}>
+        <span className={styles.groupLabel}>Zoom</span>
+        <div className={styles.toggle} role="group" aria-label="Timeline zoom level">
+          {ZOOM_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`${styles.toggleButton} ${
+                filters.zoom === opt.value ? styles.toggleButtonActive : ''
+              }`}
+              aria-pressed={filters.zoom === opt.value}
+              onClick={() => onChange({ zoom: opt.value, dateFrom: '', dateTo: '' })}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Actions + count */}
+      <div className={styles.actions}>
+        <span className={styles.count} aria-live="polite">
+          {filteredCount} / {totalCount}
+        </span>
+
+        <button
+          type="button"
+          className={styles.iconAction}
+          onClick={onRefresh}
+          title="Refresh"
+          aria-label="Refresh task list"
+        >
+          <RotateCw size={14} />
+        </button>
+
+        {hasActiveFilters && (
+          <button type="button" className={styles.resetButton} onClick={onReset}>
+            <X size={14} />
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/tasks/TaskTimeline.module.css
+++ b/frontend/src/components/tasks/TaskTimeline.module.css
@@ -1,0 +1,529 @@
+/* ─── Timeline container ─────────────────────────────────────────── */
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* ─── Date bucket separator ─────────────────────────────────────── */
+
+.dateBucket {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 0 8px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  /* slight backdrop so it doesn't clash with cards when scrolling */
+  background: var(--bg-primary);
+}
+
+.dateBucketLine {
+  flex: 1;
+  height: 1px;
+  background: var(--panel-border);
+}
+
+.dateBucketLabel {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  white-space: nowrap;
+}
+
+/* ─── Entry layout ──────────────────────────────────────────────── */
+
+.entry {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 0 12px;
+  padding: 6px 0;
+  transition: opacity 0.15s;
+}
+
+.entry[aria-selected='true'] .card {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.18);
+}
+
+.entryFailed .card {
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+/* ─── Connector (dot + line) ──────────────────────────────────────  */
+
+.connectorArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 14px;
+}
+
+.dot {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  z-index: 1;
+  border: 2px solid transparent;
+  transition: box-shadow 0.15s;
+}
+
+.dotPending {
+  background: rgba(245, 158, 11, 0.12);
+  border-color: rgba(245, 158, 11, 0.4);
+  color: #fbbf24;
+}
+
+.dotRunning {
+  background: rgba(99, 102, 241, 0.18);
+  border-color: rgba(99, 102, 241, 0.6);
+  color: #818cf8;
+  box-shadow: 0 0 10px rgba(99, 102, 241, 0.35);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.dotCompleted {
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #34d399;
+}
+
+.dotFailed {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #f87171;
+}
+
+.dotSkeleton {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--panel-border);
+}
+
+.line {
+  flex: 1;
+  width: 2px;
+  min-height: 16px;
+  background: var(--panel-border);
+  margin-top: 4px;
+}
+
+/* Hide the line on the very last entry in each group */
+.entry:last-child .line {
+  display: none;
+}
+
+/* ─── Card ─────────────────────────────────────────────────────────  */
+
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 14px 16px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  cursor: default;
+  min-width: 0;
+}
+
+.card:hover {
+  border-color: rgba(139, 92, 246, 0.25);
+}
+
+/* ─── Card header ───────────────────────────────────────────────── */
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+}
+
+.cardHeaderLeft {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+}
+
+.cardHeaderRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* ─── Select button ─────────────────────────────────────────────── */
+
+.selectBtn {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: 2px solid var(--panel-border);
+  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+  margin-top: 2px;
+  transition: border-color 0.15s, background 0.15s;
+  cursor: pointer;
+  padding: 0;
+}
+
+.selectBtn:hover {
+  border-color: var(--primary);
+  background: rgba(139, 92, 246, 0.12);
+  transform: none;
+  box-shadow: none;
+}
+
+.selectBtnActive {
+  border-color: var(--primary);
+  background: rgba(139, 92, 246, 0.3);
+}
+
+.selectIndex {
+  font-size: 0.7rem;
+  font-weight: 800;
+  color: #c7d2fe;
+}
+
+.selectEmpty {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: transparent;
+}
+
+/* ─── Task title / prompt ──────────────────────────────────────── */
+
+.taskTitle {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.taskPrompt {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.taskId {
+  font-size: 0.68rem;
+  font-family: ui-monospace, 'Fira Code', monospace;
+  color: var(--text-secondary);
+}
+
+/* ─── Status badge ──────────────────────────────────────────────── */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 3px 9px;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+.badgePending {
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  color: #fbbf24;
+}
+
+.badgeRunning {
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  color: #818cf8;
+}
+
+.badgeCompleted {
+  background: rgba(16, 185, 129, 0.12);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  color: #34d399;
+}
+
+.badgeFailed {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #f87171;
+}
+
+/* ─── Date / time labels ────────────────────────────────────────── */
+
+.dateLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.timeLabel {
+  opacity: 0.6;
+}
+
+/* ─── Detail link ───────────────────────────────────────────────── */
+
+.detailBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  box-shadow: none;
+  transition: color 0.15s, background 0.15s;
+  padding: 0;
+}
+
+.detailBtn:hover {
+  background: rgba(56, 189, 248, 0.1);
+  color: var(--accent);
+  border-color: rgba(56, 189, 248, 0.3);
+  transform: none;
+  box-shadow: none;
+}
+
+/* ─── Execution bar ─────────────────────────────────────────────── */
+
+.execBar {
+  display: flex;
+  height: 4px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 10px 0 8px;
+  background: var(--panel-border);
+  gap: 1px;
+}
+
+.execSegment {
+  flex: 1;
+  border-radius: 2px;
+  transition: opacity 0.2s;
+}
+
+.execSegmentPending { background: rgba(245, 158, 11, 0.35); }
+.execSegmentRunning {
+  background: #6366f1;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+.execSegmentCompleted { background: #10b981; }
+.execSegmentFailed { background: #ef4444; }
+
+/* ─── Meta row ──────────────────────────────────────────────────── */
+
+.metaRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.agentIcons {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.agentBadge {
+  font-size: 0.62rem;
+  font-weight: 800;
+  padding: 2px 7px;
+  border-radius: 9999px;
+  font-family: ui-monospace, monospace;
+  letter-spacing: 0.04em;
+}
+
+.stats {
+  display: flex;
+  gap: 12px;
+}
+
+.stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* ─── Error section ─────────────────────────────────────────────── */
+
+.errorSection {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.errorToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  border: none;
+  color: #f87171;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0;
+  box-shadow: none;
+  cursor: pointer;
+}
+
+.errorToggle:hover {
+  color: #fca5a5;
+  transform: none;
+  box-shadow: none;
+}
+
+.errorIcon {
+  color: #ef4444;
+}
+
+.errorDetails {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.errorItem {
+  display: flex;
+  gap: 8px;
+  font-size: 0.75rem;
+  background: rgba(239, 68, 68, 0.06);
+  border: 1px solid rgba(239, 68, 68, 0.15);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
+.errorNodeId {
+  font-weight: 700;
+  font-family: monospace;
+  color: #fca5a5;
+  white-space: nowrap;
+  text-transform: capitalize;
+  flex-shrink: 0;
+}
+
+.errorMsg {
+  color: #fecaca;
+  word-break: break-word;
+}
+
+/* ─── Empty state ───────────────────────────────────────────────── */
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 24px;
+  text-align: center;
+  gap: 10px;
+}
+
+.emptyIcon {
+  color: var(--text-secondary);
+  opacity: 0.3;
+}
+
+.emptyTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.emptySubtitle {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  max-width: 340px;
+}
+
+/* ─── Skeleton ──────────────────────────────────────────────────── */
+
+.skeletonCard {
+  pointer-events: none;
+}
+
+.skeletonLine {
+  height: 12px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+/* ─── Animations ────────────────────────────────────────────────── */
+
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 8px rgba(99, 102, 241, 0.3); }
+  50%       { box-shadow: 0 0 16px rgba(99, 102, 241, 0.6); }
+}
+
+@keyframes shimmer {
+  0%   { opacity: 0.6; }
+  50%  { opacity: 1; }
+  100% { opacity: 0.6; }
+}
+
+.spinIcon {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* ─── Responsive ────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .entry {
+    grid-template-columns: 28px 1fr;
+    gap: 0 8px;
+  }
+
+  .dot {
+    width: 22px;
+    height: 22px;
+    font-size: 10px;
+  }
+
+  .cardHeaderRight {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 5px;
+  }
+
+  .taskPrompt {
+    font-size: 0.8rem;
+  }
+
+  .stats {
+    gap: 8px;
+  }
+}

--- a/frontend/src/components/tasks/TaskTimeline.tsx
+++ b/frontend/src/components/tasks/TaskTimeline.tsx
@@ -1,0 +1,452 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Loader2,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  AlertCircle,
+} from 'lucide-react';
+import type { TaskResponse } from '../../types/api';
+import {
+  getTaskDuration,
+  getTaskCost,
+  getTaskAgentTypes,
+  formatDuration,
+} from '../../hooks/useTaskHistory';
+import styles from './TaskTimeline.module.css';
+
+// ─── Agent icon colours ───────────────────────────────────────────────────────
+
+const AGENT_COLORS: Record<string, string> = {
+  research: '#38bdf8', // cyan
+  risk: '#f59e0b',     // amber
+  coding: '#a78bfa',   // violet
+  design: '#f472b6',   // pink
+  report: '#34d399',   // green
+};
+
+const AGENT_ABBR: Record<string, string> = {
+  research: 'RE',
+  risk: 'RI',
+  coding: 'CO',
+  design: 'DE',
+  report: 'RP',
+};
+
+// ─── Status helpers ───────────────────────────────────────────────────────────
+
+interface StatusMeta {
+  icon: React.ReactNode;
+  dotClass: string;
+  badgeClass: string;
+  label: string;
+}
+
+function getStatusMeta(status: TaskResponse['status']): StatusMeta {
+  switch (status) {
+    case 'completed':
+      return {
+        icon: <CheckCircle2 size={14} />,
+        dotClass: styles.dotCompleted,
+        badgeClass: styles.badgeCompleted,
+        label: 'Completed',
+      };
+    case 'failed':
+      return {
+        icon: <XCircle size={14} />,
+        dotClass: styles.dotFailed,
+        badgeClass: styles.badgeFailed,
+        label: 'Failed',
+      };
+    case 'running':
+      return {
+        icon: <Loader2 size={14} className={styles.spinIcon} />,
+        dotClass: styles.dotRunning,
+        badgeClass: styles.badgeRunning,
+        label: 'Running',
+      };
+    default:
+      return {
+        icon: <Clock size={14} />,
+        dotClass: styles.dotPending,
+        badgeClass: styles.badgePending,
+        label: 'Pending',
+      };
+  }
+}
+
+// ─── Execution bar ────────────────────────────────────────────────────────────
+
+interface ExecutionBarProps {
+  task: TaskResponse;
+}
+
+const ExecutionBar: React.FC<ExecutionBarProps> = ({ task }) => {
+  if (!task.dag || task.dag.length === 0) return null;
+
+  const total = task.dag.length;
+  const width = 100 / total;
+
+  return (
+    <div className={styles.execBar} role="img" aria-label="Node execution status breakdown">
+      {task.dag.map((node, i) => {
+        let cls = styles.execSegmentPending;
+        if (node.status === 'completed') cls = styles.execSegmentCompleted;
+        else if (node.status === 'running') cls = styles.execSegmentRunning;
+        else if (node.status === 'failed') cls = styles.execSegmentFailed;
+
+        return (
+          <div
+            key={node.nodeId || i}
+            className={`${styles.execSegment} ${cls}`}
+            style={{ width: `${width}%` }}
+            title={`${node.agentType || node.nodeId}: ${node.status}`}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+// ─── Single timeline entry ────────────────────────────────────────────────────
+
+interface TimelineEntryProps {
+  task: TaskResponse;
+  isSelected: boolean;
+  selectionIndex: 0 | 1 | null;
+  onToggleSelect: (id: string) => void;
+  isComparing: boolean;
+}
+
+const TimelineEntry: React.FC<TimelineEntryProps> = ({
+  task,
+  isSelected,
+  selectionIndex,
+  onToggleSelect,
+  isComparing,
+}) => {
+  const navigate = useNavigate();
+  const [errorExpanded, setErrorExpanded] = useState(false);
+
+  const taskId = task.taskId || task.id || '';
+  const meta = getStatusMeta(task.status);
+  const duration = getTaskDuration(task);
+  const cost = getTaskCost(task);
+  const agentTypes = getTaskAgentTypes(task);
+  const hasFailed = task.status === 'failed';
+
+  // Find error details from the DAG
+  const failedNodes = task.dag?.filter((n) => n.status === 'failed') ?? [];
+
+  const date = new Date(task.createdAt);
+  const dateStr = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const timeStr = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+
+  const handleSelect = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleSelect(taskId);
+  };
+
+  const handleNavigate = () => {
+    navigate(`/tasks/${taskId}`);
+  };
+
+  return (
+    <div
+      className={`${styles.entry} ${isSelected ? styles.entrySelected : ''} ${
+        hasFailed ? styles.entryFailed : ''
+      }`}
+      aria-selected={isSelected}
+    >
+      {/* Timeline connector */}
+      <div className={styles.connectorArea}>
+        <div className={`${styles.dot} ${meta.dotClass}`} aria-hidden="true">
+          {meta.icon}
+        </div>
+        <div className={styles.line} aria-hidden="true" />
+      </div>
+
+      {/* Card body */}
+      <div className={styles.card}>
+        {/* Header row */}
+        <div className={styles.cardHeader}>
+          <div className={styles.cardHeaderLeft}>
+            {/* Selection checkbox */}
+            <button
+              type="button"
+              className={`${styles.selectBtn} ${isSelected ? styles.selectBtnActive : ''}`}
+              onClick={handleSelect}
+              aria-label={isSelected ? 'Deselect task for comparison' : 'Select task for comparison'}
+              title={
+                isSelected
+                  ? 'Deselect'
+                  : isComparing && !isSelected
+                  ? 'Replace one selection to compare'
+                  : 'Select to compare'
+              }
+            >
+              {isSelected && selectionIndex !== null ? (
+                <span className={styles.selectIndex}>{selectionIndex + 1}</span>
+              ) : (
+                <span className={styles.selectEmpty} />
+              )}
+            </button>
+
+            {/* Prompt / title */}
+            <div className={styles.taskTitle}>
+              <span className={styles.taskPrompt} title={task.prompt}>
+                {task.prompt?.length > 80
+                  ? `${task.prompt.slice(0, 80)}…`
+                  : task.prompt}
+              </span>
+              <span className={styles.taskId}>#{taskId.slice(-8)}</span>
+            </div>
+          </div>
+
+          <div className={styles.cardHeaderRight}>
+            {/* Status badge */}
+            <span className={`${styles.badge} ${meta.badgeClass}`} aria-label={`Status: ${meta.label}`}>
+              {meta.icon}
+              {meta.label}
+            </span>
+
+            {/* Date */}
+            <span className={styles.dateLabel}>
+              {dateStr} <span className={styles.timeLabel}>{timeStr}</span>
+            </span>
+
+            {/* Navigate to detail */}
+            <button
+              type="button"
+              className={styles.detailBtn}
+              onClick={handleNavigate}
+              aria-label="View task detail"
+              title="View task detail"
+            >
+              <ExternalLink size={13} />
+            </button>
+          </div>
+        </div>
+
+        {/* Execution bar */}
+        <ExecutionBar task={task} />
+
+        {/* Meta row: agents, duration, cost */}
+        <div className={styles.metaRow}>
+          {agentTypes.length > 0 && (
+            <div className={styles.agentIcons} aria-label="Agents used">
+              {agentTypes.map((type) => (
+                <span
+                  key={type}
+                  className={styles.agentBadge}
+                  style={{
+                    background: `${AGENT_COLORS[type] || '#94a3b8'}22`,
+                    border: `1px solid ${AGENT_COLORS[type] || '#94a3b8'}44`,
+                    color: AGENT_COLORS[type] || '#94a3b8',
+                  }}
+                  title={type}
+                  aria-label={`${type} agent`}
+                >
+                  {AGENT_ABBR[type] || type.slice(0, 2).toUpperCase()}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className={styles.stats}>
+            {duration !== undefined && (
+              <span className={styles.stat} title="Duration">
+                <Clock size={11} aria-hidden="true" />
+                {formatDuration(duration)}
+              </span>
+            )}
+            {cost > 0 && (
+              <span className={styles.stat} title="Estimated cost">
+                <span aria-hidden="true">◎</span>
+                {cost.toFixed(2)} XLM
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Failed node error expander */}
+        {hasFailed && failedNodes.length > 0 && (
+          <div className={styles.errorSection}>
+            <button
+              type="button"
+              className={styles.errorToggle}
+              onClick={() => setErrorExpanded((p) => !p)}
+              aria-expanded={errorExpanded}
+              aria-controls={`error-${taskId}`}
+            >
+              <AlertCircle size={13} className={styles.errorIcon} aria-hidden="true" />
+              <span>{failedNodes.length} node{failedNodes.length > 1 ? 's' : ''} failed</span>
+              {errorExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+            </button>
+
+            {errorExpanded && (
+              <div id={`error-${taskId}`} className={styles.errorDetails}>
+                {failedNodes.map((node) => (
+                  <div key={node.nodeId} className={styles.errorItem}>
+                    <span className={styles.errorNodeId}>
+                      {node.nodeId.replace(/^node[_-]/, '')}
+                    </span>
+                    <span className={styles.errorMsg}>
+                      {node.error || 'Unknown error'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─── Date separator ───────────────────────────────────────────────────────────
+
+interface DateBucketProps {
+  label: string;
+}
+
+const DateBucket: React.FC<DateBucketProps> = ({ label }) => (
+  <div className={styles.dateBucket} aria-label={`Tasks for ${label}`}>
+    <div className={styles.dateBucketLine} aria-hidden="true" />
+    <span className={styles.dateBucketLabel}>{label}</span>
+    <div className={styles.dateBucketLine} aria-hidden="true" />
+  </div>
+);
+
+// ─── Group tasks by bucket ────────────────────────────────────────────────────
+
+function getBucketLabel(date: Date): string {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const taskDay = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate()
+  ).getTime();
+  const diff = today - taskDay;
+
+  if (diff === 0) return 'Today';
+  if (diff === 86_400_000) return 'Yesterday';
+  if (diff < 7 * 86_400_000) {
+    return date.toLocaleDateString(undefined, { weekday: 'long' });
+  }
+  return date.toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+const EmptyState: React.FC<{ hasFilters: boolean }> = ({ hasFilters }) => (
+  <div className={styles.empty}>
+    <Clock size={40} className={styles.emptyIcon} aria-hidden="true" />
+    <p className={styles.emptyTitle}>
+      {hasFilters ? 'No tasks match the current filters' : 'No task history yet'}
+    </p>
+    <p className={styles.emptySubtitle}>
+      {hasFilters
+        ? 'Try adjusting the filters or expanding the zoom window.'
+        : 'Submit a task to see it appear here.'}
+    </p>
+  </div>
+);
+
+// ─── Skeleton loader ──────────────────────────────────────────────────────────
+
+const SkeletonEntry: React.FC = () => (
+  <div className={styles.entry}>
+    <div className={styles.connectorArea}>
+      <div className={`${styles.dot} ${styles.dotSkeleton}`} aria-hidden="true" />
+      <div className={styles.line} aria-hidden="true" />
+    </div>
+    <div className={`${styles.card} ${styles.skeletonCard}`}>
+      <div className={styles.skeletonLine} style={{ width: '60%' }} />
+      <div className={styles.skeletonLine} style={{ width: '40%', marginTop: 6 }} />
+    </div>
+  </div>
+);
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface TaskTimelineProps {
+  tasks: TaskResponse[];
+  loading: boolean;
+  selectedIds: [string | null, string | null];
+  onToggleSelect: (id: string) => void;
+  isComparing: boolean;
+  hasFilters: boolean;
+}
+
+export const TaskTimeline: React.FC<TaskTimelineProps> = ({
+  tasks,
+  loading,
+  selectedIds,
+  onToggleSelect,
+  isComparing,
+  hasFilters,
+}) => {
+  if (loading) {
+    return (
+      <div className={styles.timeline} aria-busy="true" aria-label="Loading task history">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <SkeletonEntry key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (tasks.length === 0) {
+    return <EmptyState hasFilters={hasFilters} />;
+  }
+
+  // Group tasks by date bucket
+  const buckets: { label: string; items: TaskResponse[] }[] = [];
+  let currentBucket: string | null = null;
+
+  for (const task of tasks) {
+    const label = getBucketLabel(new Date(task.createdAt));
+    if (label !== currentBucket) {
+      buckets.push({ label, items: [] });
+      currentBucket = label;
+    }
+    buckets[buckets.length - 1].items.push(task);
+  }
+
+  return (
+    <div className={styles.timeline} role="feed" aria-label="Task history timeline">
+      {buckets.map(({ label, items }) => (
+        <React.Fragment key={label}>
+          <DateBucket label={label} />
+          {items.map((task) => {
+            const taskId = task.taskId || task.id || '';
+            const selIndex =
+              selectedIds[0] === taskId
+                ? 0
+                : selectedIds[1] === taskId
+                ? 1
+                : null;
+
+            return (
+              <TimelineEntry
+                key={taskId}
+                task={task}
+                isSelected={selIndex !== null}
+                selectionIndex={selIndex as 0 | 1 | null}
+                onToggleSelect={onToggleSelect}
+                isComparing={isComparing}
+              />
+            );
+          })}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useTaskHistory.ts
+++ b/frontend/src/hooks/useTaskHistory.ts
@@ -1,0 +1,283 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import type { TaskResponse, NodeStatus } from '../types/api';
+import { apiClient } from '../services/api';
+
+// ─── Filter types ────────────────────────────────────────────────────────────
+
+export type ZoomLevel = 'day' | 'week' | 'month';
+
+export interface TaskHistoryFilters {
+  status: NodeStatus | 'all';
+  agentType: string;
+  dateFrom: string; // ISO date string or ''
+  dateTo: string;   // ISO date string or ''
+  zoom: ZoomLevel;
+  search: string;
+}
+
+export const DEFAULT_FILTERS: TaskHistoryFilters = {
+  status: 'all',
+  agentType: 'all',
+  dateFrom: '',
+  dateTo: '',
+  zoom: 'week',
+  search: '',
+};
+
+// ─── URL serialisation ───────────────────────────────────────────────────────
+
+export function filtersFromSearchParams(
+  params: URLSearchParams
+): TaskHistoryFilters {
+  return {
+    status: (params.get('status') as TaskHistoryFilters['status']) || 'all',
+    agentType: params.get('agentType') || 'all',
+    dateFrom: params.get('dateFrom') || '',
+    dateTo: params.get('dateTo') || '',
+    zoom: (params.get('zoom') as ZoomLevel) || 'week',
+    search: params.get('search') || '',
+  };
+}
+
+export function filtersToSearchParams(
+  filters: TaskHistoryFilters
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (filters.status !== 'all') out.status = filters.status;
+  if (filters.agentType !== 'all') out.agentType = filters.agentType;
+  if (filters.dateFrom) out.dateFrom = filters.dateFrom;
+  if (filters.dateTo) out.dateTo = filters.dateTo;
+  if (filters.zoom !== 'week') out.zoom = filters.zoom;
+  if (filters.search) out.search = filters.search;
+  return out;
+}
+
+// ─── Derived helpers ─────────────────────────────────────────────────────────
+
+/** Compute the total duration (ms) of a task. Returns undefined when unknown. */
+export function getTaskDuration(task: TaskResponse): number | undefined {
+  if (!task.createdAt || !task.updatedAt) return undefined;
+  const start = new Date(task.createdAt).getTime();
+  const end = new Date(task.updatedAt).getTime();
+  return end > start ? end - start : undefined;
+}
+
+/** Rough cost estimate: sum agent costs derived from agentType. */
+export function getTaskCost(task: TaskResponse): number {
+  if (!task.dag || !task.dag.length) return 0;
+  const costs: Record<string, number> = {
+    research: 0.5,
+    risk: 0.3,
+    coding: 1.2,
+    design: 0.6,
+    report: 0.4,
+  };
+  return task.dag.reduce((sum, node) => {
+    const type = (node.agentType || '').toLowerCase();
+    const match = Object.keys(costs).find((k) => type.includes(k));
+    return sum + (match ? costs[match] : 0.5);
+  }, 0);
+}
+
+/** Unique agent types used across a task's DAG */
+export function getTaskAgentTypes(task: TaskResponse): string[] {
+  if (!task.dag) return [];
+  const types = new Set<string>();
+  task.dag.forEach((n) => {
+    const base = (n.agentType || '').toLowerCase();
+    const key = ['research', 'risk', 'coding', 'design', 'report'].find((k) =>
+      base.includes(k)
+    );
+    if (key) types.add(key);
+  });
+  return Array.from(types);
+}
+
+/** Format ms duration as human-readable string */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = Math.round((ms % 60_000) / 1000);
+  return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+// ─── Filter logic ─────────────────────────────────────────────────────────────
+
+function taskMatchesFilters(
+  task: TaskResponse,
+  filters: TaskHistoryFilters
+): boolean {
+  // Status filter
+  if (filters.status !== 'all' && task.status !== filters.status) return false;
+
+  // Agent type filter
+  if (filters.agentType !== 'all') {
+    const types = getTaskAgentTypes(task);
+    if (!types.includes(filters.agentType)) return false;
+  }
+
+  // Date range filter
+  const createdAt = new Date(task.createdAt).getTime();
+  if (filters.dateFrom) {
+    const from = new Date(filters.dateFrom).getTime();
+    if (createdAt < from) return false;
+  }
+  if (filters.dateTo) {
+    // Include the whole "to" day
+    const to = new Date(filters.dateTo).getTime() + 86_400_000;
+    if (createdAt > to) return false;
+  }
+
+  // Full-text search against prompt
+  if (filters.search) {
+    const q = filters.search.toLowerCase();
+    if (!task.prompt?.toLowerCase().includes(q) && !task.taskId?.toLowerCase().includes(q)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/** Restrict task list to the zoom window relative to now */
+function applyZoom(tasks: TaskResponse[], zoom: ZoomLevel): TaskResponse[] {
+  const now = Date.now();
+  const windowMs: Record<ZoomLevel, number> = {
+    day: 86_400_000,
+    week: 7 * 86_400_000,
+    month: 30 * 86_400_000,
+  };
+  const cutoff = now - windowMs[zoom];
+  return tasks.filter((t) => new Date(t.createdAt).getTime() >= cutoff);
+}
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+export interface UseTaskHistoryResult {
+  /** All tasks fetched (unfiltered) */
+  allTasks: TaskResponse[];
+  /** Tasks matching current filters within the zoom window */
+  filteredTasks: TaskResponse[];
+  loading: boolean;
+  error: string | null;
+  /** Currently applied filters */
+  filters: TaskHistoryFilters;
+  /** Update one or more filter fields */
+  updateFilters: (next: Partial<TaskHistoryFilters>) => void;
+  /** Reset all filters to defaults */
+  resetFilters: () => void;
+  /** Refetch task list from API */
+  refetch: () => void;
+  /** IDs of the (up to 2) tasks selected for comparison */
+  selectedIds: [string | null, string | null];
+  /** Toggle a task's selection for comparison; deselects oldest if >2 */
+  toggleSelect: (taskId: string) => void;
+  /** Clear the comparison selection */
+  clearSelection: () => void;
+  /** Whether comparison mode is active (both slots filled) */
+  isComparing: boolean;
+  /** Available agent types derived from the full task list */
+  availableAgentTypes: string[];
+}
+
+export function useTaskHistory(
+  filters: TaskHistoryFilters,
+  updateFilters: (next: Partial<TaskHistoryFilters>) => void,
+  resetFilters: () => void
+): UseTaskHistoryResult {
+  const [allTasks, setAllTasks] = useState<TaskResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<[string | null, string | null]>([
+    null,
+    null,
+  ]);
+
+  const fetchTasks = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const walletAddress =
+        localStorage.getItem('wallet_pubkey') ||
+        localStorage.getItem('walletAddress') ||
+        '';
+
+      let tasks: TaskResponse[] = [];
+      if (walletAddress) {
+        tasks = await apiClient.get<TaskResponse[]>(
+          `/api/wallets/${walletAddress}/tasks?limit=200`
+        );
+      } else {
+        // Fallback: try generic tasks endpoint
+        tasks = await apiClient.get<TaskResponse[]>('/api/tasks?limit=200');
+      }
+      setAllTasks(Array.isArray(tasks) ? tasks : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load task history');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTasks();
+  }, [fetchTasks]);
+
+  // Derive filtered + zoomed list
+  const filteredTasks = useMemo(() => {
+    const afterFilter = allTasks.filter((t) => taskMatchesFilters(t, filters));
+    // Only apply zoom when no explicit date range is set
+    if (!filters.dateFrom && !filters.dateTo) {
+      return applyZoom(afterFilter, filters.zoom).sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+    }
+    return afterFilter.sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+  }, [allTasks, filters]);
+
+  // Available agent types for filter dropdown
+  const availableAgentTypes = useMemo(() => {
+    const types = new Set<string>();
+    allTasks.forEach((t) => getTaskAgentTypes(t).forEach((k) => types.add(k)));
+    return Array.from(types).sort();
+  }, [allTasks]);
+
+  const toggleSelect = useCallback((taskId: string) => {
+    setSelectedIds((prev) => {
+      const [a, b] = prev;
+      // Deselect if already selected
+      if (a === taskId) return [b, null];
+      if (b === taskId) return [a, null];
+      // Fill first empty slot
+      if (a === null) return [taskId, b];
+      if (b === null) return [a, taskId];
+      // Both slots filled: replace oldest (a) with new
+      return [b, taskId];
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds([null, null]);
+  }, []);
+
+  const isComparing = selectedIds[0] !== null && selectedIds[1] !== null;
+
+  return {
+    allTasks,
+    filteredTasks,
+    loading,
+    error,
+    filters,
+    updateFilters,
+    resetFilters,
+    refetch: fetchTasks,
+    selectedIds,
+    toggleSelect,
+    clearSelection,
+    isComparing,
+    availableAgentTypes,
+  };
+}

--- a/frontend/src/pages/tasks/TaskHistoryPage.module.css
+++ b/frontend/src/pages/tasks/TaskHistoryPage.module.css
@@ -1,0 +1,156 @@
+.page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* ─── Header ────────────────────────────────────────────────────── */
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.headerIcon {
+  color: var(--primary);
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1.15;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  margin: 4px 0 0;
+}
+
+/* ─── Selection banner ──────────────────────────────────────────── */
+
+.selectionBanner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(139, 92, 246, 0.1);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  border-radius: 10px;
+  padding: 8px 14px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #c4b5fd;
+}
+
+.compareBtn {
+  background: var(--primary);
+  border: none;
+  color: #fff;
+  padding: 5px 14px;
+  border-radius: 7px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  box-shadow: none;
+  transition: background 0.15s;
+}
+
+.compareBtn:hover {
+  background: var(--primary-hover);
+  transform: none;
+  box-shadow: none;
+}
+
+.clearBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid rgba(139, 92, 246, 0.35);
+  color: #a78bfa;
+  padding: 4px 10px;
+  border-radius: 7px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  box-shadow: none;
+  transition: background 0.15s;
+  margin-left: 4px;
+}
+
+.clearBtn:hover {
+  background: rgba(139, 92, 246, 0.12);
+  transform: none;
+  box-shadow: none;
+}
+
+/* ─── Error ─────────────────────────────────────────────────────── */
+
+.errorBox {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 14px 18px;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 10px;
+  color: #fca5a5;
+  font-size: 0.875rem;
+  margin-bottom: 16px;
+}
+
+.errorBox p {
+  margin: 0;
+}
+
+.retryButton {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+  padding: 6px 14px;
+  border-radius: 7px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  box-shadow: none;
+  white-space: nowrap;
+}
+
+.retryButton:hover {
+  background: rgba(239, 68, 68, 0.25);
+  transform: none;
+  box-shadow: none;
+}
+
+/* ─── Responsive ────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .page {
+    padding: 16px;
+  }
+
+  .title {
+    font-size: 1.4rem;
+  }
+
+  .header {
+    flex-direction: column;
+  }
+
+  .selectionBanner {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/pages/tasks/TaskHistoryPage.tsx
+++ b/frontend/src/pages/tasks/TaskHistoryPage.tsx
@@ -1,0 +1,159 @@
+import React, { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { History, ArrowLeftRight, X } from 'lucide-react';
+import {
+  useTaskHistory,
+  filtersFromSearchParams,
+  filtersToSearchParams,
+  type TaskHistoryFilters,
+} from '../../hooks/useTaskHistory';
+import { TaskFilterBar } from '../../components/tasks/TaskFilterBar';
+import { TaskTimeline } from '../../components/tasks/TaskTimeline';
+import { TaskComparison } from '../../components/tasks/TaskComparison';
+import styles from './TaskHistoryPage.module.css';
+
+const TaskHistoryPage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Derive filters from URL so the view is shareable / bookmarkable
+  const filters = useMemo(
+    () => filtersFromSearchParams(searchParams),
+    [searchParams]
+  );
+
+  const updateFilters = useCallback(
+    (next: Partial<TaskHistoryFilters>) => {
+      const merged = { ...filters, ...next };
+      setSearchParams(filtersToSearchParams(merged), { replace: true });
+    },
+    [filters, setSearchParams]
+  );
+
+  const resetFilters = useCallback(() => {
+    setSearchParams({}, { replace: true });
+  }, [setSearchParams]);
+
+  const {
+    allTasks,
+    filteredTasks,
+    loading,
+    error,
+    refetch,
+    selectedIds,
+    toggleSelect,
+    clearSelection,
+    isComparing,
+    availableAgentTypes,
+  } = useTaskHistory(filters, updateFilters, resetFilters);
+
+  // Resolve the two selected tasks for the comparison panel
+  const taskA = useMemo(
+    () => allTasks.find((t) => (t.taskId || t.id) === selectedIds[0]) ?? null,
+    [allTasks, selectedIds]
+  );
+  const taskB = useMemo(
+    () => allTasks.find((t) => (t.taskId || t.id) === selectedIds[1]) ?? null,
+    [allTasks, selectedIds]
+  );
+
+  const hasFilters =
+    filters.status !== 'all' ||
+    filters.agentType !== 'all' ||
+    !!filters.dateFrom ||
+    !!filters.dateTo ||
+    !!filters.search;
+
+  return (
+    <div className={styles.page}>
+      {/* Page header */}
+      <div className={styles.header}>
+        <div className={styles.headerLeft}>
+          <History size={22} className={styles.headerIcon} aria-hidden="true" />
+          <div>
+            <h1 className={styles.title}>Task History</h1>
+            <p className={styles.subtitle}>
+              {loading
+                ? 'Loading…'
+                : `${filteredTasks.length} of ${allTasks.length} task${
+                    allTasks.length === 1 ? '' : 's'
+                  }`}
+            </p>
+          </div>
+        </div>
+
+        {/* Comparison hint / banner */}
+        {(selectedIds[0] !== null || selectedIds[1] !== null) && (
+          <div className={styles.selectionBanner} role="status">
+            <ArrowLeftRight size={15} aria-hidden="true" />
+            <span>
+              {selectedIds[0] !== null && selectedIds[1] !== null
+                ? 'Ready to compare — click Compare'
+                : `${selectedIds[0] !== null || selectedIds[1] !== null ? 1 : 0} of 2 tasks selected`}
+            </span>
+
+            {isComparing && (
+              <button
+                type="button"
+                className={styles.compareBtn}
+                onClick={() => {
+                  /* comparison panel opens automatically when isComparing && taskA && taskB */
+                }}
+                aria-label="View comparison panel"
+              >
+                Compare
+              </button>
+            )}
+
+            <button
+              type="button"
+              className={styles.clearBtn}
+              onClick={clearSelection}
+              aria-label="Clear selection"
+            >
+              <X size={13} />
+              Clear
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Error state */}
+      {error && !loading && (
+        <div className={styles.errorBox} role="alert">
+          <p>Failed to load task history: {error}</p>
+          <button type="button" className={styles.retryButton} onClick={refetch}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Filter bar */}
+      <TaskFilterBar
+        filters={filters}
+        availableAgentTypes={availableAgentTypes}
+        onChange={updateFilters}
+        onReset={resetFilters}
+        onRefresh={refetch}
+        totalCount={allTasks.length}
+        filteredCount={filteredTasks.length}
+      />
+
+      {/* Timeline */}
+      <TaskTimeline
+        tasks={filteredTasks}
+        loading={loading}
+        selectedIds={selectedIds}
+        onToggleSelect={toggleSelect}
+        isComparing={isComparing}
+        hasFilters={hasFilters}
+      />
+
+      {/* Comparison panel — shown when both tasks selected */}
+      {isComparing && taskA && taskB && (
+        <TaskComparison taskA={taskA} taskB={taskB} onClose={clearSelection} />
+      )}
+    </div>
+  );
+};
+
+export default TaskHistoryPage;


### PR DESCRIPTION
## Summary

Implements issue #234 — a rich task history timeline that lets users review past executions, filter by status/date/agent, compare two tasks side-by-side, and export comparison reports.

## What's included

### `useTaskHistory` hook
- Fetches task history from the API (wallet-scoped or generic fallback)
- Filters by status, agent type, date range, and full-text search against prompt/ID
- Zoom window (day / week / month) restricts the visible time range when no explicit date range is set
- URL query-param sync — all filter state is reflected in the URL so views are bookmarkable and shareable
- Two-slot comparison selection with toggle/clear helpers

### `TaskFilterBar` component
- Status toggle: All / Pending / Running / Completed / Failed
- Agent-type chips derived from the actual task list
- Date range pickers (from / to) with mutual min/max constraints
- Zoom selector: Today / This Week / This Month
- Full-text search with clear button
- Live result count, refresh button, and clear-all

### `TaskTimeline` component
- Vertical timeline grouped by date bucket (Today, Yesterday, weekday name, full date)
- Status-coloured animated dots: amber (pending), pulsing indigo (running), green (completed), red (failed)
- Per-entry: truncated prompt, short task ID, status badge, date/time, agent pills, segmented execution bar per DAG node, duration, estimated XLM cost
- Expandable error details panel for failed tasks — shows each failed node ID and error message
- Click checkbox to select up to 2 tasks for comparison; numbered badges show selection order
- Skeleton loader while fetching; contextual empty state

### `TaskComparison` component
- Full-screen modal split view (responsive: stacked on mobile)
- Per-column: status + date header, prompt, metrics grid (duration / cost / nodes / agents), all agent outputs
- Word-level diff highlighting toggle — unique words in each task's output/prompt are highlighted amber
- One-click **Export MD** — downloads a full markdown comparison report with summary table, prompts, and all agent outputs
- Keyboard-accessible with backdrop click to close

### `TaskHistoryPage`
- Assembles all components; filter state lives in URL so it's shareable
- Selection banner shows comparison readiness; `/tasks/history` route added before `/tasks/:id`
- "Task History" nav item added to Sidebar and MobileDrawer (History icon)

## Acceptance criteria checklist

- [x] Timeline view shows tasks as vertical timeline with status-coloured dots
- [x] Filter bar: status (pending/running/completed/failed), date range, agent type
- [x] Clicking two tasks enables comparison mode (split view)
- [x] Comparison view shows side-by-side: prompt, agent outputs, duration, cost
- [x] Timeline zoom: day, week, month views
- [x] Each timeline entry shows: task name, status badge, agent icons, duration, cost
- [x] Failed tasks highlighted with expandable error details
- [x] Export comparison as markdown report

## Testing

- `tsc --noEmit`: 0 errors
- `vitest run`: 116/116 tests pass (all pre-existing tests green, no regressions)

## Files

| File | Action |
|---|---|
| `frontend/src/hooks/useTaskHistory.ts` | New |
| `frontend/src/components/tasks/TaskFilterBar.tsx` | New |
| `frontend/src/components/tasks/TaskFilterBar.module.css` | New |
| `frontend/src/components/tasks/TaskTimeline.tsx` | New |
| `frontend/src/components/tasks/TaskTimeline.module.css` | New |
| `frontend/src/components/tasks/TaskComparison.tsx` | New |
| `frontend/src/components/tasks/TaskComparison.module.css` | New |
| `frontend/src/pages/tasks/TaskHistoryPage.tsx` | New |
| `frontend/src/pages/tasks/TaskHistoryPage.module.css` | New |
| `frontend/src/App.tsx` | Modified — added route |
| `frontend/src/components/layout/Sidebar.tsx` | Modified — added nav item |
| `frontend/src/components/layout/MobileDrawer.tsx` | Modified — added nav item |

Closes #234