### PR TITLE
feat(backend): Add Payment Reconciliation and Accounting Reports

### DIFF
--- a/backend/__mocks__/@stellar/stellar-sdk.js
+++ b/backend/__mocks__/@stellar/stellar-sdk.js
@@ -17,6 +17,14 @@ const Keypair = {
 const Server = jest.fn().mockImplementation(() => ({
   loadAccount: jest.fn().mockResolvedValue({ id: "GCOORDINATOR", sequence: "1" }),
   submitTransaction: jest.fn().mockResolvedValue({ hash: "txhash-001" }),
+  claimableBalances: jest.fn().mockReturnValue({
+    claimableBalance: jest.fn().mockReturnValue({
+      call: jest.fn().mockResolvedValue({ id: "cb-1", amount: "1.0000000", asset: "native", sponsor: "GCOORDINATOR", claimants: [{ destination: "GAGENT" }] }),
+    }),
+    forAsset: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    call: jest.fn().mockResolvedValue({ records: [] }),
+  }),
 }));
 
 const Horizon = { Server };

--- a/backend/src/@types/@stellar/stellar-sdk.d.ts
+++ b/backend/src/@types/@stellar/stellar-sdk.d.ts
@@ -12,6 +12,7 @@ declare module "@stellar/stellar-sdk" {
     constructor(serverURL: string);
     loadAccount(publicKey: string): Promise<AccountResponse>;
     submitTransaction(tx: Transaction): Promise<HorizonResponse>;
+    claimableBalances(): ClaimableBalanceCallBuilder;
   }
 
   export namespace Horizon {
@@ -19,7 +20,33 @@ declare module "@stellar/stellar-sdk" {
       constructor(serverURL: string);
       loadAccount(publicKey: string): Promise<AccountResponse>;
       submitTransaction(tx: Transaction): Promise<HorizonResponse>;
+      claimableBalances(): ClaimableBalanceCallBuilder;
     }
+  }
+
+  export class ClaimableBalanceRecordBuilder {
+    call(): Promise<ClaimableBalanceRecord>;
+  }
+
+  export class ClaimableBalanceCallBuilder {
+    claimableBalance(balanceId: string): ClaimableBalanceRecordBuilder;
+    forAsset(asset: Asset): ClaimableBalanceCallBuilder;
+    limit(limit: number): ClaimableBalanceCallBuilder;
+    call(): Promise<ClaimableBalancePage>;
+    next(): Promise<ClaimableBalancePage>;
+  }
+
+  export interface ClaimableBalanceRecord {
+    id: string;
+    asset: string;
+    amount: string;
+    sponsor: string;
+    claimants?: Array<{ destination: string; predicate?: unknown }>;
+  }
+
+  export interface ClaimableBalancePage {
+    records: ClaimableBalanceRecord[];
+    next(): Promise<ClaimableBalancePage>;
   }
 
   export interface AccountResponse {

--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -22,6 +22,7 @@ import { agentsRouter } from "./routes/agents";
 import { healthRouter } from "./routes/health";
 import { createStatsRouter } from "./routes/stats";
 import { createTasksRouter } from "./routes/tasks";
+import { createReconciliationRouter, type ReconciliationRouterOptions } from "./routes/reconciliation";
 import { rateLimitMiddleware, registerRateLimitMiddleware } from "./middleware/rateLimit";
 import { authMiddleware } from "./middleware/auth";
 import { createCorsMiddleware } from "./middleware/cors";
@@ -51,6 +52,8 @@ export interface AppOptions {
   enableHeartbeatCleanup?: boolean;
   /** Custom options for heartbeat cleanup service */
   heartbeatOptions?: HeartbeatServiceOptions;
+  /** Options for the payment reconciliation router */
+  reconciliation?: ReconciliationRouterOptions;
 }
 
 /**
@@ -116,6 +119,9 @@ export function createApp(opts: AppOptions = {}): {
 
   // ── Task routes ────────────────────────────────────────────────────────────
   app.use("/api/tasks", createTasksRouter(dispatch, releasePayment));
+
+  // ── Payment reconciliation routes ──────────────────────────────────────────
+  app.use("/api/reconciliation", createReconciliationRouter(opts.reconciliation));
 
   // ── HTTP server ────────────────────────────────────────────────────────────
   const httpServer = createServer(app);

--- a/backend/src/api/routes/reconciliation.ts
+++ b/backend/src/api/routes/reconciliation.ts
@@ -1,0 +1,93 @@
+import { Router } from 'express';
+import {
+  ReconciliationService,
+  createDefaultReconciliationService,
+} from '../../services/reconciliation';
+import type { ReconciliationTrigger } from '../../services/reconciliation.types';
+
+export interface ReconciliationRouterOptions {
+  /** Service to use; defaults to the production service. */
+  service?: ReconciliationService;
+}
+
+/**
+ * @openapi
+ * /api/reconciliation/run:
+ *   post:
+ *     summary: Trigger a payment reconciliation check
+ *     operationId: runReconciliation
+ *     tags: [Reconciliation]
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               triggeredBy:
+ *                 type: string
+ *                 enum: [manual, scheduled, release]
+ *                 default: manual
+ *     responses:
+ *       200:
+ *         description: Reconciliation report for this run
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ReconciliationReport'
+ *       500:
+ *         description: Reconciliation run failed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ * /api/reconciliation/report:
+ *   get:
+ *     summary: Get the latest reconciliation report
+ *     operationId: getLatestReconciliationReport
+ *     tags: [Reconciliation]
+ *     responses:
+ *       200:
+ *         description: Latest reconciliation report
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ReconciliationReport'
+ *       404:
+ *         description: No reconciliation report has been generated yet
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export function createReconciliationRouter(
+  options: ReconciliationRouterOptions = {}
+): Router {
+  const router = Router();
+  let service: ReconciliationService | null = null;
+  const getService = (): ReconciliationService =>
+    (service ??= options.service ?? createDefaultReconciliationService());
+
+  router.post('/run', async (req, res) => {
+    try {
+      const requested = req.body?.triggeredBy as string | undefined;
+      const triggeredBy: ReconciliationTrigger =
+        requested === 'scheduled' || requested === 'release' ? requested : 'manual';
+
+      const report = await getService().run(triggeredBy);
+      return res.status(200).json(report);
+    } catch (error) {
+      console.error('Reconciliation run failed', error);
+      return res.status(500).json({ error: 'RECONCILIATION_FAILED' });
+    }
+  });
+
+  router.get('/report', (_req, res) => {
+    const report = getService().getLatestReport();
+    if (!report) {
+      return res.status(404).json({ error: 'NO_RECONCILIATION_REPORT' });
+    }
+    return res.status(200).json(report);
+  });
+
+  return router;
+}

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -39,6 +39,12 @@ const envSchema = z.object({
   HEARTBEAT_STALE_THRESHOLD_MINUTES: z.coerce.number().int().positive().default(5),
   /** Hours an offline agent is kept before permanent cleanup. Default: 24. */
   AGENT_OFFLINE_DELETE_HOURS: z.coerce.number().int().positive().default(24),
+
+  // ── Payment reconciliation ──────────────────────────────────────────────────
+  /** Optional webhook URL that receives reconciliation discrepancy alerts. */
+  RECONCILIATION_WEBHOOK_URL: z.string().url().optional(),
+  /** Automated reconciliation interval in milliseconds. Default: 86 400 000 (daily). */
+  RECONCILIATION_INTERVAL_MS: z.coerce.number().int().positive().default(86_400_000),
 });
 
 

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -65,6 +65,8 @@ export interface PaymentDb {
   insert(record: PaymentRecord): void;
   findByKey(taskId: string, nodeId: string): PaymentRecord | undefined;
   updateStatus(taskId: string, nodeId: string, status: PaymentStatus, txHash: string): void;
+  /** All payment records — used by payment reconciliation. */
+  listAll(): PaymentRecord[];
 }
 
 export function createPaymentDb(db: Database.Database): PaymentDb {
@@ -99,6 +101,18 @@ export function createPaymentDb(db: Database.Database): PaymentDb {
       db.prepare(
         "UPDATE payments SET status = ?, txHash = ? WHERE taskId = ? AND nodeId = ?"
       ).run(status, txHash, taskId, nodeId);
+    },
+
+    listAll(): PaymentRecord[] {
+      const rows = db.prepare("SELECT * FROM payments").all() as Array<Record<string, unknown>>;
+      return rows.map((row) => ({
+        taskId: row.taskId as string,
+        nodeId: row.nodeId as string,
+        balanceId: row.balanceId as string,
+        status: row.status as PaymentStatus,
+        amountStroops: BigInt(row.amountStroops as string),
+        txHash: row.txHash as string | null,
+      }));
     },
   };
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import { AgentCleanupService } from "./services/agentCleanup";
 import { createTaskDb, getTaskDb, closeTaskDb } from "./db/tasks";
 import { createAgentDb, getAgentDb, closeAgentDb } from "./db/agents";
 import { closeDb } from "./db/index";
+import { createDefaultReconciliationService } from "./services/reconciliation";
 
 async function main() {
   // ── Validate env config at startup ──────────────────────────────────────────
@@ -32,6 +33,10 @@ async function main() {
     const cleanupService = new AgentCleanupService();
     cleanupService.start();
 
+    // Start daily payment reconciliation
+    const reconciliationService = createDefaultReconciliationService();
+    reconciliationService.startDaily(config.RECONCILIATION_INTERVAL_MS);
+
     // Create and start the server
     const { httpServer, close } = createApp();
 
@@ -49,6 +54,8 @@ async function main() {
       console.log("  - GET  /api/agents                 - List all agents");
       console.log("  - GET  /api/agents/capability/:type - Find agents by capability");
       console.log("  - POST /api/agents/:id/heartbeat    - Agent heartbeat");
+      console.log("  - POST /api/reconciliation/run      - Run payment reconciliation");
+      console.log("  - GET  /api/reconciliation/report   - Latest reconciliation report");
     });
 
     // ── Graceful shutdown ──────────────────────────────────────────────────────
@@ -60,6 +67,7 @@ async function main() {
       }, 10_000);
 
       cleanupService.stop();
+      reconciliationService.stop();
       globalAgentRegistry.shutdown();
       stopAgentSync();
 

--- a/backend/src/payment/payment.ts
+++ b/backend/src/payment/payment.ts
@@ -55,11 +55,29 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+export interface PaymentServiceHooks {
+  /**
+   * Invoked after a payment is successfully released on-chain so callers can
+   * trigger a reconciliation check (e.g. `ReconciliationService.run('release')`).
+   */
+  reconciliationHook?: (record: PaymentRecord) => void;
+}
+
 export class PaymentService {
   private server: Server;
 
-  constructor(private db: PaymentDb) {
+  constructor(
+    private db: PaymentDb,
+    private hooks: PaymentServiceHooks = {}
+  ) {
     this.server = new Server(STELLAR_HORIZON);
+  }
+
+  /**
+   * Enumerate all local payment records — the reconciliation source of truth.
+   */
+  listLocalRecords(): PaymentRecord[] {
+    return this.db.listAll();
   }
 
   async lock(
@@ -145,6 +163,12 @@ export class PaymentService {
     const txHash = (result as unknown as { hash: string }).hash;
 
     this.db.updateStatus(taskId, nodeId, "released", txHash);
+
+    this.hooks.reconciliationHook?.({
+      ...record,
+      status: "released",
+      txHash,
+    });
     return txHash;
   }
 

--- a/backend/src/services/reconciliation.test.ts
+++ b/backend/src/services/reconciliation.test.ts
@@ -1,0 +1,502 @@
+import express from "express";
+import request from "supertest";
+import { createReconciliationRouter } from "../api/routes/reconciliation";
+import {
+  ReconciliationService,
+  createSqliteReconciliationReportStore,
+  xlmStringToStroops,
+  type ClaimableBalanceProvider,
+  type ReconciliationReportStore,
+} from "./reconciliation";
+import type { PaymentDb, PaymentRecord, PaymentStatus } from "../db/index";
+import type {
+  ClaimableBalanceOnChain,
+  ReconciliationReport,
+} from "./reconciliation.types";
+
+jest.mock("@stellar/stellar-sdk");
+
+function makePaymentDb(records: PaymentRecord[] = []): PaymentDb {
+  const store = new Map<string, PaymentRecord>(
+    records.map((record) => [`${record.taskId}:${record.nodeId}`, { ...record }])
+  );
+  return {
+    insert(record: PaymentRecord): void {
+      store.set(`${record.taskId}:${record.nodeId}`, { ...record });
+    },
+    findByKey(taskId: string, nodeId: string): PaymentRecord | undefined {
+      return store.get(`${taskId}:${nodeId}`);
+    },
+    updateStatus(taskId: string, nodeId: string, status: PaymentStatus, txHash: string): void {
+      const record = store.get(`${taskId}:${nodeId}`);
+      if (record) {
+        record.status = status;
+        record.txHash = txHash;
+      }
+    },
+    listAll(): PaymentRecord[] {
+      return [...store.values()].map((record) => ({ ...record }));
+    },
+  };
+}
+
+function makeOnChainProvider(balances: ClaimableBalanceOnChain[] = []): ClaimableBalanceProvider {
+  return {
+    getBalance: jest.fn(async (balanceId: string) => {
+      const balance = balances.find((b) => b.balanceId === balanceId);
+      return balance ?? null;
+    }),
+    listBalances: jest.fn(async () => balances.map((b) => ({ ...b }))),
+  };
+}
+
+function makeReportStore(): { store: ReconciliationReportStore; reports: ReconciliationReport[] } {
+  const reports: ReconciliationReport[] = [];
+  return {
+    reports,
+    store: {
+      save(report) {
+        reports.push(report);
+      },
+      getLatest() {
+        return [...reports].sort((a, b) => b.runAt.localeCompare(a.runAt))[0];
+      },
+    },
+  };
+}
+
+function makeRecord(overrides: Partial<PaymentRecord> = {}): PaymentRecord {
+  return {
+    taskId: "task-1",
+    nodeId: "node-risk",
+    balanceId: "cb-local-1",
+    status: "locked",
+    amountStroops: 10_000_000n,
+    txHash: null,
+    ...overrides,
+  };
+}
+
+function makeBalance(overrides: Partial<ClaimableBalanceOnChain> = {}): ClaimableBalanceOnChain {
+  return {
+    balanceId: "cb-onchain-1",
+    amountStroops: "10000000",
+    asset: "native",
+    sponsor: "GCOORDINATOR",
+    claimant: "GAGENT",
+    ...overrides,
+  };
+}
+
+// ─── Amount conversion ────────────────────────────────────────────────────────
+
+describe("xlmStringToStroops", () => {
+  it("converts a full XLM amount string to stroops", () => {
+    expect(xlmStringToStroops("1.0000000")).toBe(10_000_000n);
+    expect(xlmStringToStroops("10.0000000")).toBe(100_000_000n);
+  });
+
+  it("converts sub-stroop precision exactly (no float rounding)", () => {
+    expect(xlmStringToStroops("0.0000001")).toBe(1n);
+    expect(xlmStringToStroops("42.1234567")).toBe(421_234_567n);
+  });
+
+  it("handles amounts without a fractional part", () => {
+    expect(xlmStringToStroops("5")).toBe(50_000_000n);
+  });
+});
+
+// ─── Reconciliation run ───────────────────────────────────────────────────────
+
+describe("ReconciliationService.run", () => {
+  it("flags missing_on_chain for locked records without an on-chain balance", async () => {
+    const paymentDb = makePaymentDb([makeRecord()]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([]),
+      reportStore: makeReportStore().store,
+    });
+
+    const report = await service.run();
+
+    expect(report.status).toBe("discrepancies_found");
+    expect(report.discrepancies).toHaveLength(1);
+    expect(report.discrepancies[0]).toMatchObject({
+      type: "missing_on_chain",
+      balanceId: "cb-local-1",
+      severity: "critical",
+    });
+    expect(report.summary.missingOnChain).toBe(1);
+  });
+
+  it("does not flag released/refunded records missing on-chain (claimed as expected)", async () => {
+    const paymentDb = makePaymentDb([
+      makeRecord({ taskId: "t-released", status: "released", txHash: "hash-1" }),
+      makeRecord({ taskId: "t-refunded", status: "refunded", txHash: "hash-2" }),
+    ]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([]),
+      reportStore: makeReportStore().store,
+    });
+
+    const report = await service.run();
+
+    expect(report.status).toBe("consistent");
+    expect(report.discrepancies).toHaveLength(0);
+  });
+
+  it("flags missing_local for on-chain balances with no local record", async () => {
+    const paymentDb = makePaymentDb([]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([makeBalance()]),
+      reportStore: makeReportStore().store,
+    });
+
+    const report = await service.run();
+
+    expect(report.status).toBe("discrepancies_found");
+    expect(report.discrepancies[0]).toMatchObject({
+      type: "missing_local",
+      balanceId: "cb-onchain-1",
+    });
+    expect(report.summary.missingLocal).toBe(1);
+  });
+
+  it("flags amount_mismatch when on-chain and local amounts differ", async () => {
+    const paymentDb = makePaymentDb([makeRecord()]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([
+        makeBalance({ balanceId: "cb-local-1", amountStroops: "5000000" }),
+      ]),
+      reportStore: makeReportStore().store,
+    });
+
+    const report = await service.run();
+
+    expect(report.discrepancies).toHaveLength(1);
+    expect(report.discrepancies[0]).toMatchObject({
+      type: "amount_mismatch",
+      balanceId: "cb-local-1",
+      localAmountStroops: "10000000",
+      onChainAmountStroops: "5000000",
+      expectedAmountStroops: "10000000",
+      severity: "critical",
+    });
+    expect(report.summary.amountMismatch).toBe(1);
+  });
+
+  it("flags amount_mismatch when a released record still has an on-chain balance", async () => {
+    const paymentDb = makePaymentDb([
+      makeRecord({ taskId: "t-released", status: "released", txHash: "hash-1" }),
+    ]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([
+        makeBalance({ balanceId: "cb-local-1" }),
+      ]),
+      reportStore: makeReportStore().store,
+    });
+
+    const report = await service.run();
+
+    expect(report.discrepancies).toHaveLength(1);
+    expect(report.discrepancies[0]).toMatchObject({
+      type: "amount_mismatch",
+      severity: "warning",
+      expectedAmountStroops: "0",
+      onChainAmountStroops: "10000000",
+    });
+  });
+
+  it("returns a consistent report when all records match", async () => {
+    const paymentDb = makePaymentDb([makeRecord()]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([
+        makeBalance({ balanceId: "cb-local-1" }),
+      ]),
+      reportStore: makeReportStore().store,
+    });
+
+    const report = await service.run();
+
+    expect(report.status).toBe("consistent");
+    expect(report.discrepancies).toHaveLength(0);
+    expect(report.summary).toEqual({
+      totalLocalRecords: 1,
+      totalOnChainBalances: 1,
+      matched: 1,
+      discrepancies: 0,
+      missingOnChain: 0,
+      missingLocal: 0,
+      amountMismatch: 0,
+    });
+  });
+
+  it("persists the report with a timestamp", async () => {
+    const paymentDb = makePaymentDb([makeRecord()]);
+    const reportStore = makeReportStore();
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([]),
+      reportStore: reportStore.store,
+    });
+
+    const report = await service.run("manual");
+
+    expect(reportStore.reports).toHaveLength(1);
+    expect(reportStore.reports[0].id).toBe(report.id);
+    expect(reportStore.reports[0].runAt).toBe(report.runAt);
+    expect(new Date(report.runAt).toISOString()).toBe(report.runAt);
+    expect(report.triggeredBy).toBe("manual");
+  });
+
+  it("returns the latest report from the store", async () => {
+    const paymentDb = makePaymentDb([]);
+    const reportStore = makeReportStore();
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([]),
+      reportStore: reportStore.store,
+    });
+
+    await service.run();
+    const latest = service.getLatestReport();
+
+    expect(latest).toBeDefined();
+    expect(latest!.runAt).toBe(reportStore.reports[0].runAt);
+  });
+
+  it("returns undefined before any run has been persisted", () => {
+    const service = new ReconciliationService({
+      paymentDb: makePaymentDb(),
+      onChainProvider: makeOnChainProvider([]),
+      reportStore: makeReportStore().store,
+    });
+
+    expect(service.getLatestReport()).toBeUndefined();
+  });
+});
+
+// ─── Alerting ─────────────────────────────────────────────────────────────────
+
+describe("ReconciliationService alerts", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("POSTs the report to the webhook when discrepancies are found", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const paymentDb = makePaymentDb([makeRecord()]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([]),
+      reportStore: makeReportStore().store,
+      webhookUrl: "https://alerts.example.com/reconciliation",
+    });
+
+    const report = await service.run();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://alerts.example.com/reconciliation");
+    expect(JSON.parse((init as RequestInit).body as string).id).toBe(report.id);
+  });
+
+  it("does not POST to the webhook when no discrepancies are found", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const paymentDb = makePaymentDb([makeRecord()]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([
+        makeBalance({ balanceId: "cb-local-1" }),
+      ]),
+      reportStore: makeReportStore().store,
+      webhookUrl: "https://alerts.example.com/reconciliation",
+    });
+
+    await service.run();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("logs each discrepancy", async () => {
+    const warn = jest.fn();
+    const paymentDb = makePaymentDb([makeRecord()]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([]),
+      reportStore: makeReportStore().store,
+      logger: { info: jest.fn(), warn, error: jest.fn() },
+    });
+
+    await service.run();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ discrepancy: expect.objectContaining({ type: "missing_on_chain" }) }),
+      expect.stringContaining("missing_on_chain")
+    );
+  });
+
+  it("survives webhook delivery failures without throwing", async () => {
+    const fetchMock = jest.fn().mockRejectedValue(new Error("network down"));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const paymentDb = makePaymentDb([makeRecord()]);
+    const service = new ReconciliationService({
+      paymentDb,
+      onChainProvider: makeOnChainProvider([]),
+      reportStore: makeReportStore().store,
+      webhookUrl: "https://alerts.example.com/reconciliation",
+    });
+
+    const report = await service.run();
+    expect(report.status).toBe("discrepancies_found");
+  });
+});
+
+// ─── Report store ─────────────────────────────────────────────────────────────
+
+describe("createSqliteReconciliationReportStore", () => {
+  it("persists reports and returns the latest by runAt", () => {
+    const Database = require("better-sqlite3");
+    const store = createSqliteReconciliationReportStore(new Database(":memory:"));
+
+    const earlier = {
+      id: "r-1",
+      runAt: "2026-08-18T00:00:00.000Z",
+      triggeredBy: "manual",
+      status: "consistent",
+      summary: {
+        totalLocalRecords: 0,
+        totalOnChainBalances: 0,
+        matched: 0,
+        discrepancies: 0,
+        missingOnChain: 0,
+        missingLocal: 0,
+        amountMismatch: 0,
+      },
+      discrepancies: [],
+    } as ReconciliationReport;
+
+    const later = { ...earlier, id: "r-2", runAt: "2026-08-19T00:00:00.000Z" };
+
+    store.save(earlier);
+    store.save(later);
+
+    expect(store.getLatest()?.id).toBe("r-2");
+  });
+});
+
+// ─── Payment service hook ─────────────────────────────────────────────────────
+
+describe("PaymentService reconciliation hook", () => {
+  it("exposes listLocalRecords from the payment DB", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { PaymentService } = require("../payment/payment");
+    const record = makeRecord();
+    const service = new PaymentService(makePaymentDb([record]));
+
+    expect(service.listLocalRecords()).toHaveLength(1);
+    expect(service.listLocalRecords()[0].balanceId).toBe("cb-local-1");
+  });
+});
+
+// ─── API routes ───────────────────────────────────────────────────────────────
+
+describe("reconciliation API routes", () => {
+  const sampleReport = (): ReconciliationReport => ({
+    id: "r-1",
+    runAt: "2026-08-19T00:00:00.000Z",
+    triggeredBy: "manual",
+    status: "consistent",
+    summary: {
+      totalLocalRecords: 1,
+      totalOnChainBalances: 1,
+      matched: 1,
+      discrepancies: 0,
+      missingOnChain: 0,
+      missingLocal: 0,
+      amountMismatch: 0,
+    },
+    discrepancies: [],
+  });
+
+  function makeApp(service: Partial<ReconciliationService>): express.Express {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      "/api/reconciliation",
+      createReconciliationRouter({
+        service: service as unknown as ReconciliationService,
+      })
+    );
+    return app;
+  }
+
+  it("POST /run triggers a run and returns the report", async () => {
+    const run = jest.fn().mockResolvedValue(sampleReport());
+    const app = makeApp({ run, getLatestReport: jest.fn() });
+
+    const response = await request(app)
+      .post("/api/reconciliation/run")
+      .send({ triggeredBy: "manual" });
+
+    expect(response.status).toBe(200);
+    expect(run).toHaveBeenCalledWith("manual");
+    expect(response.body.id).toBe("r-1");
+  });
+
+  it("POST /run defaults to a manual trigger", async () => {
+    const run = jest.fn().mockResolvedValue(sampleReport());
+    const app = makeApp({ run, getLatestReport: jest.fn() });
+
+    const response = await request(app).post("/api/reconciliation/run").send({});
+
+    expect(response.status).toBe(200);
+    expect(run).toHaveBeenCalledWith("manual");
+  });
+
+  it("POST /run surfaces failures as a 500", async () => {
+    const run = jest.fn().mockRejectedValue(new Error("boom"));
+    const app = makeApp({ run, getLatestReport: jest.fn() });
+
+    const response = await request(app).post("/api/reconciliation/run").send({});
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe("RECONCILIATION_FAILED");
+  });
+
+  it("GET /report returns the latest report when one exists", async () => {
+    const app = makeApp({
+      run: jest.fn(),
+      getLatestReport: jest.fn().mockReturnValue(sampleReport()),
+    });
+
+    const response = await request(app).get("/api/reconciliation/report");
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe("r-1");
+  });
+
+  it("GET /report returns 404 when no report exists", async () => {
+    const app = makeApp({
+      run: jest.fn(),
+      getLatestReport: jest.fn().mockReturnValue(undefined),
+    });
+
+    const response = await request(app).get("/api/reconciliation/report");
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe("NO_RECONCILIATION_REPORT");
+  });
+});

--- a/backend/src/services/reconciliation.ts
+++ b/backend/src/services/reconciliation.ts
@@ -1,0 +1,379 @@
+/**
+ * Payment reconciliation service.
+ *
+ * Cross-references local payment records with Stellar on-chain claimable
+ * balances, flags discrepancies (missing on-chain, missing local, amount
+ * mismatch), persists a timestamped report, and alerts on discrepancies
+ * (structured log + optional webhook).
+ */
+
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { Horizon, Asset } from '@stellar/stellar-sdk';
+import { createLogger } from '../utils/logger';
+import { createPaymentDb, getDb, type PaymentDb, type PaymentRecord } from '../db/index';
+import type {
+  ClaimableBalanceOnChain,
+  ReconciliationDiscrepancy,
+  ReconciliationReport,
+  ReconciliationSummary,
+  ReconciliationTrigger,
+} from './reconciliation.types';
+
+const log = createLogger({ component: 'reconciliation' });
+
+const DEFAULT_HORIZON_URL = 'https://horizon-testnet.stellar.org';
+const DEFAULT_DAILY_INTERVAL_MS = 86_400_000; // 24h
+const LIST_BALANCES_MAX_PAGES = 10;
+const LIST_BALANCES_PAGE_LIMIT = 200;
+
+/**
+ * Convert an XLM amount string (as returned by Horizon, e.g. "1.0000000")
+ * into an exact stroop count. Avoids floating point rounding so amounts
+ * compare exactly with local records.
+ */
+export function xlmStringToStroops(amount: string): bigint {
+  const [whole, frac = ''] = amount.split('.');
+  const fracPadded = frac.padEnd(7, '0').slice(0, 7);
+  return BigInt(whole) * 10_000_000n + BigInt(fracPadded || '0');
+}
+
+/** Read-only view of on-chain claimable balances. */
+export interface ClaimableBalanceProvider {
+  getBalance(balanceId: string): Promise<ClaimableBalanceOnChain | null>;
+  listBalances(): Promise<ClaimableBalanceOnChain[]>;
+}
+
+function mapClaimableBalanceRecord(
+  record: import('@stellar/stellar-sdk').ClaimableBalanceRecord
+): ClaimableBalanceOnChain {
+  return {
+    balanceId: record.id,
+    amountStroops: xlmStringToStroops(record.amount ?? '0').toString(),
+    asset: record.asset,
+    sponsor: record.sponsor,
+    claimant: record.claimants?.[0]?.destination,
+  };
+}
+
+/** Default provider backed by the Stellar SDK (Horizon REST API). */
+export class HorizonClaimableBalanceProvider implements ClaimableBalanceProvider {
+  private readonly server: Horizon.Server;
+
+  constructor(horizonUrl?: string) {
+    this.server = new Horizon.Server(
+      horizonUrl ?? process.env.STELLAR_HORIZON ?? DEFAULT_HORIZON_URL
+    );
+  }
+
+  async getBalance(balanceId: string): Promise<ClaimableBalanceOnChain | null> {
+    try {
+      const record = await this.server
+        .claimableBalances()
+        .claimableBalance(balanceId)
+        .call();
+      return mapClaimableBalanceRecord(record);
+    } catch (err) {
+      // 404 (already claimed / never created) or any query error → not found.
+      // Unexpected errors are logged so operators can investigate rather
+      // than silently trusting the absence of an on-chain balance.
+      log.warn({ err, balanceId }, 'Failed to query on-chain claimable balance');
+      return null;
+    }
+  }
+
+  async listBalances(): Promise<ClaimableBalanceOnChain[]> {
+    const balances: ClaimableBalanceOnChain[] = [];
+    try {
+      let page: import('@stellar/stellar-sdk').ClaimableBalancePage | null =
+        await this.server
+          .claimableBalances()
+          .forAsset(Asset.native())
+          .limit(LIST_BALANCES_PAGE_LIMIT)
+          .call();
+      let pages = 0;
+      while (page && page.records && page.records.length > 0 && pages < LIST_BALANCES_MAX_PAGES) {
+        for (const record of page.records) {
+          balances.push(mapClaimableBalanceRecord(record));
+        }
+        page = await page.next();
+        pages++;
+      }
+    } catch (err) {
+      log.error({ err }, 'Failed to list on-chain claimable balances');
+    }
+    return balances;
+  }
+}
+
+/** Persistence for reconciliation reports. */
+export interface ReconciliationReportStore {
+  save(report: ReconciliationReport): void;
+  getLatest(): ReconciliationReport | undefined;
+}
+
+/** SQLite-backed report store; defaults to an in-memory database. */
+export function createSqliteReconciliationReportStore(
+  db?: Database.Database
+): ReconciliationReportStore {
+  const database =
+    db ?? new Database(path.join(process.cwd(), 'reconciliation.db') as unknown as string);
+
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS reconciliation_reports (
+      id         TEXT PRIMARY KEY,
+      runAt      TEXT NOT NULL,
+      reportJson TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_reconciliation_reports_runAt
+      ON reconciliation_reports (runAt);
+  `);
+
+  const insertStmt = database.prepare(`
+    INSERT OR REPLACE INTO reconciliation_reports (id, runAt, reportJson)
+    VALUES (@id, @runAt, @reportJson)
+  `);
+  const latestStmt = database.prepare(
+    'SELECT reportJson FROM reconciliation_reports ORDER BY runAt DESC LIMIT 1'
+  );
+
+  return {
+    save(report: ReconciliationReport): void {
+      insertStmt.run({
+        id: report.id,
+        runAt: report.runAt,
+        reportJson: JSON.stringify(report),
+      });
+    },
+    getLatest(): ReconciliationReport | undefined {
+      const row = latestStmt.get() as { reportJson: string } | undefined;
+      if (!row) return undefined;
+      return JSON.parse(row.reportJson) as ReconciliationReport;
+    },
+  };
+}
+
+export interface ReconciliationServiceOptions {
+  /** Local payment records used as the source of truth. */
+  paymentDb: PaymentDb;
+  /** On-chain query provider; defaults to Horizon via the Stellar SDK. */
+  onChainProvider?: ClaimableBalanceProvider;
+  /** Where reports are persisted; defaults to a SQLite store. */
+  reportStore?: ReconciliationReportStore;
+  /** Optional webhook URL alerted on discrepancies. */
+  webhookUrl?: string;
+  /** Logger for reconciliation events; defaults to a pino child logger. */
+  logger?: Pick<typeof log, 'info' | 'warn' | 'error'>;
+}
+
+export class ReconciliationService {
+  private readonly paymentDb: PaymentDb;
+  private readonly onChainProvider: ClaimableBalanceProvider;
+  private readonly reportStore: ReconciliationReportStore;
+  private readonly webhookUrl?: string;
+  private readonly logger: Pick<typeof log, 'info' | 'warn' | 'error'>;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+
+  constructor(options: ReconciliationServiceOptions) {
+    this.paymentDb = options.paymentDb;
+    this.onChainProvider =
+      options.onChainProvider ?? new HorizonClaimableBalanceProvider();
+    this.reportStore =
+      options.reportStore ?? createSqliteReconciliationReportStore();
+    this.webhookUrl =
+      options.webhookUrl ?? process.env.RECONCILIATION_WEBHOOK_URL;
+    this.logger = options.logger ?? log;
+  }
+
+  /**
+   * Run a reconciliation pass: compare every local payment record against
+   * on-chain claimable balances, persist a timestamped report, and alert on
+   * discrepancies. Never throws — infrastructure failures surface inside the
+   * report's discrepancies or log, keeping automated runs resilient.
+   */
+  async run(triggeredBy: ReconciliationTrigger = 'manual'): Promise<ReconciliationReport> {
+    if (this.running) {
+      const inFlight = this.getLatestReport();
+      if (inFlight) return inFlight;
+      throw new Error('Reconciliation already in progress');
+    }
+    this.running = true;
+    try {
+      const localRecords = this.paymentDb.listAll();
+      const onChainBalances = await this.onChainProvider.listBalances();
+      const onChainByBalanceId = new Map(
+        onChainBalances.map((balance) => [balance.balanceId, balance])
+      );
+      const localBalanceIds = new Set<string>();
+      const matchedBalanceIds = new Set<string>();
+      const discrepancies: ReconciliationDiscrepancy[] = [];
+
+      for (const record of localRecords) {
+        localBalanceIds.add(record.balanceId);
+        const onChain = onChainByBalanceId.get(record.balanceId);
+
+        if (!onChain) {
+          if (record.status === 'locked') {
+            discrepancies.push({
+              type: 'missing_on_chain',
+              balanceId: record.balanceId,
+              taskId: record.taskId,
+              nodeId: record.nodeId,
+              severity: 'critical',
+              description:
+                `Local payment record (task=${record.taskId}, node=${record.nodeId}, ` +
+                `status=${record.status}) has no matching on-chain claimable balance`,
+              localAmountStroops: record.amountStroops.toString(),
+            });
+          }
+          // Released/refunded records are expected to have no on-chain
+          // balance (it was claimed) — not a discrepancy.
+          continue;
+        }
+
+        matchedBalanceIds.add(record.balanceId);
+        const onChainStroops = BigInt(onChain.amountStroops);
+        // A released/refunded record should have 0 stroops on-chain.
+        const expectedStroops = record.status === 'locked' ? record.amountStroops : 0n;
+
+        if (expectedStroops !== onChainStroops) {
+          discrepancies.push({
+            type: 'amount_mismatch',
+            balanceId: record.balanceId,
+            taskId: record.taskId,
+            nodeId: record.nodeId,
+            severity: record.status === 'locked' ? 'critical' : 'warning',
+            description:
+              record.status === 'locked'
+                ? `On-chain amount ${onChain.amountStroops} stroops does not match ` +
+                  `local record amount ${record.amountStroops.toString()} stroops ` +
+                  `(task=${record.taskId}, node=${record.nodeId})`
+                : `Record (task=${record.taskId}, node=${record.nodeId}) is ` +
+                  `status=${record.status} but ${onChain.amountStroops} stroops are ` +
+                  `still claimable on-chain`,
+            localAmountStroops: record.amountStroops.toString(),
+            onChainAmountStroops: onChain.amountStroops,
+            expectedAmountStroops: expectedStroops.toString(),
+          });
+        }
+      }
+
+      for (const balance of onChainBalances) {
+        if (!localBalanceIds.has(balance.balanceId)) {
+          discrepancies.push({
+            type: 'missing_local',
+            balanceId: balance.balanceId,
+            severity: 'warning',
+            description:
+              `On-chain claimable balance ${balance.balanceId} ` +
+              `(${balance.amountStroops} stroops) has no matching local payment record`,
+            onChainAmountStroops: balance.amountStroops,
+          });
+        }
+      }
+
+      const summary: ReconciliationSummary = {
+        totalLocalRecords: localRecords.length,
+        totalOnChainBalances: onChainBalances.length,
+        matched: matchedBalanceIds.size,
+        discrepancies: discrepancies.length,
+        missingOnChain: discrepancies.filter((d) => d.type === 'missing_on_chain').length,
+        missingLocal: discrepancies.filter((d) => d.type === 'missing_local').length,
+        amountMismatch: discrepancies.filter((d) => d.type === 'amount_mismatch').length,
+      };
+
+      const report: ReconciliationReport = {
+        id: randomUUID(),
+        runAt: new Date().toISOString(),
+        triggeredBy,
+        status: discrepancies.length > 0 ? 'discrepancies_found' : 'consistent',
+        summary,
+        discrepancies,
+      };
+
+      this.reportStore.save(report);
+      await this.alert(report);
+      return report;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** The most recently persisted report, if any. */
+  getLatestReport(): ReconciliationReport | undefined {
+    return this.reportStore.getLatest();
+  }
+
+  /** Schedule automated (daily) reconciliation runs. Idempotent. */
+  startDaily(intervalMs: number = DEFAULT_DAILY_INTERVAL_MS): void {
+    if (this.timer) return;
+    const tick = async () => {
+      try {
+        await this.run('scheduled');
+      } catch (err) {
+        this.logger.error({ err }, 'Scheduled reconciliation run failed');
+      }
+    };
+    this.timer = setInterval(tick, intervalMs);
+    this.timer.unref?.();
+    this.logger.info({ intervalMs }, 'Daily reconciliation scheduled');
+  }
+
+  /** Stop the automated scheduler. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      this.logger.info('Daily reconciliation stopped');
+    }
+  }
+
+  /**
+   * Alert on discrepancies: structured logs per discrepancy plus an optional
+   * webhook POST with the full report.
+   */
+  private async alert(report: ReconciliationReport): Promise<void> {
+    if (report.discrepancies.length === 0) {
+      this.logger.info(
+        { runId: report.id, summary: report.summary },
+        'Reconciliation complete — no discrepancies'
+      );
+      return;
+    }
+
+    for (const discrepancy of report.discrepancies) {
+      this.logger.warn(
+        { runId: report.id, discrepancy },
+        `Reconciliation discrepancy [${discrepancy.type}] ${discrepancy.balanceId}`
+      );
+    }
+
+    if (!this.webhookUrl) return;
+    try {
+      const response = await fetch(this.webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(report),
+      });
+      if (!response.ok) {
+        this.logger.warn(
+          { status: response.status },
+          'Reconciliation webhook alert returned non-2xx status'
+        );
+      }
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to deliver reconciliation webhook alert');
+    }
+  }
+}
+
+/** Default service wired to the production payment DB and Horizon. */
+export function createDefaultReconciliationService(
+  paymentDb?: PaymentDb
+): ReconciliationService {
+  return new ReconciliationService({
+    paymentDb: paymentDb ?? createPaymentDb(getDb()),
+  });
+}

--- a/backend/src/services/reconciliation.types.ts
+++ b/backend/src/services/reconciliation.types.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared types for payment reconciliation and accounting reports.
+ *
+ * Reconciliation cross-references local payment records with Stellar
+ * on-chain claimable balances and flags any discrepancies. Reports are
+ * persisted with a timestamp so operators can audit past runs.
+ */
+
+/** The three discrepancy classes detected by reconciliation. */
+export type DiscrepancyType =
+  | 'missing_on_chain'
+  | 'missing_local'
+  | 'amount_mismatch';
+
+export type DiscrepancySeverity = 'info' | 'warning' | 'critical';
+
+/** How a reconciliation run was triggered. */
+export type ReconciliationTrigger = 'manual' | 'scheduled' | 'release';
+
+/** A claimable balance as observed on-chain via Horizon. */
+export interface ClaimableBalanceOnChain {
+  /** Horizon balance ID (claimable balance identifier). */
+  balanceId: string;
+  /** Amount in stroops. String to remain JSON-safe (bigint is not). */
+  amountStroops: string;
+  asset?: string;
+  sponsor?: string;
+  claimant?: string;
+}
+
+/** A single detected discrepancy between local and on-chain state. */
+export interface ReconciliationDiscrepancy {
+  type: DiscrepancyType;
+  balanceId: string;
+  taskId?: string;
+  nodeId?: string;
+  severity: DiscrepancySeverity;
+  description: string;
+  /** Amount recorded locally (stroops). */
+  localAmountStroops?: string;
+  /** Amount observed on-chain (stroops). */
+  onChainAmountStroops?: string;
+  /** Amount that should be on-chain for this record (stroops). */
+  expectedAmountStroops?: string;
+}
+
+/** Aggregate counters for a reconciliation run. */
+export interface ReconciliationSummary {
+  totalLocalRecords: number;
+  totalOnChainBalances: number;
+  matched: number;
+  discrepancies: number;
+  missingOnChain: number;
+  missingLocal: number;
+  amountMismatch: number;
+}
+
+/** A completed reconciliation run, persisted with a timestamp. */
+export interface ReconciliationReport {
+  id: string;
+  /** ISO-8601 timestamp of when the run completed. */
+  runAt: string;
+  triggeredBy: ReconciliationTrigger;
+  status: 'consistent' | 'discrepancies_found';
+  summary: ReconciliationSummary;
+  discrepancies: ReconciliationDiscrepancy[];
+}

--- a/backend/tests/payment.test.ts
+++ b/backend/tests/payment.test.ts
@@ -71,6 +71,9 @@ function makeDb(initial?: PaymentRecord): PaymentDb {
       const r = store.get(`${taskId}:${nodeId}`);
       if (r) { r.status = status; r.txHash = txHash; }
     },
+    listAll(): PaymentRecord[] {
+      return [...store.values()].map((r) => ({ ...r }));
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

Implements payment reconciliation and accounting reports for the backend (issue #276). The service cross-references local payment records (SQLite `payments` table) against Stellar on-chain claimable balances, detects financial discrepancies, persists timestamped reports, alerts on discrepancies, and runs automatically on a daily schedule.

**Close #276**

## What was built

### New files
- `backend/src/services/reconciliation.types.ts` — report types: `ReconciliationReport`, `ReconciliationSummary`, `ReconciliationDiscrepancy` (types: `missing_on_chain`, `missing_local`, `amount_mismatch`), `ClaimableBalanceOnChain`.
- `backend/src/services/reconciliation.ts` — core service:
  - `HorizonClaimableBalanceProvider` — Stellar SDK (`Horizon.Server.claimableBalances()`) queries for single balances and paginated balance listing.
  - `ReconciliationService.run()` — compares local records vs on-chain balances, flags discrepancies, persists a timestamped report, returns it.
  - `createSqliteReconciliationReportStore()` — SQLite-backed report persistence (`reconciliation_reports` table, indexed by `runAt`).
  - `startDaily()/stop()` — automated scheduler (default 24h interval, `unref`'d so it never blocks shutdown).
  - Alerting — structured pino logs per discrepancy + optional webhook POST (`RECONCILIATION_WEBHOOK_URL`) with the full report; webhook failures are logged, never thrown.
- `backend/src/api/routes/reconciliation.ts` — `POST /api/reconciliation/run` (manual trigger, `triggeredBy` body option) and `GET /api/reconciliation/report` (latest report or `404`), with OpenAPI docs.
- `backend/src/services/reconciliation.test.ts` — 23 unit/integration tests.

### Modified files
- `backend/src/api/app.ts` — mounts `/api/reconciliation` router; `AppOptions.reconciliation` for test injection.
- `backend/src/payment/payment.ts` — reconciliation hooks: `PaymentService.listLocalRecords()` (enumerates the local source of truth) and an optional `reconciliationHook` invoked after a successful on-chain release.
- `backend/src/db/index.ts` — `PaymentDb.listAll()` to enumerate local payment records.
- `backend/src/config/index.ts` — `RECONCILIATION_WEBHOOK_URL`, `RECONCILIATION_INTERVAL_MS` env config.
- `backend/src/index.ts` — starts daily reconciliation on boot; stops on graceful shutdown.
- `backend/src/@types/@stellar/stellar-sdk.d.ts` + `backend/__mocks__/@stellar/stellar-sdk.js` — extended the local SDK type shim / jest manual mock with `claimableBalances()` builders.
- `backend/tests/payment.test.ts` — updated in-memory `PaymentDb` helper for `listAll()`.

## Discrepancy detection logic

| Discrepancy | Rule |
| --- | --- |
| `missing_on_chain` | Local record with `status=locked` has no on-chain claimable balance (critical). Released/refunded records with no on-chain balance are *expected* (claimed) and not flagged. |
| `missing_local` | On-chain claimable balance with no matching local record. |
| `amount_mismatch` | Amounts differ (exact stroop comparison via string parsing — no float rounding). A released/refunded record that still has an on-chain balance is flagged with `expectedAmountStroops: "0"`. |

All amounts are compared in stroops with exact string→BigInt conversion (`xlmStringToStroops`).

## Acceptance criteria coverage

- ✅ `POST /api/reconciliation/run` triggers a reconciliation check
- ✅ Compares local payment records with Stellar claimable balances (Horizon via Stellar SDK)
- ✅ Flags `missing_on_chain`, `missing_local`, `amount_mismatch`
- ✅ Report stored with timestamp (`reconciliation_reports`, `runAt` indexed)
- ✅ `GET /api/reconciliation/report` returns the latest report
- ✅ Daily automated reconciliation (scheduler started in `src/index.ts`)
- ✅ Alerts on discrepancies (structured log + optional webhook)
- ✅ 23 unit tests for reconciliation logic, discrepancy detection, alerting, and API routes

## Verification

- `npm run build` — passes (tsc clean)
- `npm test` (backend) — 217 passed; only the 4 pre-existing `agents.test.ts` failures remain (unrelated to this change, present on `main`)
- New test file: `npx jest src/services/reconciliation.test.ts` — 23/23 passing
- Note: no lint script is defined in the repo (CI uses `--if-present`), so lint is a no-op.
