### PR TITLE
feat: standardized exit codes, agent status cards, release & frontend docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ This document specifies repository instructions and conventions for developers a
 3. **Frontend Invariants**:
    - Responsive, token-driven modern design.
    - Proper skeleton loading states and graceful error boundaries.
+   - Follow [Frontend Architecture & Conventions](docs/FRONTEND_ARCHITECTURE.md) for folder structure, naming, and component patterns.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ npm run test:e2e
 - [Node Operators Guide](docs/NODE_OPERATORS_GUIDE.md): Step-by-step instructions for provisioning, configuring secrets, deploying smart contracts, funding accounts, operating nodes, monitoring metrics, and troubleshooting common errors.
 - [Smart Contract Deployment Guide](smart-contracts/docs/DEPLOYMENT_GUIDE.md): Complete deployment and upgrade workflows on Soroban.
 - [End-to-End Testing Guide](docs/e2e-testing.md): Automated test execution and validation.
+- [Release Engineering Guide](docs/RELEASE_ENGINEERING.md): Tagging, changelog generation, artifact signing, and release checklists.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ npm run test:e2e
 - [Smart Contract Deployment Guide](smart-contracts/docs/DEPLOYMENT_GUIDE.md): Complete deployment and upgrade workflows on Soroban.
 - [End-to-End Testing Guide](docs/e2e-testing.md): Automated test execution and validation.
 - [Release Engineering Guide](docs/RELEASE_ENGINEERING.md): Tagging, changelog generation, artifact signing, and release checklists.
+- [Frontend Architecture & Conventions](docs/FRONTEND_ARCHITECTURE.md): Folder structure, naming rules, state management, and component patterns.
 
 ---
 

--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -1,0 +1,138 @@
+# Frontend Architecture & Component Conventions
+
+This document defines the folder structure, naming rules, state management
+patterns, and conventions for the ai-net frontend.
+
+---
+
+## Folder Structure
+
+```
+frontend/src/
+├── components/          # Reusable UI components
+│   ├── common/          # Generic, domain-agnostic (Toast, Skeleton, ErrorBoundary)
+│   ├── layout/          # App shell, navigation, sidebar
+│   ├── landing/         # Public landing page components
+│   ├── dashboard/       # Dashboard widgets (KPI cards, tables, charts)
+│   ├── tasks/           # Task-related UI (filter, timeline, comparison)
+│   ├── notifications/   # Notification center and items
+│   └── wallet/          # Wallet wizard, transaction table, charts
+├── context/             # React Context providers (Wallet, Theme, Toast, Notifications)
+├── hooks/               # Custom React hooks (useWallet, useTheme, useTaskWebSocket, etc.)
+├── i18n/                # Internationalization config and locale JSON files
+│   └── locales/         # en.json, zh.json, etc.
+├── mocks/               # MSW mock handlers for development/testing
+├── pages/               # Route-level page components
+│   └── tasks/           # Task sub-pages (NewTaskPage, TaskHistoryPage)
+├── schemas/             # Zod validation schemas (wallet, task)
+├── types/               # TypeScript type definitions (agent, api, notification)
+└── utils/               # Pure utility functions (format, time, agentRegistry)
+```
+
+---
+
+## Naming Rules
+
+### Files
+
+| Kind | Pattern | Example |
+|------|---------|---------|
+| Component | `PascalCase.tsx` | `AgentCard.tsx`, `TaskFilterBar.tsx` |
+| CSS Module | `PascalCase.module.css` | `AgentCard.module.css` |
+| Plain CSS | `PascalCase.css` | `Toast.css` |
+| Hook | `camelCase.ts` (prefix `use`) | `useWallet.ts`, `useTaskWebSocket.ts` |
+| Type | `camelCase.ts` | `agent.ts`, `api.ts` |
+| Schema | `camelCase.ts` | `wallet.ts`, `task.ts` |
+| Utility | `camelCase.ts` | `format.ts`, `time.ts` |
+| Test | `*.test.ts` / `*.test.tsx` | `useNodeState.test.ts` |
+| i18n test | `*.i18n.test.tsx` | `RecentTasksTable.i18n.test.tsx` |
+
+### Components
+
+- **One component per file.** File name matches the default export.
+- **Named exports** for types/interfaces (`AgentData`, `AgentCardProps`).
+- **No default export for hooks or utilities** — use named exports.
+- **Co-locate tests** next to the component: `AgentCard.tsx` → `AgentCard.test.tsx`.
+
+### CSS
+
+- **CSS Modules** for component-scoped styles (`.module.css`).
+- **Plain CSS** only for global resets or third-party overrides.
+- Use Tailwind utility classes inline when possible; CSS Modules for complex
+  animations or pseudo-elements.
+
+---
+
+## State Management
+
+### React Context (Global State)
+
+Used for cross-cutting concerns that many components need:
+
+| Context | Purpose |
+|---------|---------|
+| `WalletContext` | Stellar wallet connection, signing, balance |
+| `ThemeContext` | Dark/light mode toggle |
+| `ToastContext` | Global toast notifications |
+| `NotificationContext` | In-app notification feed |
+
+### Custom Hooks (Component State)
+
+Data fetching and component-local state live in custom hooks:
+
+| Hook | Purpose |
+|------|---------|
+| `useWallet` | Wallet connection and signing |
+| `useWalletBalance` | Balance polling |
+| `useTaskWebSocket` | Real-time task status via WS |
+| `useAgentRegistry` | Agent discovery and registration |
+| `useTaskSubmit` | Task submission flow |
+| `useNotifications` | Notification polling |
+| `useTheme` | Theme preference persistence |
+| `useNetworkStats` | Network health metrics |
+
+### Rules
+
+1. **No Redux or Zustand.** Context + hooks is the pattern.
+2. **Lift state up** only when two sibling components need the same data.
+3. **Prefer colocation** — keep state close to where it's used.
+4. **Memoize expensive computations** with `useMemo`/`useCallback`.
+
+---
+
+## Adding New Components
+
+1. Create `ComponentName.tsx` in the appropriate `components/<category>/` folder.
+2. Create `ComponentName.module.css` if custom styles are needed.
+3. Create `ComponentName.test.tsx` for unit tests.
+4. Export the component as default from the file.
+5. Use the `PascalCase` naming convention.
+
+## Adding New Pages
+
+1. Create `PageName.tsx` in `pages/` (or `pages/<section>/` for sub-pages).
+2. Create `PageName.module.css` if needed.
+3. Add the route in `App.tsx`.
+4. Add i18n keys in `i18n/locales/en.json` (and other locales).
+
+## Adding New Hooks
+
+1. Create `useHookName.ts` in `hooks/`.
+2. Create `useHookName.test.ts` for unit tests.
+3. Export as a named export.
+4. Prefix with `use`.
+
+---
+
+## Verification
+
+Before submitting changes:
+
+```bash
+cd frontend
+npm run lint
+npm run build
+```
+
+Lint catches naming violations (unused imports, type issues). Build verifies
+the full bundle compiles without errors.

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -1,0 +1,165 @@
+# Release Engineering Guide
+
+This document covers the release process for ai-net across backend, frontend,
+and smart-contract tracks.
+
+---
+
+## Semantic Versioning
+
+ai-net follows [SemVer 2.0.0](https://semver.org/):
+
+- **MAJOR** — Breaking changes to APIs, contract interfaces, or storage layouts.
+- **MINOR** — New features, backward-compatible.
+- **PATCH** — Bug fixes, backward-compatible.
+
+Smart contracts use SemVer on the `stellar-cli` deploy metadata. The on-chain
+contract name stays the same; the version is recorded in deployment JSON.
+
+---
+
+## Tagging Convention
+
+Tags follow the pattern `v<MAJOR>.<MINOR>.<PATCH>`:
+
+```bash
+git tag -a v1.2.3 -m "Release v1.2.3"
+git push origin v1.2.3
+```
+
+Use annotated tags (`-a`) so the tag message is stored. Tags are immutable
+once pushed.
+
+---
+
+## Changelog Generation
+
+The project uses [Conventional Commits](https://www.conventionalcommits.org/)
+for automatic changelog entries. Each release includes a `CHANGELOG.md` update
+with sections:
+
+- **Features** — new functionality (`feat:`)
+- **Bug Fixes** — resolved issues (`fix:`)
+- **Breaking Changes** — backward-incompatible changes (`feat!:` or `BREAKING CHANGE:`)
+- **Other Changes** — docs, chores, refactors, tests
+
+### Generate changelog since last tag
+
+```bash
+LAST_TAG=$(git describe --tags --abbrev=0)
+git log ${LAST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges
+```
+
+Add the output under the appropriate section in `CHANGELOG.md`.
+
+---
+
+## Release Checklist
+
+### 1. Pre-release
+
+- [ ] All CI checks passing on `main`
+- [ ] No open critical/blocking issues tagged for this release
+- [ ] `CHANGELOG.md` updated with release notes
+- [ ] Version bumped in relevant files (package.json, Cargo.toml, etc.)
+
+### 2. Backend
+
+- [ ] `cd backend && npm run lint && npm test`
+- [ ] Build production bundle: `npm run build`
+- [ ] Verify no secrets in build output
+
+### 3. Frontend
+
+- [ ] `cd frontend && npm run lint && npm run build`
+- [ ] Verify no secrets in build output
+
+### 4. Smart Contracts
+
+- [ ] `cd smart-contracts && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test`
+- [ ] Build Wasm artifacts: `cargo build --target wasm32-unknown-unknown --release`
+- [ ] Generate SHA256 checksums for all `.wasm` files
+
+### 5. Tag & Release
+
+- [ ] Create annotated tag: `git tag -a v<VERSION> -m "Release v<VERSION>"`
+- [ ] Push tag: `git push origin v<VERSION>`
+- [ ] Create GitHub Release with changelog notes
+- [ ] Attach Wasm artifacts and SHA256SUMS to release
+
+### 6. Post-release
+
+- [ ] Deploy contracts to testnet (verify)
+- [ ] Deploy contracts to mainnet (if applicable)
+- [ ] Update deployment JSON with new contract addresses
+- [ ] Monitor for 24h after mainnet deploy
+
+---
+
+## Artifact Signing & Verification
+
+### SHA256SUMS
+
+Every release includes a `SHA256SUMS` file for integrity verification:
+
+```bash
+# Generate checksums for all Wasm artifacts
+cd smart-contracts/contracts
+find . -name "*.wasm" -exec sha256sum {} \; > SHA256SUMS
+
+# Verify a downloaded artifact
+sha256sum -c SHA256SUMS
+```
+
+### Wasm Artifact Verification
+
+After downloading a release artifact:
+
+```bash
+# 1. Verify checksum
+sha256sum -c SHA256SUMS
+
+# 2. Verify the Wasm module has correct imports
+stellar contract inspect <artifact.wasm>
+
+# 3. Deploy and verify on testnet before mainnet
+./scripts/deploy.sh --network testnet
+./scripts/verify.sh --network testnet
+```
+
+---
+
+## Contract Upgrade Coordination
+
+When upgrading deployed contracts:
+
+1. **Testnet first** — always deploy to testnet and run full E2E tests.
+2. **Announce** — notify stakeholders at least 48h before mainnet upgrade.
+3. **Upgrade via upgrade-manager** — use the `upgrade.sh` script with the
+   upgrade-manager contract for safe upgrades with rollback window.
+4. **Verify** — run `verify.sh` post-upgrade to confirm storage and state.
+5. **Monitor** — watch metrics for 24h post-upgrade.
+
+```bash
+# Dry run
+./scripts/upgrade.sh --network mainnet --dry-run
+
+# Upgrade
+./scripts/upgrade.sh --network mainnet --use-upgrade-manager agent-registry
+
+# Verify
+./scripts/verify.sh --network mainnet
+```
+
+---
+
+## Release Tracks
+
+| Track | Cadence | Artifacts |
+|-------|---------|-----------|
+| Smart Contracts | On-demand (after audit or feature milestone) | `.wasm` files, SHA256SUMS |
+| Backend | Bi-weekly or on critical fix | Docker image, npm package |
+| Frontend | Bi-weekly or on critical fix | Static build, Docker image |
+
+All tracks share the same SemVer and tagging convention. A single git tag
+covers all tracks for a given version.

--- a/frontend/src/components/landing/AgentCard.tsx
+++ b/frontend/src/components/landing/AgentCard.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { motion } from 'framer-motion'
 import { formatNumber } from '../../utils/format'
+import { Star } from 'lucide-react'
 
 export interface AgentData {
   id: string
@@ -11,6 +12,10 @@ export interface AgentData {
   icon: React.ReactNode
   tasksCompleted: number
   successRate: number
+  capabilities?: string[]
+  isOnline?: boolean
+  lastHeartbeat?: number
+  reputation?: number
 }
 
 interface AgentCardProps {
@@ -18,8 +23,61 @@ interface AgentCardProps {
   index: number
 }
 
+function formatHeartbeatAge(lastHeartbeat?: number): string {
+  if (!lastHeartbeat) return ''
+  const now = Date.now()
+  const diffMs = now - lastHeartbeat
+  const seconds = Math.floor(diffMs / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ago`
+}
+
+function CapabilityBadges({ capabilities }: { capabilities: string[] }) {
+  const badgeColors: Record<string, string> = {
+    research: 'bg-[#60A5FA]/15 text-[#60A5FA] border-[#60A5FA]/30',
+    risk: 'bg-[#FBBF24]/15 text-[#FBBF24] border-[#FBBF24]/30',
+    coding: 'bg-[#34D399]/15 text-[#34D399] border-[#34D399]/30',
+    design: 'bg-[#C084FC]/15 text-[#C084FC] border-[#C084FC]/30',
+    report: 'bg-[#F87171]/15 text-[#F87171] border-[#F87171]/30',
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5 mb-3">
+      {capabilities.map((cap) => (
+        <span
+          key={cap}
+          className={`text-[9px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border ${badgeColors[cap] || 'bg-text-secondary/10 text-text-secondary border-text-secondary/30'}`}
+          title={cap}
+        >
+          {cap}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function ReputationStars({ rating }: { rating: number }) {
+  const stars = Math.round((rating / 100) * 5)
+  return (
+    <div className="flex items-center gap-0.5" title={`Reputation: ${rating}/100`}>
+      {Array.from({ length: 5 }, (_, i) => (
+        <Star
+          key={i}
+          size={10}
+          className={i < stars ? 'text-[#FBBF24] fill-[#FBBF24]' : 'text-text-secondary/30'}
+        />
+      ))}
+    </div>
+  )
+}
+
 const AgentCard: React.FC<AgentCardProps> = ({ agent, index }) => {
   const { t, i18n } = useTranslation()
+  const isOnline = agent.isOnline ?? true
+  const capabilities = agent.capabilities ?? []
 
   return (
     <motion.div
@@ -33,7 +91,7 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, index }) => {
       <div className="absolute inset-0 bg-gradient-primary opacity-0 group-hover:opacity-[0.03] transition-opacity duration-500" />
       <div className="absolute -inset-px rounded-2xl border border-accent-cyan/0 group-hover:border-accent-cyan/30 transition-all duration-500 pointer-events-none" />
 
-      <div className="flex items-start justify-between mb-4 relative">
+      <div className="flex items-start justify-between mb-3 relative">
         <div className="flex items-center gap-3">
           <div className="w-10 h-10 rounded-xl bg-background-surface-alt border border-border-subtle flex items-center justify-center group-hover:border-accent-cyan/30 group-hover:shadow-[0_0_12px_rgba(56,189,248,0.15)] transition-all duration-300">
             {agent.icon}
@@ -47,21 +105,54 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, index }) => {
             </span>
           </div>
         </div>
-        <div className="w-2 h-2 rounded-full bg-accent-green shadow-[0_0_8px_rgba(52,211,153,0.6)] relative" />
+
+        <div className="flex items-center gap-2">
+          <div className="flex flex-col items-end">
+            <span className="text-[9px] text-text-secondary uppercase tracking-wider font-bold">
+              {isOnline ? 'Online' : 'Offline'}
+            </span>
+            {agent.lastHeartbeat && (
+              <span className="text-[8px] text-text-secondary/60">
+                {formatHeartbeatAge(agent.lastHeartbeat)}
+              </span>
+            )}
+          </div>
+          <div
+            className={`w-2.5 h-2.5 rounded-full relative ${
+              isOnline
+                ? 'bg-accent-green shadow-[0_0_8px_rgba(52,211,153,0.6)]'
+                : 'bg-text-secondary/40'
+            }`}
+          >
+            {isOnline && (
+              <span className="absolute inset-0 rounded-full bg-accent-green animate-ping opacity-75" />
+            )}
+          </div>
+        </div>
       </div>
 
-      <p className="text-sm text-text-secondary mb-6 flex-grow line-clamp-3 relative leading-relaxed">
+      {capabilities.length > 0 && <CapabilityBadges capabilities={capabilities} />}
+
+      <p className="text-sm text-text-secondary mb-4 flex-grow line-clamp-3 relative leading-relaxed">
         {agent.description}
       </p>
 
-      <div className="flex items-center justify-between pt-4 border-t border-border-subtle/50 relative">
+      <div className="flex items-center justify-between pt-3 border-t border-border-subtle/50 relative">
         <div className="flex flex-col gap-0.5">
           <span className="text-[10px] text-text-secondary uppercase tracking-wider font-bold">{t('agent.tasks')}</span>
           <span className="text-sm font-bold text-text-primary">{formatNumber(agent.tasksCompleted, i18n.language)}</span>
         </div>
-        <div className="flex flex-col items-end gap-0.5">
+        <div className="flex flex-col items-center gap-0.5">
           <span className="text-[10px] text-text-secondary uppercase tracking-wider font-bold">{t('agent.success')}</span>
           <span className="text-sm font-bold text-accent-green">{agent.successRate}%</span>
+        </div>
+        <div className="flex flex-col items-end gap-0.5">
+          <span className="text-[10px] text-text-secondary uppercase tracking-wider font-bold">Rating</span>
+          {agent.reputation !== undefined ? (
+            <ReputationStars rating={agent.reputation} />
+          ) : (
+            <span className="text-sm font-bold text-text-secondary">—</span>
+          )}
         </div>
       </div>
     </motion.div>

--- a/frontend/src/components/landing/SpecialistAgentsSection.tsx
+++ b/frontend/src/components/landing/SpecialistAgentsSection.tsx
@@ -15,7 +15,11 @@ const mockAgents: AgentData[] = [
     description: 'Specializes in deep-dive data collection, market analysis, and summarizing whitepapers across the web3 ecosystem.',
     icon: <Search size={22} className="text-[#60A5FA]" />,
     tasksCompleted: 1420,
-    successRate: 98.5
+    successRate: 98.5,
+    capabilities: ['research', 'report'],
+    isOnline: true,
+    lastHeartbeat: Date.now() - 15000,
+    reputation: 95,
   },
   {
     id: '2',
@@ -24,7 +28,11 @@ const mockAgents: AgentData[] = [
     description: 'Analyzes smart contracts for vulnerabilities, flags malicious addresses, and assesses protocol risk metrics.',
     icon: <ShieldAlert size={22} className="text-[#FBBF24]" />,
     tasksCompleted: 850,
-    successRate: 99.2
+    successRate: 99.2,
+    capabilities: ['risk', 'research'],
+    isOnline: true,
+    lastHeartbeat: Date.now() - 45000,
+    reputation: 99,
   },
   {
     id: '3',
@@ -33,7 +41,11 @@ const mockAgents: AgentData[] = [
     description: 'Writes, reviews, and tests Soroban smart contracts. Fluent in Rust, Python, and TypeScript.',
     icon: <Code2 size={22} className="text-[#34D399]" />,
     tasksCompleted: 3105,
-    successRate: 97.8
+    successRate: 97.8,
+    capabilities: ['coding', 'research'],
+    isOnline: false,
+    lastHeartbeat: Date.now() - 3600000,
+    reputation: 92,
   },
   {
     id: '4',
@@ -42,7 +54,11 @@ const mockAgents: AgentData[] = [
     description: 'Generates UI mockups, marketing assets, and NFT artwork based on natural language prompts.',
     icon: <Paintbrush size={22} />,
     tasksCompleted: 620,
-    successRate: 95.4
+    successRate: 95.4,
+    capabilities: ['design'],
+    isOnline: true,
+    lastHeartbeat: Date.now() - 5000,
+    reputation: 88,
   },
   {
     id: '5',
@@ -51,7 +67,11 @@ const mockAgents: AgentData[] = [
     description: 'Compiles raw data and research notes into structured, executive-ready PDF reports and markdown documents.',
     icon: <FileText size={22} />,
     tasksCompleted: 112,
-    successRate: 99.9
+    successRate: 99.9,
+    capabilities: ['report', 'research'],
+    isOnline: true,
+    lastHeartbeat: Date.now() - 120000,
+    reputation: 97,
   }
 ]
 

--- a/smart-contracts/contracts/agent_registry/src/lib.rs
+++ b/smart-contracts/contracts/agent_registry/src/lib.rs
@@ -32,6 +32,7 @@
 //! Callers inspect the returned `Vec<BatchResult>` / `Vec<VoidBatchResult>`:
 //! all-success means the batch committed; any failure means **no** writes occurred.
 
+pub mod shared_exit_codes;
 mod errors;
 mod events;
 mod upgrade;
@@ -40,6 +41,7 @@ mod upgrade;
 mod upgrade_tests;
 
 pub use upgrade::*;
+pub use shared_exit_codes::CommonExitCode;
 
 use events::{
     AdminChangedEvent, AgentDeregisteredEvent, AgentRegisteredEvent, ErrorReportedEvent,
@@ -2256,6 +2258,27 @@ impl AgentRegistryContract {
         };
 
         Some((sla, compliance))
+    }
+
+    /// Map a raw error code from any ai-net contract to its standardized
+    /// [`CommonExitCode`] equivalent.
+    ///
+    /// This is the single entry-point for cross-contract error interpretation.
+    /// Callers pass the raw `u32` error code returned by any contract call and
+    /// receive the standardized [`CommonExitCode`] if the code falls within the
+    /// reserved common range (1..=15), or `None` if it is contract-specific.
+    ///
+    /// ```text
+    /// // Off-chain usage:
+    /// let result = registry.error_mapper(raw_error_code);
+    /// match result {
+    ///     Some(CommonExitCode::NotFound) => { /* handle */ }
+    ///     Some(CommonExitCode::Unauthorized) => { /* handle */ }
+    ///     None => { /* contract-specific code, inspect locally */ }
+    /// }
+    /// ```
+    pub fn error_mapper(_env: Env, raw_code: u32) -> Option<CommonExitCode> {
+        shared_exit_codes::CommonExitCode::from_raw(raw_code)
     }
 }
 

--- a/smart-contracts/contracts/agent_registry/src/shared_exit_codes.rs
+++ b/smart-contracts/contracts/agent_registry/src/shared_exit_codes.rs
@@ -1,0 +1,186 @@
+//! # Standardized Cross-Contract Exit Codes
+//!
+//! Common exit-code registry shared across all ai-net Soroban contracts.
+//! Contracts map their local error codes to these common codes for
+//! cross-contract error propagation so callers can interpret failures
+//! without coupling to a specific contract's internal enum.
+//!
+//! ## Code ranges
+//!
+//! * `1..=15` — Reserved **common codes** (defined here).
+//! * `100..` — Contract-specific codes (local to each contract).
+//!
+//! ## Exit-code-to-meaning table
+//!
+//! | Code | Name                | Meaning                                               |
+//! |------|---------------------|-------------------------------------------------------|
+//! | 1    | NotFound            | The requested entity does not exist                    |
+//! | 2    | Unauthorized        | Caller lacks the required authorization signature      |
+//! | 3    | AlreadyExists       | Entity already registered / duplicate creation          |
+//! | 4    | ContractPaused      | Contract is paused; all mutations rejected              |
+//! | 5    | AgentFrozen         | Agent is frozen; operations on it are rejected          |
+//! | 6    | NotAdmin            | Caller is not an admin of the contract                  |
+//! | 7    | InvalidRecord       | Input record fails validation                           |
+//! | 8    | DuplicateInBatch    | Batch contains duplicate entity IDs                     |
+//! | 9    | StorageLimitReached | Global storage capacity has been reached                |
+//! | 10   | InvalidArgument     | A required argument is missing or malformed             |
+//! | 11   | InternalError       | Unexpected internal error (contract bug)                |
+//! | 12   | Expired             | The entity has expired or its TTL has elapsed            |
+//! | 13   | InsufficientFunds   | Caller or escrow lacks sufficient balance               |
+//! | 14   | RateLimited         | Operation rejected due to rate limiting                 |
+//! | 15   | ContractNotLinked   | Cross-contract call target is not configured            |
+
+use soroban_sdk::contracterror;
+
+/// Standardized common exit codes shared across all ai-net contracts.
+///
+/// Contracts should map their local error variants to these codes when
+/// propagating errors cross-contract. Off-chain callers can match on
+/// `CommonExitCode` without knowing which contract produced the error.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum CommonExitCode {
+    /// The requested entity does not exist.
+    NotFound = 1,
+    /// Caller lacks the required authorization signature.
+    Unauthorized = 2,
+    /// Entity already registered / duplicate creation.
+    AlreadyExists = 3,
+    /// Contract is paused; all mutations rejected.
+    ContractPaused = 4,
+    /// Agent is frozen; operations on it are rejected.
+    AgentFrozen = 5,
+    /// Caller is not an admin of the contract.
+    NotAdmin = 6,
+    /// Input record fails validation.
+    InvalidRecord = 7,
+    /// Batch contains duplicate entity IDs.
+    DuplicateInBatch = 8,
+    /// Global storage capacity has been reached.
+    StorageLimitReached = 9,
+    /// A required argument is missing or malformed.
+    InvalidArgument = 10,
+    /// Unexpected internal error (contract bug).
+    InternalError = 11,
+    /// The entity has expired or its TTL has elapsed.
+    Expired = 12,
+    /// Caller or escrow lacks sufficient balance.
+    InsufficientFunds = 13,
+    /// Operation rejected due to rate limiting.
+    RateLimited = 14,
+    /// Cross-contract call target is not configured.
+    ContractNotLinked = 15,
+}
+
+impl CommonExitCode {
+    /// Convert a raw `u32` status code to a [`CommonExitCode`].
+    ///
+    /// Returns `None` when the code is outside the reserved range or is
+    /// not a recognized common code (i.e. it is contract-specific).
+    pub fn from_raw(code: u32) -> Option<Self> {
+        match code {
+            1 => Some(Self::NotFound),
+            2 => Some(Self::Unauthorized),
+            3 => Some(Self::AlreadyExists),
+            4 => Some(Self::ContractPaused),
+            5 => Some(Self::AgentFrozen),
+            6 => Some(Self::NotAdmin),
+            7 => Some(Self::InvalidRecord),
+            8 => Some(Self::DuplicateInBatch),
+            9 => Some(Self::StorageLimitReached),
+            10 => Some(Self::InvalidArgument),
+            11 => Some(Self::InternalError),
+            12 => Some(Self::Expired),
+            13 => Some(Self::InsufficientFunds),
+            14 => Some(Self::RateLimited),
+            15 => Some(Self::ContractNotLinked),
+            _ => None,
+        }
+    }
+
+    /// Human-readable label for the exit code.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::NotFound => "NotFound",
+            Self::Unauthorized => "Unauthorized",
+            Self::AlreadyExists => "AlreadyExists",
+            Self::ContractPaused => "ContractPaused",
+            Self::AgentFrozen => "AgentFrozen",
+            Self::NotAdmin => "NotAdmin",
+            Self::InvalidRecord => "InvalidRecord",
+            Self::DuplicateInBatch => "DuplicateInBatch",
+            Self::StorageLimitReached => "StorageLimitReached",
+            Self::InvalidArgument => "InvalidArgument",
+            Self::InternalError => "InternalError",
+            Self::Expired => "Expired",
+            Self::InsufficientFunds => "InsufficientFunds",
+            Self::RateLimited => "RateLimited",
+            Self::ContractNotLinked => "ContractNotLinked",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn common_codes_roundtrip_through_raw() {
+        let codes = [
+            CommonExitCode::NotFound,
+            CommonExitCode::Unauthorized,
+            CommonExitCode::AlreadyExists,
+            CommonExitCode::ContractPaused,
+            CommonExitCode::AgentFrozen,
+            CommonExitCode::NotAdmin,
+            CommonExitCode::InvalidRecord,
+            CommonExitCode::DuplicateInBatch,
+            CommonExitCode::StorageLimitReached,
+            CommonExitCode::InvalidArgument,
+            CommonExitCode::InternalError,
+            CommonExitCode::Expired,
+            CommonExitCode::InsufficientFunds,
+            CommonExitCode::RateLimited,
+            CommonExitCode::ContractNotLinked,
+        ];
+        for code in &codes {
+            let raw = *code as u32;
+            assert!(raw >= 1 && raw <= 15);
+            let recovered = CommonExitCode::from_raw(raw).unwrap();
+            assert_eq!(recovered as u32, raw);
+        }
+    }
+
+    #[test]
+    fn from_raw_returns_none_for_out_of_range() {
+        assert!(CommonExitCode::from_raw(0).is_none());
+        assert!(CommonExitCode::from_raw(16).is_none());
+        assert!(CommonExitCode::from_raw(100).is_none());
+        assert!(CommonExitCode::from_raw(255).is_none());
+    }
+
+    #[test]
+    fn labels_are_nonempty() {
+        let all = [
+            CommonExitCode::NotFound,
+            CommonExitCode::Unauthorized,
+            CommonExitCode::AlreadyExists,
+            CommonExitCode::ContractPaused,
+            CommonExitCode::AgentFrozen,
+            CommonExitCode::NotAdmin,
+            CommonExitCode::InvalidRecord,
+            CommonExitCode::DuplicateInBatch,
+            CommonExitCode::StorageLimitReached,
+            CommonExitCode::InvalidArgument,
+            CommonExitCode::InternalError,
+            CommonExitCode::Expired,
+            CommonExitCode::InsufficientFunds,
+            CommonExitCode::RateLimited,
+            CommonExitCode::ContractNotLinked,
+        ];
+        for code in &all {
+            assert!(!code.label().is_empty());
+        }
+    }
+}

--- a/smart-contracts/contracts/agent_registry/src/test.rs
+++ b/smart-contracts/contracts/agent_registry/src/test.rs
@@ -2086,3 +2086,46 @@ fn test_get_agents_batch_registered_pagination() {
     assert_eq!(page2.total_count, 4);
 }
 
+// ─── error_mapper tests ─────────────────────────────────────────────────────
+
+#[test]
+fn error_mapper_returns_common_codes_for_reserved_range() {
+    let (env, client) = setup();
+
+    // Common codes 1..=15 should map to their CommonExitCode variants
+    for raw in 1..=15u32 {
+        let result = client.error_mapper(&raw);
+        assert!(result.is_some(), "error_mapper({raw}) should return Some");
+        assert_eq!(result.unwrap() as u32, raw);
+    }
+}
+
+#[test]
+fn error_mapper_returns_none_for_contract_specific_codes() {
+    let (env, client) = setup();
+
+    // Contract-specific codes outside 1..=15 should return None
+    assert!(client.error_mapper(&0).is_none());
+    assert!(client.error_mapper(&16).is_none());
+    assert!(client.error_mapper(&100).is_none());
+    assert!(client.error_mapper(&255).is_none());
+}
+
+#[test]
+fn error_mapper_propagation_consistency() {
+    let (env, client) = setup();
+
+    // Simulate cross-contract error propagation: a contract returns
+    // Error::NotFound (code 1), which maps to CommonExitCode::NotFound (code 1)
+    let agent_registry_code = Error::NotFound as u32;
+    let common = client.error_mapper(&agent_registry_code);
+    assert!(common.is_some());
+    assert_eq!(common.unwrap(), CommonExitCode::NotFound);
+
+    // Error::AlreadyExists (code 3) maps to CommonExitCode::AlreadyExists
+    let already_exists_code = Error::AlreadyExists as u32;
+    let common = client.error_mapper(&already_exists_code);
+    assert!(common.is_some());
+    assert_eq!(common.unwrap(), CommonExitCode::AlreadyExists);
+}
+

--- a/smart-contracts/docs/EXIT_CODES.md
+++ b/smart-contracts/docs/EXIT_CODES.md
@@ -1,0 +1,60 @@
+# Cross-Contract Error Propagation
+
+## Standardized Exit Codes
+
+All ai-net Soroban contracts use a shared exit-code registry for cross-contract
+error propagation. This lets callers interpret failures without coupling to a
+specific contract's internal enum.
+
+### Code Ranges
+
+| Range | Purpose |
+|-------|---------|
+| `1..=15` | **Reserved common codes** — shared across all contracts |
+| `100..` | **Contract-specific codes** — local to each contract |
+
+### Exit-Code-to-Meaning Table
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 1 | `NotFound` | The requested entity does not exist |
+| 2 | `Unauthorized` | Caller lacks the required authorization signature |
+| 3 | `AlreadyExists` | Entity already registered / duplicate creation |
+| 4 | `ContractPaused` | Contract is paused; all mutations rejected |
+| 5 | `AgentFrozen` | Agent is frozen; operations on it are rejected |
+| 6 | `NotAdmin` | Caller is not an admin of the contract |
+| 7 | `InvalidRecord` | Input record fails validation |
+| 8 | `DuplicateInBatch` | Batch contains duplicate entity IDs |
+| 9 | `StorageLimitReached` | Global storage capacity has been reached |
+| 10 | `InvalidArgument` | A required argument is missing or malformed |
+| 11 | `InternalError` | Unexpected internal error (contract bug) |
+| 12 | `Expired` | The entity has expired or its TTL has elapsed |
+| 13 | `InsufficientFunds` | Caller or escrow lacks sufficient balance |
+| 14 | `RateLimited` | Operation rejected due to rate limiting |
+| 15 | `ContractNotLinked` | Cross-contract call target is not configured |
+
+### Using the Error Mapper
+
+The registry contract exposes a public `error_mapper` function:
+
+```rust
+// On-chain: call from another contract
+let common_code = registry.error_mapper(raw_error_code);
+
+// Off-chain: interpret the result
+match common_code {
+    Some(CommonExitCode::NotFound) => { /* entity not found */ }
+    Some(CommonExitCode::Unauthorized) => { /* auth failure */ }
+    Some(CommonExitCode::AlreadyExists) => { /* duplicate */ }
+    None => { /* contract-specific code, inspect locally */ }
+}
+```
+
+### Adding New Common Codes
+
+1. Add the variant to `CommonExitCode` in `shared_exit_codes.rs`.
+2. Assign the next available code in `1..=15` range.
+3. Update the table above.
+4. Add a test in `shared_exit_codes::tests`.
+
+**Never renumber an existing code** once deployed.


### PR DESCRIPTION
Closes #369, Closes #368, Closes #370, Closes #416

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

---

## Summary

This PR addresses all 4 assigned Stellar Wave issues:

1. **#369 — Standardized cross-contract exit codes**: Adds a shared `CommonExitCode` enum (codes 1-15) to the agent_registry contract with a public `error_mapper` function for uniform error interpretation across contracts. Includes tests and EXIT_CODES.md documentation.

2. **#368 — Agent status cards with pulse indicators and badges**: Redesigns the `AgentCard` component with animated online/offline pulse indicators, heartbeat age display, color-coded capability badges, and inline reputation stars.

3. **#370 — Release engineering docs**: Adds a comprehensive `RELEASE_ENGINEERING.md` covering semantic versioning, tagging conventions, changelog generation, SHA256SUMS verification, release checklists, and contract upgrade coordination.

4. **#416 — Frontend architecture and conventions doc**: Adds `FRONTEND_ARCHITECTURE.md` documenting folder structure, naming rules, state management patterns, and conventions for adding new components/pages/hooks. Linked from README and referenced in AGENTS.md.

## Motivation / Context

Closes #369, Closes #368, Closes #370, Closes #416