### PR TITLE
feat(backend): Implement Health Check Dashboard with Real-time Metrics

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,3 +67,20 @@ COMPRESSION_LEVEL=6
 # Enable Brotli compression when clients send Accept-Encoding: br. Default: true.
 COMPRESSION_ENABLE_BROTLI=true
 
+
+# ── Admin API ─────────────────────────────────────────────────────────────────
+# Shared secret required by admin-only endpoints such as GET /health/dashboard.
+# Send it as `X-Admin-API-Key: <key>` or `Authorization: Bearer <key>`.
+# When unset, those endpoints refuse every request with HTTP 503 rather than
+# falling open. Generate one with: openssl rand -hex 32
+ADMIN_API_KEY=your_admin_api_key_here
+
+# ── Health Dashboard Metrics ──────────────────────────────────────────────────
+# How long a dashboard snapshot is served before it is recollected.
+# Default: 5000 (5 s).
+METRICS_CACHE_TTL_MS=5000
+# Rolling window used for request rate, latency percentile and error-rate
+# analytics. Default: 60000 (1 min).
+METRICS_WINDOW_MS=60000
+# Maximum number of request samples retained in memory. Default: 1000.
+METRICS_MAX_SAMPLES=1000

--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -12,7 +12,11 @@ import type { AgentRegistry } from "../types/agent";
 import { getTask } from "../coordinator/taskStore";
 import { eventBus } from "../coordinator/eventBus";
 import type { EventStore } from "../events/eventStore";
-import { attachTaskStream, type TaskStreamOptions } from "./routes/stream";
+import {
+  attachTaskStream,
+  getStreamConnectionCount,
+  type TaskStreamOptions,
+} from "./routes/stream";
 import type { DAGNode } from "../types/task";
 import {
   createPaymentReleaseFn,
@@ -36,6 +40,7 @@ import { createV2TasksRouter } from "./routes/v2/tasks";
 import { createLogger } from "../utils/logger";
 import { createTaskDb, getTaskDb } from "../db/tasks";
 import { createHeartbeatService, type HeartbeatServiceOptions } from "../services/heartbeat";
+import { metricsMiddleware, metricsService } from "../services/metrics";
 import { openapiSpec } from "./docs/openapi";
 import { createTaskJobHandler } from "../coordinator/coordinator";
 import {
@@ -117,6 +122,9 @@ export function createApp(opts: AppOptions = {}): {
   app.use(createCorsMiddleware());
   app.use(requestId);
   app.use(requestLogger);
+  // Samples every response into the health dashboard's rolling window. Mounted
+  // before the routers so latency covers the full handler chain.
+  app.use(metricsMiddleware);
   app.use(versioningMiddleware);
 
   // ── Response compression ────────────────────────────────────────────────────
@@ -213,12 +221,23 @@ export function createApp(opts: AppOptions = {}): {
     ...opts.stream,
   });
 
+  // ── Metrics ────────────────────────────────────────────────────────────────
+  // GC is process-global, so the observer is started once and left running for
+  // the lifetime of the process (it is unref'd and never holds the event loop
+  // open). The WebSocket probe is per-app and is cleared on close().
+  metricsService.startGcObserver();
+  metricsService.setWebSocketProbe(() => ({
+    listening: httpServer.listening,
+    connections: getStreamConnectionCount(),
+  }));
+
   // ── Error handler (must be last) ───────────────────────────────────────────
   app.use(errorHandler);
 
   function close(callback?: () => void): void {
     jobWorker.stop();
     heartbeatService.stop();
+    metricsService.setWebSocketProbe(null);
     detachStream();
     httpServer.close(callback);
   }

--- a/backend/src/api/middleware/auth.ts
+++ b/backend/src/api/middleware/auth.ts
@@ -24,3 +24,70 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
 
   next();
 }
+
+/**
+ * Resolve the configured admin API key.
+ *
+ * Reads the validated config when it has been loaded, falling back to the raw
+ * environment so the middleware also works in contexts (tests, scripts) that
+ * never call `loadConfig()`.
+ */
+export function resolveAdminApiKey(): string | undefined {
+  let fromConfig: string | undefined;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    fromConfig = (require('../../config') as typeof import('../../config')).getConfig()
+      .ADMIN_API_KEY;
+  } catch {
+    // Config not loaded — fall through to the environment.
+  }
+  const key = fromConfig ?? process.env.ADMIN_API_KEY;
+  return key && key.length > 0 ? key : undefined;
+}
+
+/** Constant-time string comparison; length differences short-circuit safely. */
+function timingSafeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/** Extract the presented admin key from either supported header. */
+function readPresentedKey(req: Request): string {
+  const header = req.headers['x-admin-api-key'];
+  const fromHeader = Array.isArray(header) ? header[0] : header;
+  if (fromHeader) return fromHeader.trim();
+
+  const auth = req.headers['authorization'] ?? '';
+  return auth.startsWith('Bearer ') ? auth.slice(7).trim() : '';
+}
+
+/**
+ * Guard admin-only endpoints with a shared secret.
+ *
+ * Accepts `X-Admin-API-Key: <key>` or `Authorization: Bearer <key>`. Unlike
+ * {@link authMiddleware}, this middleware **fails closed**: when
+ * `ADMIN_API_KEY` is not configured the endpoint responds 503, so an
+ * unconfigured deployment never exposes admin data anonymously.
+ */
+export function adminAuthMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const expected = resolveAdminApiKey();
+  if (!expected) {
+    res.status(503).json({
+      error: 'Admin API not configured',
+      message: 'Set ADMIN_API_KEY to enable admin endpoints.',
+    });
+    return;
+  }
+
+  const presented = readPresentedKey(req);
+  if (!presented || !timingSafeEquals(presented, expected)) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  next();
+}

--- a/backend/src/api/routes/health.test.ts
+++ b/backend/src/api/routes/health.test.ts
@@ -159,3 +159,244 @@ describe("GET /health/ready", () => {
     expect(res.body.checks).toHaveProperty("payments");
   });
 });
+
+// ── GET /health/dashboard ────────────────────────────────────────────────────
+
+describe("GET /health/dashboard", () => {
+  const ADMIN_KEY = "test-admin-key";
+
+  /** A fully-populated snapshot, so route assertions never touch I/O. */
+  function fakeDashboard() {
+    return {
+      status: "healthy",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      version: "0.1.0",
+      stellarNetwork: "testnet",
+      cacheAgeMs: 0,
+      cacheTtlMs: 5000,
+      requests: {
+        totalRequests: 3,
+        windowMs: 60000,
+        requestRatePerSecond: 0.05,
+        avgResponseTimeMs: 12.5,
+        p95ResponseTimeMs: 30,
+        p99ResponseTimeMs: 40,
+        errorRate: 0.33,
+        serverErrorCount: 1,
+        clientErrorCount: 0,
+      },
+      dependencies: {
+        sqlite: { status: "ok", latencyMs: 1 },
+        venice: { status: "ok", latencyMs: 20 },
+        stellarHorizon: { status: "ok", latencyMs: 30 },
+        websocket: { status: "ok", details: { connections: 2 } },
+      },
+      system: {
+        uptimeSeconds: 120,
+        memory: {
+          rssBytes: 1000,
+          heapTotalBytes: 800,
+          heapUsedBytes: 400,
+          externalBytes: 100,
+          heapUsedPercent: 50,
+        },
+        cpu: {
+          userMs: 10,
+          systemMs: 5,
+          usagePercent: 1.5,
+          loadAverage: [0.1, 0.2, 0.3],
+          cpuCount: 8,
+        },
+        gc: {
+          available: true,
+          collections: 2,
+          totalPauseMs: 4,
+          avgPauseMs: 2,
+          lastPauseMs: 1,
+        },
+      },
+      agents: { total: 2, online: 1, offline: 1, avgResponseTimeMs: 42 },
+      tasks: { total: 4, active: 1, queued: 1, completed: 1, failed: 1, cancelled: 0 },
+      payments: {
+        locked: { count: 1, stroops: "10000000", xlm: 1 },
+        released: { count: 1, stroops: "20000000", xlm: 2 },
+        refunded: { count: 0, stroops: "0", xlm: 0 },
+      },
+    };
+  }
+
+  let dashboardSpy: jest.SpyInstance;
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+
+    const { metricsService } = require("../../services/metrics");
+    dashboardSpy = jest
+      .spyOn(metricsService, "getDashboard")
+      .mockResolvedValue(fakeDashboard());
+  });
+
+  afterEach(() => {
+    dashboardSpy.mockRestore();
+    if (originalKey === undefined) delete process.env.ADMIN_API_KEY;
+    else process.env.ADMIN_API_KEY = originalKey;
+  });
+
+  // ── Admin API key protection ───────────────────────────────────────────────
+
+  it("returns 401 when no admin API key is supplied", async () => {
+    const res = await request(buildApp()).get("/health/dashboard");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Unauthorized");
+    expect(dashboardSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the admin API key is wrong", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", "wrong-key");
+    expect(res.status).toBe(401);
+    expect(dashboardSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the key is a prefix of the configured key", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY.slice(0, 5));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when ADMIN_API_KEY is not configured", async () => {
+    delete process.env.ADMIN_API_KEY;
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("Admin API not configured");
+    expect(dashboardSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts the key via the X-Admin-API-Key header", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts the key via an Authorization Bearer header", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("Authorization", `Bearer ${ADMIN_KEY}`);
+    expect(res.status).toBe(200);
+  });
+
+  // ── Payload shape ──────────────────────────────────────────────────────────
+
+  it("returns every metric family in the payload", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("status", "healthy");
+    expect(res.body).toHaveProperty("timestamp");
+    expect(res.body).toHaveProperty("requests");
+    expect(res.body).toHaveProperty("dependencies");
+    expect(res.body).toHaveProperty("system");
+    expect(res.body).toHaveProperty("agents");
+    expect(res.body).toHaveProperty("tasks");
+    expect(res.body).toHaveProperty("payments");
+  });
+
+  it("reports request rate, latency percentiles and error rate", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+
+    expect(res.body.requests).toMatchObject({
+      requestRatePerSecond: 0.05,
+      avgResponseTimeMs: 12.5,
+      p95ResponseTimeMs: 30,
+      p99ResponseTimeMs: 40,
+      errorRate: 0.33,
+    });
+  });
+
+  it("reports the status of every tracked dependency", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+
+    expect(Object.keys(res.body.dependencies).sort()).toEqual([
+      "sqlite",
+      "stellarHorizon",
+      "venice",
+      "websocket",
+    ]);
+    expect(res.body.dependencies.websocket.details.connections).toBe(2);
+  });
+
+  it("reports memory, CPU, uptime and GC statistics", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+
+    expect(res.body.system.memory.heapUsedPercent).toBe(50);
+    expect(res.body.system.cpu.usagePercent).toBe(1.5);
+    expect(res.body.system.uptimeSeconds).toBe(120);
+    expect(res.body.system.gc.avgPauseMs).toBe(2);
+  });
+
+  it("reports agent, task and payment counters", async () => {
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+
+    expect(res.body.agents).toEqual({
+      total: 2,
+      online: 1,
+      offline: 1,
+      avgResponseTimeMs: 42,
+    });
+    expect(res.body.tasks.active).toBe(1);
+    expect(res.body.tasks.queued).toBe(1);
+    expect(res.body.tasks.completed).toBe(1);
+    expect(res.body.tasks.failed).toBe(1);
+    expect(res.body.payments.locked.xlm).toBe(1);
+    expect(res.body.payments.released.xlm).toBe(2);
+    expect(res.body.payments.refunded.xlm).toBe(0);
+  });
+
+  // ── Caching ────────────────────────────────────────────────────────────────
+
+  it("serves the cached snapshot by default", async () => {
+    await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+    expect(dashboardSpy).toHaveBeenCalledWith(false);
+  });
+
+  it("forces a refresh when ?refresh=true is supplied", async () => {
+    await request(buildApp())
+      .get("/health/dashboard?refresh=true")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+    expect(dashboardSpy).toHaveBeenCalledWith(true);
+  });
+
+  // ── Failure handling ───────────────────────────────────────────────────────
+
+  it("returns 500 with a structured body when collection fails", async () => {
+    dashboardSpy.mockRejectedValue(new Error("collection exploded"));
+
+    const res = await request(buildApp())
+      .get("/health/dashboard")
+      .set("X-Admin-API-Key", ADMIN_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.status).toBe("unhealthy");
+    expect(res.body.error).toBe("Failed to collect metrics");
+    expect(res.body.message).toBe("collection exploded");
+  });
+});

--- a/backend/src/api/routes/health.ts
+++ b/backend/src/api/routes/health.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from "express";
 import { getConfig } from "../../config";
+import { adminAuthMiddleware } from "../middleware/auth";
+import { metricsService } from "../../services/metrics";
 import { tracingService } from "../../services/tracing";
 
 const router = Router();
@@ -121,6 +123,82 @@ router.get("/ready", async (_req: Request, res: Response) => {
 
   const allOk = Object.values(checks).every((status) => status === "ok");
   res.status(allOk ? 200 : 500).json({ status: allOk ? "ok" : "error", checks });
+});
+
+/**
+ * @openapi
+ * /health/dashboard:
+ *   get:
+ *     summary: Comprehensive health and metrics dashboard
+ *     operationId: getHealthDashboard
+ *     description: >
+ *       Returns a full system snapshot: HTTP traffic analytics (rate, average /
+ *       p95 / p99 latency, error rate), dependency reachability (SQLite,
+ *       Venice AI, Stellar Horizon, WebSocket), process health (memory, CPU,
+ *       uptime, garbage collection), and domain counters for agents, tasks and
+ *       payments.
+ *
+ *
+ *       The snapshot is cached for `METRICS_CACHE_TTL_MS` (default 5 seconds);
+ *       `cacheAgeMs` reports how stale the served copy is. Pass `?refresh=true`
+ *       to bypass the cache.
+ *
+ *
+ *       Requires the admin API key via `X-Admin-API-Key` or
+ *       `Authorization: Bearer`. Responds 503 when `ADMIN_API_KEY` is unset.
+ *     tags: [Health]
+ *     parameters:
+ *       - in: query
+ *         name: refresh
+ *         required: false
+ *         schema:
+ *           type: string
+ *           enum: ["true", "false"]
+ *         description: Bypass the metrics cache and collect a fresh snapshot.
+ *     responses:
+ *       200:
+ *         description: Dashboard snapshot
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   enum: [healthy, degraded, unhealthy]
+ *                 timestamp:
+ *                   type: string
+ *                   format: date-time
+ *                 cacheAgeMs:
+ *                   type: number
+ *                 requests:
+ *                   type: object
+ *                 dependencies:
+ *                   type: object
+ *                 system:
+ *                   type: object
+ *                 agents:
+ *                   type: object
+ *                 tasks:
+ *                   type: object
+ *                 payments:
+ *                   type: object
+ *       401:
+ *         description: Missing or invalid admin API key
+ *       503:
+ *         description: ADMIN_API_KEY is not configured
+ */
+router.get("/dashboard", adminAuthMiddleware, async (req: Request, res: Response) => {
+  try {
+    const dashboard = await metricsService.getDashboard(req.query.refresh === "true");
+    res.json(dashboard);
+  } catch (error) {
+    res.status(500).json({
+      status: "unhealthy",
+      error: "Failed to collect metrics",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 });
 
 /**

--- a/backend/src/api/routes/stream.ts
+++ b/backend/src/api/routes/stream.ts
@@ -80,6 +80,23 @@ export interface TaskStreamDeps extends TaskStreamOptions {
 }
 
 /**
+ * Every WebSocketServer currently attached to an HTTP server.
+ *
+ * Tracked so the health dashboard can report live connection counts without
+ * threading a handle through `createApp`.
+ */
+const activeStreamServers = new Set<WebSocketServer>();
+
+/** Total number of clients connected across all attached stream servers. */
+export function getStreamConnectionCount(): number {
+  let total = 0;
+  for (const server of activeStreamServers) {
+    total += server.clients.size;
+  }
+  return total;
+}
+
+/**
  * Attach the live DAG-execution stream to an HTTP server.
  *
  * Exposes ws://<host>/tasks/:id/stream. Each connection:
@@ -110,6 +127,7 @@ export function attachTaskStream(deps: TaskStreamDeps): () => void {
   } = deps;
 
   const wss = new WebSocketServer({ noServer: true });
+  activeStreamServers.add(wss);
 
   const onUpgrade = (req: IncomingMessage, socket: Socket, head: Buffer): void => {
     const match = (req.url ?? '').match(STREAM_PATH);
@@ -241,6 +259,7 @@ export function attachTaskStream(deps: TaskStreamDeps): () => void {
 
   return function detach(): void {
     httpServer.off('upgrade', onUpgrade);
+    activeStreamServers.delete(wss);
     for (const client of wss.clients) {
       client.terminate();
     }

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -66,6 +66,23 @@ const envSchema = z.object({
   API_DEFAULT_VERSION: z.string().default("1.0"),
   /** Sunset date for deprecated API versions (ISO 8601 format). Optional. */
   API_V1_SUNSET_DATE: z.string().optional(),
+
+  // ── Admin API ───────────────────────────────────────────────────────────────
+  /**
+   * Shared secret required by admin-only endpoints such as
+   * `GET /health/dashboard`. Sent as `X-Admin-API-Key: <key>` or
+   * `Authorization: Bearer <key>`. When unset, those endpoints refuse every
+   * request with 503 rather than falling open.
+   */
+  ADMIN_API_KEY: z.string().min(1).optional(),
+
+  // ── Health dashboard metrics ────────────────────────────────────────────────
+  /** How long a dashboard snapshot is served before recollection. Default: 5 000 (5 s). */
+  METRICS_CACHE_TTL_MS: z.coerce.number().int().positive().default(5_000),
+  /** Rolling window used for request rate/latency/error analytics. Default: 60 000 (1 min). */
+  METRICS_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
+  /** Maximum request samples retained in memory. Default: 1 000. */
+  METRICS_MAX_SAMPLES: z.coerce.number().int().positive().default(1_000),
 });
 
 

--- a/backend/src/services/metrics.test.ts
+++ b/backend/src/services/metrics.test.ts
@@ -1,0 +1,838 @@
+/**
+ * Unit tests for the health dashboard metrics service.
+ *
+ * Strategy:
+ *  - Exercise every metric calculation as a pure function: fixed inputs in,
+ *    exact numbers out. No database, no network, no real clock.
+ *  - Drive MetricsService through an injected clock and injected sources so
+ *    caching, the rolling window, and the ring buffer are deterministic.
+ */
+import {
+  MetricsService,
+  calculateAgentResponseTime,
+  calculateCpuMetrics,
+  calculateGcMetrics,
+  calculateMemoryMetrics,
+  calculateRequestMetrics,
+  deriveDashboardStatus,
+  parseStroops,
+  percentile,
+  round,
+  summarizeAgents,
+  summarizePayments,
+  summarizeTasks,
+  toPaymentAmount,
+  type NodeTimingEvent,
+  type PaymentRow,
+} from "./metrics";
+import type {
+  AgentMetrics,
+  DependencyMetrics,
+  PaymentMetrics,
+  RequestSample,
+  TaskMetrics,
+} from "./metrics.types";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function sample(
+  timestamp: number,
+  durationMs: number,
+  statusCode = 200,
+): RequestSample {
+  return { timestamp, durationMs, statusCode };
+}
+
+const OK_DEPENDENCIES: DependencyMetrics = {
+  sqlite: { status: "ok" },
+  venice: { status: "ok" },
+  stellarHorizon: { status: "ok" },
+  websocket: { status: "ok" },
+};
+
+// ── round ────────────────────────────────────────────────────────────────────
+
+describe("round", () => {
+  it("rounds to two decimal places by default", () => {
+    expect(round(1.23456)).toBe(1.23);
+    expect(round(1.239)).toBe(1.24);
+    expect(round(2)).toBe(2);
+  });
+
+  it("honours an explicit digit count", () => {
+    expect(round(1.23456, 4)).toBe(1.2346);
+    expect(round(1.5, 0)).toBe(2);
+  });
+
+  it("maps non-finite values to 0", () => {
+    expect(round(NaN)).toBe(0);
+    expect(round(Infinity)).toBe(0);
+  });
+});
+
+// ── percentile ───────────────────────────────────────────────────────────────
+
+describe("percentile", () => {
+  it("returns 0 for an empty sample set", () => {
+    expect(percentile([], 95)).toBe(0);
+  });
+
+  it("uses nearest-rank on a sorted array", () => {
+    const sorted = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+    expect(percentile(sorted, 95)).toBe(95);
+    expect(percentile(sorted, 99)).toBe(99);
+    expect(percentile(sorted, 50)).toBe(50);
+    expect(percentile(sorted, 100)).toBe(100);
+  });
+
+  it("returns the single value for a one-element array", () => {
+    expect(percentile([42], 95)).toBe(42);
+    expect(percentile([42], 1)).toBe(42);
+  });
+
+  it("clamps percentiles outside 0..100", () => {
+    const sorted = [10, 20, 30];
+    expect(percentile(sorted, -5)).toBe(10);
+    expect(percentile(sorted, 150)).toBe(30);
+  });
+
+  it("rounds the rank up so p99 of 10 samples is the largest", () => {
+    const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(percentile(sorted, 99)).toBe(10);
+    expect(percentile(sorted, 91)).toBe(10);
+    expect(percentile(sorted, 90)).toBe(9);
+  });
+});
+
+// ── calculateRequestMetrics ──────────────────────────────────────────────────
+
+describe("calculateRequestMetrics", () => {
+  const NOW = 1_000_000;
+
+  it("returns zeroed metrics when there are no samples", () => {
+    const metrics = calculateRequestMetrics([], NOW, 60_000);
+    expect(metrics).toEqual({
+      totalRequests: 0,
+      windowMs: 60_000,
+      requestRatePerSecond: 0,
+      avgResponseTimeMs: 0,
+      p95ResponseTimeMs: 0,
+      p99ResponseTimeMs: 0,
+      errorRate: 0,
+      serverErrorCount: 0,
+      clientErrorCount: 0,
+    });
+  });
+
+  it("ignores samples older than the window", () => {
+    const samples = [
+      sample(NOW - 90_000, 500), // outside a 60s window
+      sample(NOW - 30_000, 100),
+      sample(NOW - 10_000, 200),
+    ];
+    const metrics = calculateRequestMetrics(samples, NOW, 60_000);
+    expect(metrics.totalRequests).toBe(2);
+    expect(metrics.avgResponseTimeMs).toBe(150);
+  });
+
+  it("includes a sample landing exactly on the window boundary", () => {
+    const metrics = calculateRequestMetrics([sample(NOW - 60_000, 10)], NOW, 60_000);
+    expect(metrics.totalRequests).toBe(1);
+  });
+
+  it("computes the request rate over the window length, not the sample span", () => {
+    const samples = Array.from({ length: 120 }, (_, i) => sample(NOW - i * 100, 5));
+    const metrics = calculateRequestMetrics(samples, NOW, 60_000);
+    expect(metrics.totalRequests).toBe(120);
+    expect(metrics.requestRatePerSecond).toBe(2); // 120 requests / 60 s
+  });
+
+  it("computes the average, p95 and p99 response times", () => {
+    // 1..100 ms, one request each.
+    const samples = Array.from({ length: 100 }, (_, i) => sample(NOW - 1_000, i + 1));
+    const metrics = calculateRequestMetrics(samples, NOW, 60_000);
+    expect(metrics.avgResponseTimeMs).toBe(50.5);
+    expect(metrics.p95ResponseTimeMs).toBe(95);
+    expect(metrics.p99ResponseTimeMs).toBe(99);
+  });
+
+  it("counts 4xx and 5xx separately and folds both into the error rate", () => {
+    const samples = [
+      sample(NOW, 10, 200),
+      sample(NOW, 10, 201),
+      sample(NOW, 10, 404),
+      sample(NOW, 10, 500),
+    ];
+    const metrics = calculateRequestMetrics(samples, NOW, 60_000);
+    expect(metrics.clientErrorCount).toBe(1);
+    expect(metrics.serverErrorCount).toBe(1);
+    expect(metrics.errorRate).toBe(0.5);
+  });
+
+  it("reports an error rate of 0 when every response succeeded", () => {
+    const samples = [sample(NOW, 10, 200), sample(NOW, 10, 304)];
+    expect(calculateRequestMetrics(samples, NOW, 60_000).errorRate).toBe(0);
+  });
+
+  it("reports an error rate of 1 when every response failed", () => {
+    const samples = [sample(NOW, 10, 500), sample(NOW, 10, 503)];
+    expect(calculateRequestMetrics(samples, NOW, 60_000).errorRate).toBe(1);
+  });
+
+  it("does not require the samples to be pre-sorted by duration", () => {
+    const samples = [
+      sample(NOW, 300),
+      sample(NOW, 100),
+      sample(NOW, 200),
+      sample(NOW, 400),
+    ];
+    const metrics = calculateRequestMetrics(samples, NOW, 60_000);
+    expect(metrics.avgResponseTimeMs).toBe(250);
+    expect(metrics.p95ResponseTimeMs).toBe(400);
+  });
+});
+
+// ── calculateMemoryMetrics ───────────────────────────────────────────────────
+
+describe("calculateMemoryMetrics", () => {
+  it("passes through the raw byte counters and derives heap usage", () => {
+    const metrics = calculateMemoryMetrics({
+      rss: 100,
+      heapTotal: 200,
+      heapUsed: 50,
+      external: 10,
+      arrayBuffers: 5,
+    });
+    expect(metrics).toEqual({
+      rssBytes: 100,
+      heapTotalBytes: 200,
+      heapUsedBytes: 50,
+      externalBytes: 10,
+      heapUsedPercent: 25,
+    });
+  });
+
+  it("reports 0 % usage rather than NaN when heapTotal is 0", () => {
+    const metrics = calculateMemoryMetrics({
+      rss: 0,
+      heapTotal: 0,
+      heapUsed: 0,
+      external: 0,
+      arrayBuffers: 0,
+    });
+    expect(metrics.heapUsedPercent).toBe(0);
+  });
+});
+
+// ── calculateCpuMetrics ──────────────────────────────────────────────────────
+
+describe("calculateCpuMetrics", () => {
+  it("converts microsecond deltas into milliseconds and a usage percentage", () => {
+    // 500 ms user + 250 ms system over 1 000 ms of wall clock = 75 %.
+    const metrics = calculateCpuMetrics(
+      { user: 500_000, system: 250_000 },
+      1_000,
+      [1, 2, 3],
+      8,
+    );
+    expect(metrics.userMs).toBe(500);
+    expect(metrics.systemMs).toBe(250);
+    expect(metrics.usagePercent).toBe(75);
+    expect(metrics.loadAverage).toEqual([1, 2, 3]);
+    expect(metrics.cpuCount).toBe(8);
+  });
+
+  it("allows usage above 100 % when several cores are busy", () => {
+    const metrics = calculateCpuMetrics(
+      { user: 2_000_000, system: 0 },
+      1_000,
+      [0, 0, 0],
+      4,
+    );
+    expect(metrics.usagePercent).toBe(200);
+  });
+
+  it("reports 0 % when no wall-clock time has elapsed", () => {
+    const metrics = calculateCpuMetrics({ user: 1_000, system: 1_000 }, 0, [], 1);
+    expect(metrics.usagePercent).toBe(0);
+  });
+
+  it("pads a short load average array with zeros", () => {
+    expect(calculateCpuMetrics({ user: 0, system: 0 }, 1, [], 1).loadAverage).toEqual([
+      0, 0, 0,
+    ]);
+  });
+});
+
+// ── calculateGcMetrics ───────────────────────────────────────────────────────
+
+describe("calculateGcMetrics", () => {
+  it("derives the mean pause from the totals", () => {
+    const metrics = calculateGcMetrics({
+      available: true,
+      collections: 4,
+      totalPauseMs: 10,
+      lastPauseMs: 3,
+    });
+    expect(metrics.collections).toBe(4);
+    expect(metrics.totalPauseMs).toBe(10);
+    expect(metrics.avgPauseMs).toBe(2.5);
+    expect(metrics.lastPauseMs).toBe(3);
+    expect(metrics.available).toBe(true);
+  });
+
+  it("reports a mean of 0 before any collection is observed", () => {
+    const metrics = calculateGcMetrics({
+      available: false,
+      collections: 0,
+      totalPauseMs: 0,
+      lastPauseMs: 0,
+    });
+    expect(metrics.avgPauseMs).toBe(0);
+    expect(metrics.available).toBe(false);
+  });
+});
+
+// ── parseStroops / toPaymentAmount ───────────────────────────────────────────
+
+describe("parseStroops", () => {
+  it("parses decimal strings", () => {
+    expect(parseStroops("12345")).toBe(12345n);
+    expect(parseStroops(" 42 ")).toBe(42n);
+    expect(parseStroops("-7")).toBe(-7n);
+  });
+
+  it("parses numbers and bigints", () => {
+    expect(parseStroops(1_000)).toBe(1000n);
+    expect(parseStroops(1.9)).toBe(1n);
+    expect(parseStroops(99n)).toBe(99n);
+  });
+
+  it("treats null, undefined and malformed values as zero", () => {
+    expect(parseStroops(null)).toBe(0n);
+    expect(parseStroops(undefined)).toBe(0n);
+    expect(parseStroops("abc")).toBe(0n);
+    expect(parseStroops("1.5")).toBe(0n);
+    expect(parseStroops(NaN)).toBe(0n);
+  });
+});
+
+describe("toPaymentAmount", () => {
+  it("converts stroops to XLM", () => {
+    expect(toPaymentAmount(1, 10_000_000n)).toEqual({
+      count: 1,
+      stroops: "10000000",
+      xlm: 1,
+    });
+  });
+
+  it("keeps sub-XLM precision to 7 decimal places", () => {
+    expect(toPaymentAmount(1, 1n).xlm).toBe(0.0000001);
+    expect(toPaymentAmount(1, 15_000_001n).xlm).toBe(1.5000001);
+  });
+
+  it("keeps totals beyond Number.MAX_SAFE_INTEGER exact in the stroops field", () => {
+    const huge = 9_007_199_254_740_993n; // 2^53 + 1
+    expect(toPaymentAmount(1, huge).stroops).toBe("9007199254740993");
+  });
+});
+
+// ── summarizePayments ────────────────────────────────────────────────────────
+
+describe("summarizePayments", () => {
+  it("returns zeroed totals for no rows", () => {
+    const metrics = summarizePayments([]);
+    expect(metrics.locked).toEqual({ count: 0, stroops: "0", xlm: 0 });
+    expect(metrics.released).toEqual({ count: 0, stroops: "0", xlm: 0 });
+    expect(metrics.refunded).toEqual({ count: 0, stroops: "0", xlm: 0 });
+  });
+
+  it("totals each status independently", () => {
+    const rows: PaymentRow[] = [
+      { status: "locked", amountStroops: "10000000" },
+      { status: "locked", amountStroops: "5000000" },
+      { status: "released", amountStroops: "20000000" },
+      { status: "refunded", amountStroops: "1000000" },
+    ];
+    const metrics = summarizePayments(rows);
+    expect(metrics.locked).toEqual({ count: 2, stroops: "15000000", xlm: 1.5 });
+    expect(metrics.released).toEqual({ count: 1, stroops: "20000000", xlm: 2 });
+    expect(metrics.refunded).toEqual({ count: 1, stroops: "1000000", xlm: 0.1 });
+  });
+
+  it("ignores rows with an unrecognised status", () => {
+    const rows: PaymentRow[] = [
+      { status: "pending", amountStroops: "10000000" },
+      { status: "locked", amountStroops: "10000000" },
+    ];
+    const metrics = summarizePayments(rows);
+    expect(metrics.locked.count).toBe(1);
+    expect(metrics.released.count).toBe(0);
+  });
+
+  it("sums exactly past the float safe-integer range", () => {
+    const rows: PaymentRow[] = [
+      { status: "released", amountStroops: "9007199254740992" },
+      { status: "released", amountStroops: "1" },
+    ];
+    expect(summarizePayments(rows).released.stroops).toBe("9007199254740993");
+  });
+
+  it("treats malformed amounts as zero without corrupting the total", () => {
+    const rows: PaymentRow[] = [
+      { status: "locked", amountStroops: "not-a-number" },
+      { status: "locked", amountStroops: "10000000" },
+    ];
+    const metrics = summarizePayments(rows);
+    expect(metrics.locked.count).toBe(2);
+    expect(metrics.locked.stroops).toBe("10000000");
+  });
+});
+
+// ── summarizeTasks ───────────────────────────────────────────────────────────
+
+describe("summarizeTasks", () => {
+  it("returns zeroed counters for no rows", () => {
+    expect(summarizeTasks([])).toEqual({
+      total: 0,
+      active: 0,
+      queued: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+    });
+  });
+
+  it("maps running to active and totals every row", () => {
+    const metrics = summarizeTasks([
+      { status: "running", count: 3 },
+      { status: "queued", count: 5 },
+      { status: "completed", count: 10 },
+      { status: "failed", count: 2 },
+      { status: "cancelled", count: 1 },
+    ]);
+    expect(metrics).toEqual({
+      total: 21,
+      active: 3,
+      queued: 5,
+      completed: 10,
+      failed: 2,
+      cancelled: 1,
+    });
+  });
+
+  it("counts unknown statuses towards the total only", () => {
+    const metrics = summarizeTasks([
+      { status: "completed", count: 2 },
+      { status: "archived", count: 4 },
+    ]);
+    expect(metrics.total).toBe(6);
+    expect(metrics.completed).toBe(2);
+  });
+
+  it("coerces non-numeric counts to 0", () => {
+    const metrics = summarizeTasks([
+      { status: "queued", count: "3" as unknown as number },
+      { status: "failed", count: NaN },
+    ]);
+    expect(metrics.queued).toBe(3);
+    expect(metrics.failed).toBe(0);
+  });
+});
+
+// ── summarizeAgents ──────────────────────────────────────────────────────────
+
+describe("summarizeAgents", () => {
+  it("splits the population into online and offline", () => {
+    const metrics = summarizeAgents(
+      [
+        { status: "online", count: 4 },
+        { status: "offline", count: 6 },
+      ],
+      123.456,
+    );
+    expect(metrics).toEqual({
+      total: 10,
+      online: 4,
+      offline: 6,
+      avgResponseTimeMs: 123.46,
+    });
+  });
+
+  it("counts any non-online status as offline", () => {
+    const metrics = summarizeAgents([{ status: "frozen", count: 2 }], 0);
+    expect(metrics.offline).toBe(2);
+    expect(metrics.online).toBe(0);
+  });
+
+  it("returns zeros for an empty registry", () => {
+    expect(summarizeAgents([], 0)).toEqual({
+      total: 0,
+      online: 0,
+      offline: 0,
+      avgResponseTimeMs: 0,
+    });
+  });
+});
+
+// ── calculateAgentResponseTime ───────────────────────────────────────────────
+
+describe("calculateAgentResponseTime", () => {
+  function event(
+    taskId: string,
+    nodeId: string | null,
+    type: string,
+    timestamp: string,
+  ): NodeTimingEvent {
+    return { taskId, nodeId, type, timestamp };
+  }
+
+  it("returns 0 when there are no events", () => {
+    expect(calculateAgentResponseTime([])).toBe(0);
+  });
+
+  it("pairs a start with its completion and averages the durations", () => {
+    const events = [
+      event("t1", "n1", "node_started", "2026-01-01T00:00:00.000Z"),
+      event("t1", "n1", "node_completed", "2026-01-01T00:00:01.000Z"),
+      event("t2", "n1", "node_started", "2026-01-01T00:00:00.000Z"),
+      event("t2", "n1", "node_completed", "2026-01-01T00:00:03.000Z"),
+    ];
+    expect(calculateAgentResponseTime(events)).toBe(2000);
+  });
+
+  it("pairs on (taskId, nodeId) so identical node ids do not cross tasks", () => {
+    const events = [
+      event("t1", "n1", "node_started", "2026-01-01T00:00:00.000Z"),
+      event("t2", "n1", "node_started", "2026-01-01T00:00:05.000Z"),
+      event("t1", "n1", "node_completed", "2026-01-01T00:00:10.000Z"),
+    ];
+    expect(calculateAgentResponseTime(events)).toBe(10_000);
+  });
+
+  it("counts failures as responses", () => {
+    const events = [
+      event("t1", "n1", "node_started", "2026-01-01T00:00:00.000Z"),
+      event("t1", "n1", "node_failed", "2026-01-01T00:00:00.500Z"),
+    ];
+    expect(calculateAgentResponseTime(events)).toBe(500);
+  });
+
+  it("ignores still-running nodes and completions with no start", () => {
+    const events = [
+      event("t1", "n1", "node_started", "2026-01-01T00:00:00.000Z"),
+      event("t2", "n2", "node_completed", "2026-01-01T00:00:04.000Z"),
+    ];
+    expect(calculateAgentResponseTime(events)).toBe(0);
+  });
+
+  it("sorts events by timestamp before pairing", () => {
+    const events = [
+      event("t1", "n1", "node_completed", "2026-01-01T00:00:02.000Z"),
+      event("t1", "n1", "node_started", "2026-01-01T00:00:00.000Z"),
+    ];
+    expect(calculateAgentResponseTime(events)).toBe(2000);
+  });
+
+  it("skips events without a node id or with an unparseable timestamp", () => {
+    const events = [
+      event("t1", null, "node_started", "2026-01-01T00:00:00.000Z"),
+      event("t1", null, "node_completed", "2026-01-01T00:00:02.000Z"),
+      event("t2", "n1", "node_started", "not-a-date"),
+      event("t2", "n1", "node_completed", "2026-01-01T00:00:02.000Z"),
+    ];
+    expect(calculateAgentResponseTime(events)).toBe(0);
+  });
+});
+
+// ── deriveDashboardStatus ────────────────────────────────────────────────────
+
+describe("deriveDashboardStatus", () => {
+  it("is healthy when every dependency is ok", () => {
+    expect(deriveDashboardStatus(OK_DEPENDENCIES)).toBe("healthy");
+  });
+
+  it("is unhealthy when SQLite is unreachable", () => {
+    expect(
+      deriveDashboardStatus({
+        ...OK_DEPENDENCIES,
+        sqlite: { status: "unreachable" },
+      }),
+    ).toBe("unhealthy");
+  });
+
+  it("is degraded when an external dependency is unreachable", () => {
+    expect(
+      deriveDashboardStatus({
+        ...OK_DEPENDENCIES,
+        venice: { status: "unreachable" },
+      }),
+    ).toBe("degraded");
+  });
+
+  it("is degraded when a dependency is degraded", () => {
+    expect(
+      deriveDashboardStatus({
+        ...OK_DEPENDENCIES,
+        stellarHorizon: { status: "degraded" },
+      }),
+    ).toBe("degraded");
+  });
+
+  it("stays healthy when a dependency is merely unknown", () => {
+    expect(
+      deriveDashboardStatus({
+        ...OK_DEPENDENCIES,
+        websocket: { status: "unknown" },
+      }),
+    ).toBe("healthy");
+  });
+});
+
+// ── MetricsService ───────────────────────────────────────────────────────────
+
+describe("MetricsService", () => {
+  const AGENTS: AgentMetrics = {
+    total: 2,
+    online: 1,
+    offline: 1,
+    avgResponseTimeMs: 42,
+  };
+  const TASKS: TaskMetrics = {
+    total: 4,
+    active: 1,
+    queued: 1,
+    completed: 1,
+    failed: 1,
+    cancelled: 0,
+  };
+  const PAYMENTS: PaymentMetrics = {
+    locked: { count: 1, stroops: "10000000", xlm: 1 },
+    released: { count: 1, stroops: "20000000", xlm: 2 },
+    refunded: { count: 0, stroops: "0", xlm: 0 },
+  };
+
+  /** Build a service whose every source is stubbed and whose clock is manual. */
+  function buildService(overrides: Record<string, unknown> = {}) {
+    let now = 1_000_000;
+    const collectAgents = jest.fn(() => AGENTS);
+    const service = new MetricsService({
+      cacheTtlMs: 5_000,
+      windowMs: 60_000,
+      maxSamples: 5,
+      clock: () => now,
+      sources: {
+        checkSqlite: () => ({ status: "ok" as const }),
+        checkVenice: () => ({ status: "ok" as const }),
+        checkStellarHorizon: () => ({ status: "ok" as const }),
+        checkWebSocket: () => ({ status: "ok" as const }),
+        collectAgents,
+        collectTasks: () => TASKS,
+        collectPayments: () => PAYMENTS,
+        ...overrides,
+      },
+    });
+    return {
+      service,
+      collectAgents,
+      advance: (ms: number) => {
+        now += ms;
+      },
+      nowRef: () => now,
+    };
+  }
+
+  it("records requests and derives metrics from them", () => {
+    const { service } = buildService();
+    service.recordRequest(100, 200);
+    service.recordRequest(300, 500);
+
+    const metrics = service.getRequestMetrics();
+    expect(metrics.totalRequests).toBe(2);
+    expect(metrics.avgResponseTimeMs).toBe(200);
+    expect(metrics.serverErrorCount).toBe(1);
+    expect(metrics.errorRate).toBe(0.5);
+  });
+
+  it("caps retained samples at maxSamples, discarding the oldest", () => {
+    const { service } = buildService();
+    for (let i = 0; i < 10; i++) service.recordRequest(i, 200);
+
+    const samples = service.getSamples();
+    expect(samples).toHaveLength(5);
+    expect(samples.map((s) => s.durationMs)).toEqual([5, 6, 7, 8, 9]);
+  });
+
+  it("drops samples that fall out of the rolling window", () => {
+    const { service, advance } = buildService();
+    service.recordRequest(100, 200);
+    advance(61_000);
+    service.recordRequest(200, 200);
+
+    const metrics = service.getRequestMetrics();
+    expect(metrics.totalRequests).toBe(1);
+    expect(metrics.avgResponseTimeMs).toBe(200);
+  });
+
+  it("assembles every metric family into the dashboard", async () => {
+    const { service } = buildService();
+    service.recordRequest(50, 200);
+
+    const dashboard = await service.getDashboard();
+    expect(dashboard.status).toBe("healthy");
+    expect(dashboard.agents).toEqual(AGENTS);
+    expect(dashboard.tasks).toEqual(TASKS);
+    expect(dashboard.payments).toEqual(PAYMENTS);
+    expect(dashboard.requests.totalRequests).toBe(1);
+    expect(dashboard.dependencies.sqlite.status).toBe("ok");
+    expect(dashboard.system.memory.rssBytes).toBeGreaterThan(0);
+    expect(dashboard.system.uptimeSeconds).toBeGreaterThanOrEqual(0);
+    expect(dashboard.cacheTtlMs).toBe(5_000);
+    expect(dashboard.cacheAgeMs).toBe(0);
+    expect(new Date(dashboard.timestamp).toISOString()).toBe(dashboard.timestamp);
+  });
+
+  it("serves the cached snapshot until the TTL expires", async () => {
+    const { service, collectAgents, advance } = buildService();
+
+    await service.getDashboard();
+    advance(4_000);
+    const cached = await service.getDashboard();
+
+    expect(collectAgents).toHaveBeenCalledTimes(1);
+    expect(cached.cacheAgeMs).toBe(4_000);
+  });
+
+  it("recollects once the TTL has elapsed", async () => {
+    const { service, collectAgents, advance } = buildService();
+
+    await service.getDashboard();
+    advance(5_001);
+    const fresh = await service.getDashboard();
+
+    expect(collectAgents).toHaveBeenCalledTimes(2);
+    expect(fresh.cacheAgeMs).toBe(0);
+  });
+
+  it("bypasses the cache when forced", async () => {
+    const { service, collectAgents } = buildService();
+
+    await service.getDashboard();
+    await service.getDashboard(true);
+
+    expect(collectAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it("collapses concurrent cache misses onto a single collection", async () => {
+    const { service, collectAgents } = buildService();
+
+    await Promise.all([
+      service.getDashboard(),
+      service.getDashboard(),
+      service.getDashboard(),
+    ]);
+
+    expect(collectAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it("recollects after the cache is reset", async () => {
+    const { service, collectAgents } = buildService();
+
+    await service.getDashboard();
+    service.resetCache();
+    await service.getDashboard();
+
+    expect(collectAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears recorded samples on resetSamples", () => {
+    const { service } = buildService();
+    service.recordRequest(10, 200);
+    service.resetSamples();
+    expect(service.getSamples()).toHaveLength(0);
+  });
+
+  it("reports a failing dependency probe as unreachable", async () => {
+    const { service } = buildService({
+      checkVenice: () => {
+        throw new Error("boom");
+      },
+    });
+
+    const dashboard = await service.getDashboard();
+    expect(dashboard.dependencies.venice.status).toBe("unreachable");
+    expect(dashboard.dependencies.venice.error).toBe("boom");
+    expect(dashboard.status).toBe("degraded");
+  });
+
+  it("falls back to zeroed domain metrics when a collector throws", async () => {
+    const { service } = buildService({
+      collectTasks: () => {
+        throw new Error("table missing");
+      },
+    });
+
+    const dashboard = await service.getDashboard();
+    expect(dashboard.tasks).toEqual({
+      total: 0,
+      active: 0,
+      queued: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+    });
+    // A failed collector must not take the whole dashboard down.
+    expect(dashboard.status).toBe("healthy");
+  });
+
+  /**
+   * Build a service with every source stubbed **except** the WebSocket probe,
+   * so the real `checkWebSocket` path is exercised without any network or disk.
+   */
+  function buildWithRealWebSocketProbe(): MetricsService {
+    return new MetricsService({
+      cacheTtlMs: 0,
+      sources: {
+        checkSqlite: () => ({ status: "ok" as const }),
+        checkVenice: () => ({ status: "ok" as const }),
+        checkStellarHorizon: () => ({ status: "ok" as const }),
+        collectAgents: () => AGENTS,
+        collectTasks: () => TASKS,
+        collectPayments: () => PAYMENTS,
+      },
+    });
+  }
+
+  it("reports the WebSocket dependency from the registered probe", async () => {
+    const service = buildWithRealWebSocketProbe();
+    service.setWebSocketProbe(() => ({ listening: true, connections: 3 }));
+
+    const dashboard = await service.getDashboard(true);
+    expect(dashboard.dependencies.websocket.status).toBe("ok");
+    expect(dashboard.dependencies.websocket.details).toEqual({ connections: 3 });
+  });
+
+  it("reports WebSocket as unknown when no probe is registered", async () => {
+    const service = buildWithRealWebSocketProbe();
+    service.setWebSocketProbe(null);
+
+    const dashboard = await service.getDashboard(true);
+    expect(dashboard.dependencies.websocket.status).toBe("unknown");
+  });
+
+  it("reports WebSocket as unreachable when the server is not listening", async () => {
+    const service = buildWithRealWebSocketProbe();
+    service.setWebSocketProbe(() => ({ listening: false, connections: 0 }));
+
+    const dashboard = await service.getDashboard(true);
+    expect(dashboard.dependencies.websocket.status).toBe("unreachable");
+  });
+
+  it("starts and stops the GC observer without throwing", () => {
+    const { service } = buildService();
+    service.startGcObserver();
+    service.startGcObserver(); // idempotent
+    expect(service.getSystemMetrics().gc.available).toBe(true);
+    service.stopGcObserver();
+  });
+});

--- a/backend/src/services/metrics.ts
+++ b/backend/src/services/metrics.ts
@@ -1,0 +1,818 @@
+/**
+ * Health dashboard metrics collection service.
+ *
+ * Responsibilities
+ * ────────────────
+ * • Sample every HTTP response (via {@link metricsMiddleware}) into a bounded
+ *   ring buffer and derive rate / latency / error-rate analytics from it.
+ * • Observe garbage collection pauses through `perf_hooks`.
+ * • Probe dependency reachability (SQLite, Venice AI, Stellar Horizon,
+ *   WebSocket) and read domain counters out of SQLite.
+ * • Serve the assembled snapshot from a short-lived cache so that a scraping
+ *   dashboard cannot turn `/health/dashboard` into a load generator.
+ *
+ * The heavy lifting lives in exported pure functions (`calculateRequestMetrics`,
+ * `summarizePayments`, …) so that every metric calculation is unit-testable
+ * without touching a database, a socket, or the clock.
+ */
+
+import os from "os";
+import { PerformanceObserver } from "perf_hooks";
+
+import { getConfig } from "../config";
+import { createLogger } from "../utils/logger";
+import type {
+  AgentMetrics,
+  CpuMetrics,
+  DashboardStatus,
+  DependencyMetrics,
+  DependencyStatus,
+  GcMetrics,
+  HealthDashboard,
+  MemoryMetrics,
+  MetricsCollectorOptions,
+  MetricsSources,
+  PaymentAmount,
+  PaymentMetrics,
+  RequestMetrics,
+  RequestSample,
+  SystemMetrics,
+  TaskMetrics,
+} from "./metrics.types";
+
+import type { NextFunction, Request, Response } from "express";
+
+const logger = createLogger({ component: "metrics" });
+
+/** 1 XLM = 10 000 000 stroops. */
+const STROOPS_PER_XLM = 10_000_000n;
+
+/** Timeout applied to each outbound dependency probe. */
+const PROBE_TIMEOUT_MS = 5_000;
+
+export const DEFAULT_CACHE_TTL_MS = 5_000;
+export const DEFAULT_WINDOW_MS = 60_000;
+export const DEFAULT_MAX_SAMPLES = 1_000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure metric calculations
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Round to at most `digits` decimal places, keeping the value JSON-safe. */
+export function round(value: number, digits = 2): number {
+  if (!Number.isFinite(value)) return 0;
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * Nearest-rank percentile over an **already ascending** array of samples.
+ *
+ * `percentile([1, 2, 3, 4], 95)` → `4`. Returns `0` for an empty input so the
+ * dashboard reports a number rather than `null` before any traffic arrives.
+ *
+ * @param sorted - Ascending values.
+ * @param p - Percentile in `0..100`; values outside the range are clamped.
+ */
+export function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const clamped = Math.min(100, Math.max(0, p));
+  const rank = Math.ceil((clamped / 100) * sorted.length);
+  const index = Math.min(sorted.length - 1, Math.max(0, rank - 1));
+  return sorted[index]!;
+}
+
+/**
+ * Derive traffic analytics from the raw request samples.
+ *
+ * Only samples inside `[now - windowMs, now]` are considered, so the numbers
+ * describe recent behaviour rather than the lifetime of the process. The error
+ * rate counts every response with a status code >= 400.
+ */
+export function calculateRequestMetrics(
+  samples: readonly RequestSample[],
+  now: number,
+  windowMs: number,
+): RequestMetrics {
+  const cutoff = now - windowMs;
+  const recent = samples.filter((s) => s.timestamp >= cutoff);
+
+  if (recent.length === 0) {
+    return {
+      totalRequests: 0,
+      windowMs,
+      requestRatePerSecond: 0,
+      avgResponseTimeMs: 0,
+      p95ResponseTimeMs: 0,
+      p99ResponseTimeMs: 0,
+      errorRate: 0,
+      serverErrorCount: 0,
+      clientErrorCount: 0,
+    };
+  }
+
+  const durations = recent.map((s) => s.durationMs).sort((a, b) => a - b);
+  const totalDuration = durations.reduce((sum, d) => sum + d, 0);
+  const clientErrorCount = recent.filter(
+    (s) => s.statusCode >= 400 && s.statusCode < 500,
+  ).length;
+  const serverErrorCount = recent.filter((s) => s.statusCode >= 500).length;
+
+  return {
+    totalRequests: recent.length,
+    windowMs,
+    requestRatePerSecond: round(recent.length / (windowMs / 1000), 4),
+    avgResponseTimeMs: round(totalDuration / recent.length),
+    p95ResponseTimeMs: round(percentile(durations, 95)),
+    p99ResponseTimeMs: round(percentile(durations, 99)),
+    errorRate: round((clientErrorCount + serverErrorCount) / recent.length, 4),
+    serverErrorCount,
+    clientErrorCount,
+  };
+}
+
+/** Shape memory usage into the dashboard's memory block. */
+export function calculateMemoryMetrics(usage: NodeJS.MemoryUsage): MemoryMetrics {
+  return {
+    rssBytes: usage.rss,
+    heapTotalBytes: usage.heapTotal,
+    heapUsedBytes: usage.heapUsed,
+    externalBytes: usage.external,
+    heapUsedPercent:
+      usage.heapTotal > 0 ? round((usage.heapUsed / usage.heapTotal) * 100) : 0,
+  };
+}
+
+/**
+ * Convert a `process.cpuUsage()` delta into a usage percentage.
+ *
+ * `cpuUsage` deltas are in **microseconds**; `elapsedMs` is wall-clock time
+ * since the previous sample. The result may exceed 100 % when more than one
+ * core is busy, which is expected and left unclamped.
+ */
+export function calculateCpuMetrics(
+  delta: NodeJS.CpuUsage,
+  elapsedMs: number,
+  loadAverage: number[],
+  cpuCount: number,
+): CpuMetrics {
+  const userMs = delta.user / 1000;
+  const systemMs = delta.system / 1000;
+  const usagePercent = elapsedMs > 0 ? ((userMs + systemMs) / elapsedMs) * 100 : 0;
+
+  return {
+    userMs: round(userMs),
+    systemMs: round(systemMs),
+    usagePercent: round(usagePercent),
+    loadAverage: [
+      round(loadAverage[0] ?? 0),
+      round(loadAverage[1] ?? 0),
+      round(loadAverage[2] ?? 0),
+    ],
+    cpuCount,
+  };
+}
+
+/** Accumulated garbage-collection observations. */
+export interface GcState {
+  available: boolean;
+  collections: number;
+  totalPauseMs: number;
+  lastPauseMs: number;
+}
+
+/** Derive the GC block, including the mean pause, from raw counters. */
+export function calculateGcMetrics(state: GcState): GcMetrics {
+  return {
+    available: state.available,
+    collections: state.collections,
+    totalPauseMs: round(state.totalPauseMs, 3),
+    avgPauseMs:
+      state.collections > 0 ? round(state.totalPauseMs / state.collections, 3) : 0,
+    lastPauseMs: round(state.lastPauseMs, 3),
+  };
+}
+
+/** Convert an exact stroop total into the dashboard's payment amount block. */
+export function toPaymentAmount(count: number, stroops: bigint): PaymentAmount {
+  return {
+    count,
+    stroops: stroops.toString(),
+    // Number() on the quotient keeps whole XLM exact; the remainder adds the
+    // fractional part. Exactness is preserved in the `stroops` string.
+    xlm: round(
+      Number(stroops / STROOPS_PER_XLM) +
+        Number(stroops % STROOPS_PER_XLM) / Number(STROOPS_PER_XLM),
+      7,
+    ),
+  };
+}
+
+/** A payment row as stored: status plus a stroop amount in string form. */
+export interface PaymentRow {
+  status: string;
+  amountStroops: string | number | bigint | null;
+}
+
+/**
+ * Total locked / released / refunded escrow amounts.
+ *
+ * Amounts are summed as `bigint` so that totals beyond `Number.MAX_SAFE_INTEGER`
+ * stroops stay exact. Unparseable amounts contribute `0` rather than `NaN`, and
+ * rows with an unrecognised status are ignored.
+ */
+export function summarizePayments(rows: readonly PaymentRow[]): PaymentMetrics {
+  const totals = { locked: 0n, released: 0n, refunded: 0n };
+  const counts = { locked: 0, released: 0, refunded: 0 };
+
+  for (const row of rows) {
+    const status = row.status as keyof typeof totals;
+    if (!(status in totals)) continue;
+    counts[status] += 1;
+    totals[status] += parseStroops(row.amountStroops);
+  }
+
+  return {
+    locked: toPaymentAmount(counts.locked, totals.locked),
+    released: toPaymentAmount(counts.released, totals.released),
+    refunded: toPaymentAmount(counts.refunded, totals.refunded),
+  };
+}
+
+/** Parse a stroop amount into a `bigint`, treating malformed values as zero. */
+export function parseStroops(value: string | number | bigint | null | undefined): bigint {
+  if (value === null || value === undefined) return 0n;
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? BigInt(Math.trunc(value)) : 0n;
+  const trimmed = value.trim();
+  if (!/^-?\d+$/.test(trimmed)) return 0n;
+  return BigInt(trimmed);
+}
+
+/** A `status → count` aggregate row as produced by `GROUP BY status`. */
+export interface StatusCountRow {
+  status: string;
+  count: number;
+}
+
+/**
+ * Fold task status counts into the dashboard's task block.
+ *
+ * `active` mirrors the `running` status; `total` is the sum of every row,
+ * including statuses the dashboard does not break out individually.
+ */
+export function summarizeTasks(rows: readonly StatusCountRow[]): TaskMetrics {
+  const metrics: TaskMetrics = {
+    total: 0,
+    active: 0,
+    queued: 0,
+    completed: 0,
+    failed: 0,
+    cancelled: 0,
+  };
+
+  for (const row of rows) {
+    const count = Number(row.count) || 0;
+    metrics.total += count;
+    switch (row.status) {
+      case "running":
+        metrics.active += count;
+        break;
+      case "queued":
+        metrics.queued += count;
+        break;
+      case "completed":
+        metrics.completed += count;
+        break;
+      case "failed":
+        metrics.failed += count;
+        break;
+      case "cancelled":
+        metrics.cancelled += count;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return metrics;
+}
+
+/** Fold agent status counts, plus a measured mean latency, into one block. */
+export function summarizeAgents(
+  rows: readonly StatusCountRow[],
+  avgResponseTimeMs: number,
+): AgentMetrics {
+  let total = 0;
+  let online = 0;
+  let offline = 0;
+
+  for (const row of rows) {
+    const count = Number(row.count) || 0;
+    total += count;
+    if (row.status === "online") online += count;
+    else offline += count;
+  }
+
+  return { total, online, offline, avgResponseTimeMs: round(avgResponseTimeMs) };
+}
+
+/** A node lifecycle event used to measure how long agents take to respond. */
+export interface NodeTimingEvent {
+  taskId: string;
+  nodeId: string | null;
+  type: string;
+  /** ISO-8601 timestamp. */
+  timestamp: string;
+}
+
+/**
+ * Mean agent response time, in milliseconds, derived from node lifecycle events.
+ *
+ * Each `node_started` is paired with the first subsequent `node_completed` or
+ * `node_failed` for the same `(taskId, nodeId)`. Unpaired starts (still running)
+ * and events without a `nodeId` are skipped. Returns `0` when nothing pairs up.
+ */
+export function calculateAgentResponseTime(events: readonly NodeTimingEvent[]): number {
+  const started = new Map<string, number>();
+  let totalMs = 0;
+  let pairs = 0;
+
+  const ordered = [...events].sort(
+    (a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp),
+  );
+
+  for (const event of ordered) {
+    if (!event.nodeId) continue;
+    const at = Date.parse(event.timestamp);
+    if (Number.isNaN(at)) continue;
+    const key = `${event.taskId}::${event.nodeId}`;
+
+    if (event.type === "node_started") {
+      started.set(key, at);
+      continue;
+    }
+
+    if (event.type !== "node_completed" && event.type !== "node_failed") continue;
+
+    const startedAt = started.get(key);
+    if (startedAt === undefined) continue;
+    started.delete(key);
+    totalMs += Math.max(0, at - startedAt);
+    pairs += 1;
+  }
+
+  return pairs > 0 ? round(totalMs / pairs) : 0;
+}
+
+/**
+ * Roll the individual dependency verdicts up into one dashboard status.
+ *
+ * SQLite is the only hard dependency: without it the service cannot serve
+ * traffic, so an unreachable database is `unhealthy`. Any other failure or a
+ * degraded dependency downgrades the dashboard to `degraded`.
+ */
+export function deriveDashboardStatus(dependencies: DependencyMetrics): DashboardStatus {
+  if (dependencies.sqlite.status === "unreachable") return "unhealthy";
+
+  const states = Object.values(dependencies).map((d) => d.status);
+  if (states.some((s) => s === "unreachable" || s === "degraded")) return "degraded";
+  return "healthy";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Metrics service
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Reported by whoever owns the WebSocket server, for the dependency block. */
+export interface WebSocketProbeResult {
+  listening: boolean;
+  connections: number;
+}
+
+/**
+ * Collects, caches and serves the health dashboard snapshot.
+ *
+ * A single shared instance ({@link metricsService}) is used by the HTTP
+ * middleware and the dashboard route; tests construct their own instances with
+ * injected sources and clock.
+ */
+export class MetricsService {
+  private readonly cacheTtlMs: number;
+  private readonly windowMs: number;
+  private readonly maxSamples: number;
+  private readonly clock: () => number;
+  private readonly sources: MetricsSources;
+
+  /** Bounded ring buffer of observed requests, oldest first. */
+  private samples: RequestSample[] = [];
+
+  private readonly startedAtMs: number;
+  private lastCpuUsage: NodeJS.CpuUsage;
+  private lastCpuSampleAtMs: number;
+
+  private gcState: GcState = {
+    available: false,
+    collections: 0,
+    totalPauseMs: 0,
+    lastPauseMs: 0,
+  };
+  private gcObserver: PerformanceObserver | null = null;
+
+  private cached: HealthDashboard | null = null;
+  private cachedAtMs = 0;
+  /** In-flight collection, shared so concurrent requests collect only once. */
+  private inFlight: Promise<HealthDashboard> | null = null;
+
+  private webSocketProbe: (() => WebSocketProbeResult) | null = null;
+
+  constructor(options: MetricsCollectorOptions = {}) {
+    const config = readMetricsConfig();
+    this.cacheTtlMs = options.cacheTtlMs ?? config.cacheTtlMs;
+    this.windowMs = options.windowMs ?? config.windowMs;
+    this.maxSamples = options.maxSamples ?? config.maxSamples;
+    this.clock = options.clock ?? Date.now;
+    this.sources = options.sources ?? {};
+
+    this.startedAtMs = this.clock();
+    this.lastCpuUsage = process.cpuUsage();
+    this.lastCpuSampleAtMs = Date.now();
+  }
+
+  /** Record one completed HTTP response. */
+  recordRequest(durationMs: number, statusCode: number): void {
+    this.samples.push({ timestamp: this.clock(), durationMs, statusCode });
+    if (this.samples.length > this.maxSamples) {
+      this.samples.splice(0, this.samples.length - this.maxSamples);
+    }
+  }
+
+  /** Samples currently retained — exposed for assertions and diagnostics. */
+  getSamples(): readonly RequestSample[] {
+    return this.samples;
+  }
+
+  /** Traffic analytics over the rolling window. */
+  getRequestMetrics(): RequestMetrics {
+    return calculateRequestMetrics(this.samples, this.clock(), this.windowMs);
+  }
+
+  /**
+   * Register the source of truth for WebSocket liveness.
+   *
+   * Called by the stream layer when it attaches to the HTTP server; without it
+   * the WebSocket dependency reports `unknown` rather than a false failure.
+   */
+  setWebSocketProbe(probe: (() => WebSocketProbeResult) | null): void {
+    this.webSocketProbe = probe;
+  }
+
+  /** Begin observing GC pauses. Safe to call more than once. */
+  startGcObserver(): void {
+    if (this.gcObserver) return;
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          this.gcState.collections += 1;
+          this.gcState.totalPauseMs += entry.duration;
+          this.gcState.lastPauseMs = entry.duration;
+        }
+      });
+      observer.observe({ entryTypes: ["gc"] });
+      // Newer Node builds expose unref() so the observer never holds the event
+      // loop open; older typings omit it, hence the guarded cast.
+      (observer as unknown as { unref?: () => void }).unref?.();
+      this.gcObserver = observer;
+      this.gcState.available = true;
+    } catch (error) {
+      // GC entries are unavailable on some runtimes/flags — report, don't throw.
+      logger.warn({ err: error }, "garbage collection observer unavailable");
+      this.gcState.available = false;
+    }
+  }
+
+  /** Stop observing GC pauses and release the observer. */
+  stopGcObserver(): void {
+    this.gcObserver?.disconnect();
+    this.gcObserver = null;
+  }
+
+  /** Process health: uptime, memory, CPU-since-last-sample and GC. */
+  getSystemMetrics(): SystemMetrics {
+    const nowMs = Date.now();
+    const cpuDelta = process.cpuUsage(this.lastCpuUsage);
+    const elapsedMs = nowMs - this.lastCpuSampleAtMs;
+    this.lastCpuUsage = process.cpuUsage();
+    this.lastCpuSampleAtMs = nowMs;
+
+    return {
+      uptimeSeconds: Math.max(0, Math.floor((this.clock() - this.startedAtMs) / 1000)),
+      memory: calculateMemoryMetrics(process.memoryUsage()),
+      cpu: calculateCpuMetrics(cpuDelta, elapsedMs, os.loadavg(), os.cpus().length),
+      gc: calculateGcMetrics(this.gcState),
+    };
+  }
+
+  /**
+   * The dashboard snapshot, recollected at most once per `cacheTtlMs`.
+   *
+   * @param force - Bypass the cache and collect immediately.
+   */
+  async getDashboard(force = false): Promise<HealthDashboard> {
+    const now = this.clock();
+    if (!force && this.cached) {
+      const age = now - this.cachedAtMs;
+      if (age < this.cacheTtlMs) {
+        return { ...this.cached, cacheAgeMs: Math.max(0, age) };
+      }
+    }
+
+    // Collapse concurrent misses onto a single collection.
+    if (this.inFlight) return this.inFlight;
+
+    this.inFlight = this.collect()
+      .then((dashboard) => {
+        this.cached = dashboard;
+        this.cachedAtMs = this.clock();
+        return dashboard;
+      })
+      .finally(() => {
+        this.inFlight = null;
+      });
+
+    return this.inFlight;
+  }
+
+  /** Drop the cached snapshot so the next read collects fresh data. */
+  resetCache(): void {
+    this.cached = null;
+    this.cachedAtMs = 0;
+  }
+
+  /** Discard every recorded request sample. */
+  resetSamples(): void {
+    this.samples = [];
+  }
+
+  /** Collect every metric family in parallel and assemble the snapshot. */
+  private async collect(): Promise<HealthDashboard> {
+    const [sqlite, venice, stellarHorizon, websocket, agents, tasks, payments] =
+      await Promise.all([
+        resolveProbe(this.sources.checkSqlite, checkSqlite),
+        resolveProbe(this.sources.checkVenice, checkVenice),
+        resolveProbe(this.sources.checkStellarHorizon, checkStellarHorizon),
+        resolveProbe(this.sources.checkWebSocket, () =>
+          checkWebSocket(this.webSocketProbe),
+        ),
+        resolveSource(this.sources.collectAgents, collectAgentMetrics, EMPTY_AGENTS),
+        resolveSource(this.sources.collectTasks, collectTaskMetrics, EMPTY_TASKS),
+        resolveSource(this.sources.collectPayments, collectPaymentMetrics, EMPTY_PAYMENTS),
+      ]);
+
+    const dependencies: DependencyMetrics = { sqlite, venice, stellarHorizon, websocket };
+    const config = readMetricsConfig();
+
+    return {
+      status: deriveDashboardStatus(dependencies),
+      timestamp: new Date(this.clock()).toISOString(),
+      version: config.version,
+      stellarNetwork: config.stellarNetwork,
+      cacheAgeMs: 0,
+      cacheTtlMs: this.cacheTtlMs,
+      requests: this.getRequestMetrics(),
+      dependencies,
+      system: this.getSystemMetrics(),
+      agents,
+      tasks,
+      payments,
+    };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dependency probes and SQLite collectors
+// ─────────────────────────────────────────────────────────────────────────────
+
+const EMPTY_AGENTS: AgentMetrics = { total: 0, online: 0, offline: 0, avgResponseTimeMs: 0 };
+
+const EMPTY_TASKS: TaskMetrics = {
+  total: 0,
+  active: 0,
+  queued: 0,
+  completed: 0,
+  failed: 0,
+  cancelled: 0,
+};
+
+const EMPTY_PAYMENTS: PaymentMetrics = {
+  locked: toPaymentAmount(0, 0n),
+  released: toPaymentAmount(0, 0n),
+  refunded: toPaymentAmount(0, 0n),
+};
+
+/** Run an overridable probe, converting a rejection into an `unreachable`. */
+async function resolveProbe(
+  override: (() => Promise<DependencyStatus> | DependencyStatus) | undefined,
+  fallback: () => Promise<DependencyStatus> | DependencyStatus,
+): Promise<DependencyStatus> {
+  try {
+    return await (override ?? fallback)();
+  } catch (error) {
+    return { status: "unreachable", error: errorMessage(error) };
+  }
+}
+
+/** Run an overridable collector, falling back to zeroed metrics on failure. */
+async function resolveSource<T>(
+  override: (() => Promise<T> | T) | undefined,
+  fallback: () => Promise<T> | T,
+  empty: T,
+): Promise<T> {
+  try {
+    return await (override ?? fallback)();
+  } catch (error) {
+    logger.warn({ err: error }, "metrics source failed; reporting zeroed metrics");
+    return empty;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** `SELECT 1` against the task and payment databases. */
+async function checkSqlite(): Promise<DependencyStatus> {
+  const startedAt = Date.now();
+  try {
+    const { getTaskDb } = require("../db/tasks") as typeof import("../db/tasks");
+    const { getDb } = require("../db/index") as typeof import("../db/index");
+    getTaskDb().prepare("SELECT 1").get();
+    getDb().prepare("SELECT 1").get();
+    return { status: "ok", latencyMs: Date.now() - startedAt };
+  } catch (error) {
+    return {
+      status: "unreachable",
+      latencyMs: Date.now() - startedAt,
+      error: errorMessage(error),
+    };
+  }
+}
+
+/** Probe the Venice AI model listing with a bounded timeout. */
+async function checkVenice(): Promise<DependencyStatus> {
+  const apiKey = safeConfig()?.VENICE_API_KEY ?? "";
+  return probeHttp("https://api.venice.ai/api/v1/models", {
+    Authorization: `Bearer ${apiKey}`,
+  });
+}
+
+/** Probe the configured Stellar Horizon root endpoint. */
+async function checkStellarHorizon(): Promise<DependencyStatus> {
+  const url = safeConfig()?.STELLAR_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+  return probeHttp(url);
+}
+
+/**
+ * Report WebSocket liveness from the registered probe.
+ *
+ * Without a registered probe the stream layer has not attached — that is
+ * reported as `unknown` rather than a failure, because a backend running
+ * without the WebSocket server is a valid configuration.
+ */
+function checkWebSocket(probe: (() => WebSocketProbeResult) | null): DependencyStatus {
+  if (!probe) {
+    return { status: "unknown", error: "WebSocket server not attached" };
+  }
+  try {
+    const result = probe();
+    return {
+      status: result.listening ? "ok" : "unreachable",
+      details: { connections: result.connections },
+    };
+  } catch (error) {
+    return { status: "unreachable", error: errorMessage(error) };
+  }
+}
+
+/** Issue a bounded HEAD-like GET and classify the response. */
+async function probeHttp(
+  url: string,
+  headers: Record<string, string> = {},
+): Promise<DependencyStatus> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  const startedAt = Date.now();
+  try {
+    const response = await fetch(url, { headers, signal: controller.signal });
+    const latencyMs = Date.now() - startedAt;
+    if (response.ok) return { status: "ok", latencyMs };
+    return {
+      status: "degraded",
+      latencyMs,
+      error: `HTTP ${response.status}`,
+    };
+  } catch (error) {
+    return {
+      status: "unreachable",
+      latencyMs: Date.now() - startedAt,
+      error: errorMessage(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Agent population and mean node execution time, read from SQLite. */
+function collectAgentMetrics(): AgentMetrics {
+  const { getAgentDb } = require("../db/agents") as typeof import("../db/agents");
+  const rows = getAgentDb()
+    .prepare("SELECT status, COUNT(*) AS count FROM agents GROUP BY status")
+    .all() as StatusCountRow[];
+
+  let avgResponseTimeMs = 0;
+  try {
+    const { getTaskDb } = require("../db/tasks") as typeof import("../db/tasks");
+    const events = getTaskDb()
+      .prepare(
+        `SELECT taskId, nodeId, type, timestamp FROM task_events
+          WHERE type IN ('node_started', 'node_completed', 'node_failed')
+          ORDER BY timestamp DESC
+          LIMIT 1000`,
+      )
+      .all() as NodeTimingEvent[];
+    avgResponseTimeMs = calculateAgentResponseTime(events);
+  } catch (error) {
+    // A missing task_events table must not sink the whole agent block.
+    logger.warn({ err: error }, "unable to derive agent response time");
+  }
+
+  return summarizeAgents(rows, avgResponseTimeMs);
+}
+
+/** Task pipeline counters, read from SQLite. */
+function collectTaskMetrics(): TaskMetrics {
+  const { getTaskDb } = require("../db/tasks") as typeof import("../db/tasks");
+  const rows = getTaskDb()
+    .prepare("SELECT status, COUNT(*) AS count FROM tasks GROUP BY status")
+    .all() as StatusCountRow[];
+  return summarizeTasks(rows);
+}
+
+/** Escrow totals, read from SQLite and summed exactly as `bigint`. */
+function collectPaymentMetrics(): PaymentMetrics {
+  const { getDb } = require("../db/index") as typeof import("../db/index");
+  const rows = getDb()
+    .prepare("SELECT status, amountStroops FROM payments")
+    .all() as PaymentRow[];
+  return summarizePayments(rows);
+}
+
+/** Config-backed knobs, with defaults for contexts where config is unloaded. */
+function readMetricsConfig(): {
+  cacheTtlMs: number;
+  windowMs: number;
+  maxSamples: number;
+  version: string;
+  stellarNetwork: string;
+} {
+  const config = safeConfig();
+  return {
+    cacheTtlMs: config?.METRICS_CACHE_TTL_MS ?? DEFAULT_CACHE_TTL_MS,
+    windowMs: config?.METRICS_WINDOW_MS ?? DEFAULT_WINDOW_MS,
+    maxSamples: config?.METRICS_MAX_SAMPLES ?? DEFAULT_MAX_SAMPLES,
+    version: config?.NPM_PACKAGE_VERSION ?? "0.0.0",
+    stellarNetwork: config?.STELLAR_NETWORK ?? "unknown",
+  };
+}
+
+/** `getConfig()` throws before `loadConfig()`; metrics must not depend on order. */
+function safeConfig(): ReturnType<typeof getConfig> | null {
+  try {
+    return getConfig();
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared instance and Express middleware
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Process-wide metrics instance used by the middleware and dashboard route. */
+export const metricsService = new MetricsService();
+
+/**
+ * Sample every HTTP response into {@link metricsService}.
+ *
+ * Mount before the routers so that latency covers the full handler chain.
+ */
+export function metricsMiddleware(_req: Request, res: Response, next: NextFunction): void {
+  const startedAt = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    metricsService.recordRequest(durationMs, res.statusCode);
+  });
+
+  next();
+}

--- a/backend/src/services/metrics.types.ts
+++ b/backend/src/services/metrics.types.ts
@@ -1,0 +1,203 @@
+/**
+ * Shared types for the health dashboard metrics service.
+ *
+ * The dashboard aggregates four independent families of signal:
+ *  • HTTP traffic (rate, latency percentiles, error rate) — sampled in-process.
+ *  • Dependency reachability (SQLite, Venice AI, Stellar Horizon, WebSocket).
+ *  • Process health (memory, CPU, uptime, garbage collection).
+ *  • Domain counters (agents, tasks, payments) — read from SQLite.
+ *
+ * Every numeric field is a plain JSON-safe `number`; stroop amounts are also
+ * surfaced as decimal strings so callers never lose precision on large sums.
+ */
+
+/** Reachability verdict for a single dependency. */
+export type DependencyState = "ok" | "degraded" | "unreachable" | "unknown";
+
+/** Overall dashboard verdict, derived from the individual dependency states. */
+export type DashboardStatus = "healthy" | "degraded" | "unhealthy";
+
+/** A single recorded HTTP request, kept in a bounded in-memory ring buffer. */
+export interface RequestSample {
+  /** Epoch milliseconds at which the response finished. */
+  timestamp: number;
+  /** Wall-clock duration of the request in milliseconds. */
+  durationMs: number;
+  /** HTTP status code written to the response. */
+  statusCode: number;
+}
+
+/** Traffic and latency analytics over the rolling metrics window. */
+export interface RequestMetrics {
+  /** Requests observed inside the rolling window. */
+  totalRequests: number;
+  /** Length of the rolling window in milliseconds. */
+  windowMs: number;
+  /** Requests per second across the window. */
+  requestRatePerSecond: number;
+  /** Mean response time in milliseconds. */
+  avgResponseTimeMs: number;
+  /** 95th percentile response time in milliseconds. */
+  p95ResponseTimeMs: number;
+  /** 99th percentile response time in milliseconds. */
+  p99ResponseTimeMs: number;
+  /** Fraction of requests answered with a 5xx/4xx status, in `0..1`. */
+  errorRate: number;
+  /** Count of responses with a status code >= 500. */
+  serverErrorCount: number;
+  /** Count of responses with a status code in `400..499`. */
+  clientErrorCount: number;
+}
+
+/** Reachability of one external or internal dependency. */
+export interface DependencyStatus {
+  status: DependencyState;
+  /** Round-trip time of the probe in milliseconds, when measured. */
+  latencyMs?: number;
+  /** Human-readable failure reason; omitted when healthy. */
+  error?: string;
+  /** Probe-specific extras (e.g. active WebSocket connections). */
+  details?: Record<string, unknown>;
+}
+
+/** Reachability report for every dependency the dashboard tracks. */
+export interface DependencyMetrics {
+  sqlite: DependencyStatus;
+  venice: DependencyStatus;
+  stellarHorizon: DependencyStatus;
+  websocket: DependencyStatus;
+}
+
+/** Resident memory footprint of the Node.js process. */
+export interface MemoryMetrics {
+  rssBytes: number;
+  heapTotalBytes: number;
+  heapUsedBytes: number;
+  externalBytes: number;
+  /** `heapUsed / heapTotal` as a percentage in `0..100`. */
+  heapUsedPercent: number;
+}
+
+/** CPU consumption of the Node.js process since the previous sample. */
+export interface CpuMetrics {
+  /** User-mode CPU time consumed since the previous sample, in milliseconds. */
+  userMs: number;
+  /** Kernel-mode CPU time consumed since the previous sample, in milliseconds. */
+  systemMs: number;
+  /**
+   * CPU time consumed as a percentage of elapsed wall-clock time since the
+   * previous sample. May exceed 100 on multi-core workloads.
+   */
+  usagePercent: number;
+  /** 1, 5 and 15 minute load averages as reported by the OS. */
+  loadAverage: [number, number, number];
+  /** Logical CPU count of the host. */
+  cpuCount: number;
+}
+
+/** Garbage collection activity observed since process start. */
+export interface GcMetrics {
+  /** Whether GC observation is active (requires `perf_hooks` GC entries). */
+  available: boolean;
+  /** Number of GC pauses observed. */
+  collections: number;
+  /** Cumulative GC pause time in milliseconds. */
+  totalPauseMs: number;
+  /** Mean GC pause duration in milliseconds. */
+  avgPauseMs: number;
+  /** Duration of the most recent GC pause in milliseconds. */
+  lastPauseMs: number;
+}
+
+/** Process-level health: memory, CPU, uptime and GC. */
+export interface SystemMetrics {
+  /** Seconds since the metrics service (and therefore the process) started. */
+  uptimeSeconds: number;
+  memory: MemoryMetrics;
+  cpu: CpuMetrics;
+  gc: GcMetrics;
+}
+
+/** Registered-agent population and responsiveness. */
+export interface AgentMetrics {
+  total: number;
+  online: number;
+  offline: number;
+  /** Mean node execution time across recorded agent dispatches, in ms. */
+  avgResponseTimeMs: number;
+}
+
+/** Task pipeline counters. */
+export interface TaskMetrics {
+  total: number;
+  active: number;
+  queued: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+}
+
+/** Escrow totals for one payment status. */
+export interface PaymentAmount {
+  /** Number of payment records with this status. */
+  count: number;
+  /** Exact total in stroops, as a decimal string (1 XLM = 10 000 000 stroops). */
+  stroops: string;
+  /** Total converted to XLM. Lossy above 2^53 stroops; `stroops` stays exact. */
+  xlm: number;
+}
+
+/** Escrow totals broken down by payment status. */
+export interface PaymentMetrics {
+  locked: PaymentAmount;
+  released: PaymentAmount;
+  refunded: PaymentAmount;
+}
+
+/** The full payload returned by `GET /health/dashboard`. */
+export interface HealthDashboard {
+  status: DashboardStatus;
+  /** ISO-8601 timestamp at which this snapshot was collected. */
+  timestamp: string;
+  version: string;
+  stellarNetwork: string;
+  /** Age of the cached snapshot in milliseconds; `0` on a fresh collection. */
+  cacheAgeMs: number;
+  /** How long a snapshot is served before it is recollected. */
+  cacheTtlMs: number;
+  requests: RequestMetrics;
+  dependencies: DependencyMetrics;
+  system: SystemMetrics;
+  agents: AgentMetrics;
+  tasks: TaskMetrics;
+  payments: PaymentMetrics;
+}
+
+/**
+ * Injectable probes and data sources. Every field is optional — the service
+ * falls back to the real implementations (SQLite handles, `fetch`) when a
+ * probe is not supplied, which keeps unit tests free of I/O.
+ */
+export interface MetricsCollectorOptions {
+  /** Snapshot lifetime in milliseconds. Default: `METRICS_CACHE_TTL_MS`. */
+  cacheTtlMs?: number;
+  /** Rolling request window in milliseconds. Default: `METRICS_WINDOW_MS`. */
+  windowMs?: number;
+  /** Maximum request samples retained. Default: `METRICS_MAX_SAMPLES`. */
+  maxSamples?: number;
+  /** Injectable clock, in epoch milliseconds. Default: `Date.now`. */
+  clock?: () => number;
+  /** Overrides for the individual metric sources. */
+  sources?: MetricsSources;
+}
+
+/** Individual metric sources, each independently overridable in tests. */
+export interface MetricsSources {
+  checkSqlite?: () => Promise<DependencyStatus> | DependencyStatus;
+  checkVenice?: () => Promise<DependencyStatus> | DependencyStatus;
+  checkStellarHorizon?: () => Promise<DependencyStatus> | DependencyStatus;
+  checkWebSocket?: () => Promise<DependencyStatus> | DependencyStatus;
+  collectAgents?: () => Promise<AgentMetrics> | AgentMetrics;
+  collectTasks?: () => Promise<TaskMetrics> | TaskMetrics;
+  collectPayments?: () => Promise<PaymentMetrics> | PaymentMetrics;
+}


### PR DESCRIPTION
Closes #271

## Summary

Adds `GET /health/dashboard`, an admin-only endpoint returning a comprehensive real-time system snapshot. The existing health endpoints only check basic connectivity; this one surfaces enough signal for proactive monitoring and quick incident response.

## Acceptance criteria

| Criterion | Status |
|---|---|
| `GET /health/dashboard` returns comprehensive system status | ✅ |
| Metrics: request rate, avg response time, error rate, p95/p99 latency | ✅ |
| Dependency status: SQLite, Venice AI, Stellar Horizon, WebSocket | ✅ |
| Memory usage, CPU usage, uptime, and garbage collection stats | ✅ |
| Agent status: online/offline count, average response time | ✅ |
| Task metrics: active, queued, completed, failed counts | ✅ |
| Payment metrics: total locked, released, refunded amounts | ✅ |
| Metrics refreshed every 5 seconds (cached) | ✅ |
| Endpoint protected by admin API key | ✅ |
| Unit tests for all metric calculations | ✅ 85 new tests |

## Response shape

```jsonc
{
  "status": "healthy",              // healthy | degraded | unhealthy
  "timestamp": "2026-08-26T09:00:00.000Z",
  "version": "0.1.0",
  "stellarNetwork": "testnet",
  "cacheAgeMs": 1200,
  "cacheTtlMs": 5000,
  "requests": {
    "totalRequests": 340, "windowMs": 60000, "requestRatePerSecond": 5.67,
    "avgResponseTimeMs": 12.5, "p95ResponseTimeMs": 48, "p99ResponseTimeMs": 91,
    "errorRate": 0.0088, "serverErrorCount": 1, "clientErrorCount": 2
  },
  "dependencies": {
    "sqlite":         { "status": "ok", "latencyMs": 1 },
    "venice":         { "status": "ok", "latencyMs": 210 },
    "stellarHorizon": { "status": "ok", "latencyMs": 145 },
    "websocket":      { "status": "ok", "details": { "connections": 3 } }
  },
  "system": {
    "uptimeSeconds": 8412,
    "memory": { "rssBytes": 0, "heapTotalBytes": 0, "heapUsedBytes": 0, "externalBytes": 0, "heapUsedPercent": 62.4 },
    "cpu": { "userMs": 120, "systemMs": 35, "usagePercent": 3.1, "loadAverage": [0.4, 0.5, 0.6], "cpuCount": 8 },
    "gc": { "available": true, "collections": 214, "totalPauseMs": 388.2, "avgPauseMs": 1.81, "lastPauseMs": 0.94 }
  },
  "agents":   { "total": 12, "online": 9, "offline": 3, "avgResponseTimeMs": 1842.6 },
  "tasks":    { "total": 512, "active": 3, "queued": 7, "completed": 480, "failed": 20, "cancelled": 2 },
  "payments": {
    "locked":   { "count": 4,   "stroops": "150000000",   "xlm": 15 },
    "released": { "count": 480, "stroops": "24000000000", "xlm": 2400 },
    "refunded": { "count": 20,  "stroops": "500000000",   "xlm": 50 }
  }
}
```

## Design notes

**Caching.** Snapshots are cached for `METRICS_CACHE_TTL_MS` (default 5 s) and `cacheAgeMs` reports how stale the served copy is. Concurrent cache misses are collapsed onto a single collection, so a scraping dashboard can't turn the endpoint into a load generator. `?refresh=true` bypasses the cache.

**Admin auth fails closed.** `adminAuthMiddleware` accepts the key via `X-Admin-API-Key` or `Authorization: Bearer`, compared in constant time. Unlike the existing `authMiddleware` (which no-ops when `API_KEYS` is unset), an unconfigured `ADMIN_API_KEY` makes the endpoint answer **503** rather than exposing admin data anonymously.

**Failure isolation.** A failing dependency probe degrades only its own block; a failing SQLite collector reports zeroed counters. Neither takes the endpoint down. Only an unreachable SQLite rolls the overall status up to `unhealthy` — everything else yields `degraded`.

**Exact payment totals.** Escrow amounts are summed as `bigint` and surfaced both as an exact decimal `stroops` string and a convenience `xlm` number, so totals beyond `Number.MAX_SAFE_INTEGER` stroops stay precise.

**Testability.** Every metric calculation is an exported pure function (`calculateRequestMetrics`, `summarizePayments`, `percentile`, …) and every data source is injectable, so the whole test suite runs without a database, a socket, or the real clock.

## Files changed

| File | Action |
|---|---|
| `backend/src/services/metrics.ts` | **New** — metrics collection service + Express sampling middleware |
| `backend/src/services/metrics.types.ts` | **New** — metrics type definitions |
| `backend/src/services/metrics.test.ts` | **New** — 71 unit tests for the metric calculations |
| `backend/src/api/routes/health.ts` | Dashboard endpoint + OpenAPI docs |
| `backend/src/api/routes/health.test.ts` | 14 dashboard endpoint tests |
| `backend/src/api/middleware/auth.ts` | `adminAuthMiddleware` + `resolveAdminApiKey` |
| `backend/src/config/index.ts` | `ADMIN_API_KEY`, `METRICS_CACHE_TTL_MS`, `METRICS_WINDOW_MS`, `METRICS_MAX_SAMPLES` |
| `backend/src/api/app.ts` | Mount the sampling middleware; register the WebSocket probe |
| `backend/src/api/routes/stream.ts` | Export `getStreamConnectionCount()` for live connection counts |
| `backend/.env.example` | Document the new environment variables |

## Configuration

```bash
# Required to enable the endpoint — without it, /health/dashboard returns 503
ADMIN_API_KEY=$(openssl rand -hex 32)

# Optional tuning
METRICS_CACHE_TTL_MS=5000    # snapshot lifetime
METRICS_WINDOW_MS=60000      # rolling window for rate/latency/error analytics
METRICS_MAX_SAMPLES=1000     # request samples retained in memory
```

```bash
curl -H "X-Admin-API-Key: $ADMIN_API_KEY" http://localhost:3001/health/dashboard
```

## Testing

- `npm run build` — clean.
- `npm test` — no new failures. `tests/e2e/pipeline.test.ts › payment was released exactly once per node` fails, but it fails identically on a clean checkout of `main`; it is pre-existing and unrelated to this change.
- Full-suite baseline comparison: **626 tests / 3 failures** before → **711 tests / the same 3 failures** after. 85 tests added, 0 regressions.

Two notes for reviewers:

1. **`npm run lint` was not run** — no lint script or ESLint config exists in `backend/package.json` (the only `lint` script in the repo lives in `smart-contracts`, untouched here). `tsc --noEmit` was run instead rather than adding a lint toolchain as unrequested scope.
2. **`npm test` doesn't run these tests in CI.** The script is `jest --testPathPattern=tests`, which excludes everything under `src/` — including the pre-existing `health.test.ts`. The new tests pass under `npx jest src/`, but won't execute in CI until that pattern is widened. Left alone here to keep the diff scoped; happy to fix it in a follow-up if you'd like.
