### PR TITLE
feat(contracts): emit versioned task lifecycle events in task_store (#358)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ npm run test:e2e
 - [REST API Reference](docs/API_REFERENCE.md): Comprehensive per-endpoint documentation, error codes taxonomy, authentication headers, and runnable curl examples.
 - [Node Operators Guide](docs/NODE_OPERATORS_GUIDE.md): Step-by-step instructions for provisioning, configuring secrets, deploying smart contracts, funding accounts, operating nodes, monitoring metrics, and troubleshooting common errors.
 - [Smart Contract Deployment Guide](smart-contracts/docs/DEPLOYMENT_GUIDE.md): Complete deployment and upgrade workflows on Soroban.
+- [Task Store Lifecycle Events](smart-contracts/docs/TASK_STORE_EVENTS.md): Versioned on-chain event schema for task creation, updates, and finalization.
 - [End-to-End Testing Guide](docs/e2e-testing.md): Automated test execution and validation.
 
 ---

--- a/smart-contracts/contracts/task_store/src/lib.rs
+++ b/smart-contracts/contracts/task_store/src/lib.rs
@@ -3,8 +3,9 @@
 mod types;
 
 pub use types::{
-    DataKey, Error, TaskMetadata, TaskMetadataStored, TaskStatus, TaskStatusUpdated,
-    DEFAULT_TTL_DAYS, LEDGERS_PER_DAY, MAX_COMPRESSED_DAG_BYTES, MAX_TTL_DAYS,
+    DataKey, Error, TaskCreatedEvent, TaskFinalizedEvent, TaskMetadata, TaskStatus,
+    TaskUpdatedEvent, DEFAULT_TTL_DAYS, LEDGERS_PER_DAY, MAX_COMPRESSED_DAG_BYTES, MAX_TTL_DAYS,
+    TASK_LIFECYCLE_EVENT_VERSION,
 };
 
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, Vec};
@@ -53,6 +54,10 @@ fn can_transition(from: TaskStatus, to: TaskStatus) -> bool {
             | (TaskStatus::Running, TaskStatus::Completed)
             | (TaskStatus::Running, TaskStatus::Failed)
     )
+}
+
+fn is_terminal(status: TaskStatus) -> bool {
+    matches!(status, TaskStatus::Completed | TaskStatus::Failed)
 }
 
 #[contract]
@@ -114,10 +119,13 @@ impl TaskStoreContract {
             .extend_ttl(&key, ledgers.saturating_sub(1), ledgers);
 
         env.events().publish(
-            (symbol_short!("task_meta"), symbol_short!("stored")),
-            TaskMetadataStored {
+            (symbol_short!("task_meta"), symbol_short!("created")),
+            TaskCreatedEvent {
+                version: TASK_LIFECYCLE_EVENT_VERSION,
                 task_id,
                 prompt_hash,
+                assigned_agents: metadata.assigned_agents,
+                created_at,
                 expires_at,
             },
         );
@@ -154,15 +162,35 @@ impl TaskStoreContract {
         metadata.status = new_status;
         env.storage().persistent().set(&key, &metadata);
 
-        env.events().publish(
-            (symbol_short!("task_meta"), symbol_short!("status")),
-            TaskStatusUpdated {
-                task_id,
-                agent,
-                old_status,
-                new_status,
-            },
-        );
+        // Every successful transition emits exactly one lifecycle event:
+        // terminal transitions (-> Completed / -> Failed) emit `finalized`,
+        // everything else emits `updated` — never both.
+        let timestamp = env.ledger().timestamp();
+        if is_terminal(new_status) {
+            env.events().publish(
+                (symbol_short!("task_meta"), symbol_short!("finalized")),
+                TaskFinalizedEvent {
+                    version: TASK_LIFECYCLE_EVENT_VERSION,
+                    task_id,
+                    agent,
+                    old_status,
+                    final_status: new_status,
+                    finalized_at: timestamp,
+                },
+            );
+        } else {
+            env.events().publish(
+                (symbol_short!("task_meta"), symbol_short!("updated")),
+                TaskUpdatedEvent {
+                    version: TASK_LIFECYCLE_EVENT_VERSION,
+                    task_id,
+                    agent,
+                    old_status,
+                    new_status,
+                    updated_at: timestamp,
+                },
+            );
+        }
 
         Ok(())
     }
@@ -289,25 +317,105 @@ mod test {
     }
 
     #[test]
-    fn emits_storage_and_status_events() {
+    fn emits_exactly_one_created_event_on_store() {
         let fixture = fixture();
         store(&fixture, 1);
-        let stored_events = fixture.env.events().all();
-        assert_eq!(stored_events.len(), 1);
+
+        let events = fixture.env.events().all();
+        assert_eq!(events.len(), 1);
         assert_eq!(
-            stored_events.get(0).unwrap().1,
-            (symbol_short!("task_meta"), symbol_short!("stored")).into_val(&fixture.env)
+            events.get(0).unwrap().1,
+            (symbol_short!("task_meta"), symbol_short!("created")).into_val(&fixture.env)
         );
+    }
+
+    #[test]
+    fn emits_exactly_one_updated_event_on_non_terminal_transition() {
+        let fixture = fixture();
+        store(&fixture, 1);
 
         fixture
             .client
             .update_task_status(&fixture.task_id, &fixture.agent, &TaskStatus::Running);
 
-        let status_events = fixture.env.events().all();
-        assert_eq!(status_events.len(), 1);
+        let events = fixture.env.events().all();
+        assert_eq!(events.len(), 1);
         assert_eq!(
-            status_events.get(0).unwrap().1,
-            (symbol_short!("task_meta"), symbol_short!("status")).into_val(&fixture.env)
+            events.get(0).unwrap().1,
+            (symbol_short!("task_meta"), symbol_short!("updated")).into_val(&fixture.env)
         );
+    }
+
+    #[test]
+    fn emits_exactly_one_finalized_event_on_terminal_transition() {
+        let fixture = fixture();
+        store(&fixture, 1);
+        fixture
+            .client
+            .update_task_status(&fixture.task_id, &fixture.agent, &TaskStatus::Running);
+
+        fixture
+            .client
+            .update_task_status(&fixture.task_id, &fixture.agent, &TaskStatus::Completed);
+
+        // No `updated` event alongside it — exactly one lifecycle event
+        // for this transition, and it's `finalized`, not `updated`.
+        let events = fixture.env.events().all();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events.get(0).unwrap().1,
+            (symbol_short!("task_meta"), symbol_short!("finalized")).into_val(&fixture.env)
+        );
+    }
+
+    #[test]
+    fn finalized_event_fires_for_the_failed_terminal_status_too() {
+        let fixture = fixture();
+        store(&fixture, 1);
+
+        fixture
+            .client
+            .update_task_status(&fixture.task_id, &fixture.agent, &TaskStatus::Failed);
+
+        let events = fixture.env.events().all();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events.get(0).unwrap().1,
+            (symbol_short!("task_meta"), symbol_short!("finalized")).into_val(&fixture.env)
+        );
+    }
+
+    #[test]
+    fn created_event_payload_matches_stored_metadata() {
+        let fixture = fixture();
+        store(&fixture, 1);
+
+        let metadata = fixture.client.get_task_metadata(&fixture.task_id);
+        let events = fixture.env.events().all();
+        let (_contract_id, _topics, data) = events.get(0).unwrap();
+        let payload: TaskCreatedEvent = data.into_val(&fixture.env);
+
+        assert_eq!(payload.version, TASK_LIFECYCLE_EVENT_VERSION);
+        assert_eq!(payload.task_id, fixture.task_id);
+        assert_eq!(payload.prompt_hash, fixture.prompt_hash);
+        assert_eq!(payload.assigned_agents, metadata.assigned_agents);
+        assert_eq!(payload.created_at, metadata.created_at);
+        assert_eq!(payload.expires_at, metadata.expires_at);
+    }
+
+    #[test]
+    fn a_rejected_transition_emits_no_lifecycle_event() {
+        let fixture = fixture();
+        store(&fixture, 1);
+
+        // Pending -> Completed is not a valid transition (must pass through
+        // Running first) and is rejected before any event is published.
+        let _ = fixture.client.try_update_task_status(
+            &fixture.task_id,
+            &fixture.agent,
+            &TaskStatus::Completed,
+        );
+
+        assert_eq!(fixture.env.events().all().len(), 0);
     }
 }

--- a/smart-contracts/contracts/task_store/src/types.rs
+++ b/smart-contracts/contracts/task_store/src/types.rs
@@ -5,6 +5,11 @@ pub const MAX_TTL_DAYS: u32 = 365;
 pub const MAX_COMPRESSED_DAG_BYTES: u32 = 8 * 1024;
 pub const LEDGERS_PER_DAY: u32 = 17_280;
 
+/// Schema version stamped on every task lifecycle event payload (see
+/// `docs/TASK_LIFECYCLE_EVENTS.md`). Bump only for a breaking payload
+/// change; additive fields do not require a bump.
+pub const TASK_LIFECYCLE_EVENT_VERSION: u32 = 1;
+
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u32)]
@@ -33,21 +38,47 @@ pub enum DataKey {
     Task(BytesN<32>),
 }
 
+/// Emitted exactly once per successful `store_task_metadata` call, under
+/// topics `(task_meta, created)`. See `docs/TASK_LIFECYCLE_EVENTS.md`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TaskMetadataStored {
+pub struct TaskCreatedEvent {
+    pub version: u32,
     pub task_id: BytesN<32>,
     pub prompt_hash: BytesN<32>,
+    pub assigned_agents: Vec<Address>,
+    pub created_at: u64,
     pub expires_at: u64,
 }
 
+/// Emitted for a successful non-terminal status transition (currently only
+/// `Pending -> Running`), under topics `(task_meta, updated)`. Terminal
+/// transitions (`-> Completed` / `-> Failed`) emit [`TaskFinalizedEvent`]
+/// instead — never both — so each transition emits exactly one lifecycle
+/// event. See `docs/TASK_LIFECYCLE_EVENTS.md`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TaskStatusUpdated {
+pub struct TaskUpdatedEvent {
+    pub version: u32,
     pub task_id: BytesN<32>,
     pub agent: Address,
     pub old_status: TaskStatus,
     pub new_status: TaskStatus,
+    pub updated_at: u64,
+}
+
+/// Emitted for a successful transition into a terminal status (`Completed`
+/// or `Failed`), under topics `(task_meta, finalized)`. `final_status` is
+/// always one of those two values. See `docs/TASK_LIFECYCLE_EVENTS.md`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TaskFinalizedEvent {
+    pub version: u32,
+    pub task_id: BytesN<32>,
+    pub agent: Address,
+    pub old_status: TaskStatus,
+    pub final_status: TaskStatus,
+    pub finalized_at: u64,
 }
 
 #[contracterror]

--- a/smart-contracts/docs/TASK_STORE_EVENTS.md
+++ b/smart-contracts/docs/TASK_STORE_EVENTS.md
@@ -1,0 +1,122 @@
+# Task Store Contract — Lifecycle Events
+
+This document details the Soroban events emitted by the `task_store` smart
+contract. These events give off-chain indexers and the UI a consistent,
+versioned signal for every task lifecycle transition, without needing to
+poll `get_task_metadata`/`get_task_status`.
+
+## Event Topics
+
+All task lifecycle events share the first topic (`task_meta`). The second
+topic indicates which lifecycle stage occurred: `created`, `updated`, or
+`finalized`.
+
+## Versioning & Compatibility
+
+Every payload carries a `version: u32` field (currently `1`, the
+`TASK_LIFECYCLE_EVENT_VERSION` constant in
+`contracts/task_store/src/types.rs`). The schema is **append-only**:
+
+- Adding a new field to an existing payload does **not** require a version
+  bump — consumers should tolerate unknown/new fields.
+- Removing, renaming, or changing the type/meaning of an existing field
+  **does** require a version bump, so existing consumers can detect the
+  change (by branching on `version`) instead of silently misreading data.
+- The topic pair for a given lifecycle stage (e.g. `(task_meta, created)`)
+  is stable; a schema-breaking change bumps `version` in the payload, it
+  does not introduce a new topic.
+
+## Invariant: exactly one event per transition
+
+Every successful call to `store_task_metadata` emits exactly one `created`
+event. Every successful call to `update_task_status` emits exactly one
+event — `updated` for a non-terminal transition, or `finalized` for a
+transition into a terminal status — never both, and never zero. A call
+that is rejected (unauthorized agent, invalid transition, expired task)
+emits no lifecycle event at all, since it errors out before any state
+change or publish.
+
+---
+
+### 1. Task Created
+
+Emitted once, when `store_task_metadata` succeeds.
+
+- **Topic 1**: `Symbol::new(env, "task_meta")`
+- **Topic 2**: `Symbol::new(env, "created")`
+- **Data (Structure)**: `TaskCreatedEvent`
+  ```rust
+  pub struct TaskCreatedEvent {
+      pub version: u32,
+      pub task_id: BytesN<32>,
+      pub prompt_hash: BytesN<32>,
+      pub assigned_agents: Vec<Address>,
+      pub created_at: u64,
+      pub expires_at: u64,
+  }
+  ```
+
+### 2. Task Updated
+
+Emitted when `update_task_status` succeeds with a **non-terminal**
+transition. Today the only non-terminal transition is `Pending -> Running`;
+`Pending -> Failed` is terminal and emits `finalized` instead (see below).
+
+- **Topic 1**: `Symbol::new(env, "task_meta")`
+- **Topic 2**: `Symbol::new(env, "updated")`
+- **Data (Structure)**: `TaskUpdatedEvent`
+  ```rust
+  pub struct TaskUpdatedEvent {
+      pub version: u32,
+      pub task_id: BytesN<32>,
+      pub agent: Address,
+      pub old_status: TaskStatus,
+      pub new_status: TaskStatus,
+      pub updated_at: u64,
+  }
+  ```
+
+### 3. Task Finalized
+
+Emitted when `update_task_status` succeeds with a transition **into a
+terminal status** — `-> Completed` or `-> Failed`. `final_status` is
+always one of those two values; `old_status` records what it transitioned
+from.
+
+- **Topic 1**: `Symbol::new(env, "task_meta")`
+- **Topic 2**: `Symbol::new(env, "finalized")`
+- **Data (Structure)**: `TaskFinalizedEvent`
+  ```rust
+  pub struct TaskFinalizedEvent {
+      pub version: u32,
+      pub task_id: BytesN<32>,
+      pub agent: Address,
+      pub old_status: TaskStatus,
+      pub final_status: TaskStatus,
+      pub finalized_at: u64,
+  }
+  ```
+
+## Status transition → event map
+
+| Transition | Event |
+|---|---|
+| (none) → `store_task_metadata` succeeds | `created` |
+| `Pending` → `Running` | `updated` |
+| `Running` → `Completed` | `finalized` |
+| `Pending` → `Failed` | `finalized` |
+| `Running` → `Failed` | `finalized` |
+| Any other transition (rejected — `InvalidStatusTransition`) | *(no event)* |
+
+## Reading events with the JS/TS SDK
+
+The contract's generated bindings (`smart-contracts/src/`) expose the
+event payload types once regenerated from the built Wasm. Off-chain code
+should filter by topic pair before decoding, e.g.:
+
+```ts
+if (topics[0] === "task_meta" && topics[1] === "finalized") {
+  const event = scValToNative(data) as TaskFinalizedEvent;
+  // event.version, event.final_status, ...
+}
+```


### PR DESCRIPTION
## Summary

Replaces `task_store`'s two ad hoc events (`task_meta/stored`, `task_meta/status` — never documented, never consumed by anything in this codebase) with a versioned lifecycle event schema matching the issue's requested shape.

- `store_task_metadata` emits exactly one `(task_meta, created)` event (`TaskCreatedEvent`) — richer than the old "stored" payload, now including `assigned_agents` and `created_at` so an indexer can build the initial task record from the event alone.
- `update_task_status` emits exactly one event per successful transition: `(task_meta, updated)` (`TaskUpdatedEvent`) for the non-terminal `Pending -> Running` transition, or `(task_meta, finalized)` (`TaskFinalizedEvent`) for a transition into a terminal status (`-> Completed` or `-> Failed`) — **never both**. A rejected transition (unauthorized agent, invalid transition, expired task) emits **no event at all**, since it errors out before any state change.
- Every payload carries `version: u32` (`TASK_LIFECYCLE_EVENT_VERSION = 1`). Documented as append-only in `smart-contracts/docs/TASK_STORE_EVENTS.md`: new fields don't need a version bump, but removing/renaming/retyping a field does, so existing consumers can branch on `version` instead of silently misreading data.

Nothing in this codebase currently subscribes to the old event topics/payload shapes (only the *function names* like `store_task_metadata` are referenced from `smart-contracts/src/coordinator/coordinator.ts` — not the event structs), so there was no real off-chain consumer to keep compatible. The old `TaskMetadataStored`/`TaskStatusUpdated` types are replaced rather than duplicated alongside the new ones, and the topic segments `stored`/`status` become `created`/`updated` to match the issue's naming.

## Acceptance Criteria

- [x] Every transition emits exactly one event
- [x] Schema documented and backward-compatible — `docs/TASK_STORE_EVENTS.md`, append-only versioning policy

## Test plan

`contracts/task_store/src/test.rs`:
- exactly one `created` event on `store_task_metadata`
- exactly one `updated` event on a non-terminal transition
- exactly one `finalized` event on a terminal transition (both `Completed` and `Failed`)
- the created event's payload matches the stored metadata
- a rejected transition emits zero lifecycle events

### Verification note

`task_store` is **not currently a member of `smart-contracts/Cargo.toml`'s `[workspace] members` list**, so `cargo test -p task-store` (or `cargo test` from within the crate) cannot run at all in this repo today — running it gives `error: current package believes it's in a workspace when it's not`. This is a pre-existing gap unrelated to this change; adding it to the workspace felt like a separate decision outside this PR's scope (worth a maintainer call — happy to open a follow-up if wanted). Rust compilation is also unavailable in my environment regardless (link.exe fails on the proc-macro build scripts every soroban-sdk crate needs).

Verified instead by close manual review: walked each new/changed test by hand against the implementation, and checked the diff against this same file's existing (larger) test suite's conventions for correctness.

Closes #358
