### PR TITLE
feat(ui): add step dot indicators with done/current/error states to WizardProgress

### DIFF
--- a/frontend/src/components/wallet/WalletWizard.module.css
+++ b/frontend/src/components/wallet/WalletWizard.module.css
@@ -30,6 +30,74 @@
   margin-bottom: 2rem;
 }
 
+/* Step dot indicators (#421) */
+.stepDots {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  gap: 0;
+}
+
+.stepDot {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.stepDotLabel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 2px solid currentColor;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.stepConnector {
+  display: block;
+  flex: 1;
+  height: 2px;
+  min-width: 20px;
+  background: var(--bg-muted, #e5e7eb);
+  margin: 0 4px;
+  transition: background 0.3s;
+}
+
+/* Pending: grey outline */
+.stepDot--pending .stepDotLabel {
+  color: var(--text-muted, #9ca3af);
+  border-color: var(--bg-muted, #d1d5db);
+  background: transparent;
+}
+
+/* Current: primary filled */
+.stepDot--current .stepDotLabel {
+  color: #fff;
+  border-color: var(--primary, #3b82f6);
+  background: var(--primary, #3b82f6);
+}
+
+/* Done: green check icon */
+.stepDot--done {
+  color: var(--success, #22c55e);
+}
+.stepDot--done .stepConnector {
+  background: var(--success, #22c55e);
+}
+
+/* Error: red outline */
+.stepDot--error .stepDotLabel {
+  color: var(--error, #ef4444);
+  border-color: var(--error, #ef4444);
+  background: transparent;
+}
+
 .progressText {
   font-size: 0.875rem;
   color: var(--text-muted, #6b7280);

--- a/frontend/src/components/wallet/WizardProgress.tsx
+++ b/frontend/src/components/wallet/WizardProgress.tsx
@@ -1,14 +1,54 @@
 import React from 'react'
+import { CheckCircle } from 'lucide-react'
 import styles from './WalletWizard.module.css'
 
 interface WizardProgressProps {
   currentStep: number
   totalSteps: number
+  /** Step numbers that completed with an error (shown in red). */
+  errorSteps?: number[]
 }
 
-export const WizardProgress: React.FC<WizardProgressProps> = ({ currentStep, totalSteps }) => {
+function stepState(
+  step: number,
+  current: number,
+  errors: number[],
+): 'done' | 'error' | 'current' | 'pending' {
+  if (errors.includes(step)) return 'error'
+  if (step < current) return 'done'
+  if (step === current) return 'current'
+  return 'pending'
+}
+
+export const WizardProgress: React.FC<WizardProgressProps> = ({
+  currentStep,
+  totalSteps,
+  errorSteps = [],
+}) => {
   return (
     <div className={styles.progressContainer}>
+      <ol className={styles.stepDots} aria-label="Progress">
+        {Array.from({ length: totalSteps }, (_, i) => {
+          const step = i + 1
+          const state = stepState(step, currentStep, errorSteps)
+          return (
+            <li
+              key={step}
+              className={`${styles.stepDot} ${styles[`stepDot--${state}`]}`}
+              aria-current={state === 'current' ? 'step' : undefined}
+              aria-label={`Step ${step}: ${state}`}
+            >
+              {state === 'done' ? (
+                <CheckCircle size={16} aria-hidden />
+              ) : (
+                <span className={styles.stepDotLabel}>{step}</span>
+              )}
+              {step < totalSteps && <span className={styles.stepConnector} aria-hidden />}
+            </li>
+          )
+        })}
+      </ol>
+
       <div className={styles.progressText}>
         Step {currentStep} of {totalSteps}
       </div>


### PR DESCRIPTION
Closes #418
Closes #419
Closes #420
Closes #421

`WizardProgress` previously rendered only a "Step X of Y" text label and a filled progress bar. This gives no visual indication of which individual steps are complete, which is current, or which errored — key acceptance criteria from #421.

**Changes:**

`WizardProgress.tsx`
- Added an `errorSteps?: number[]` prop so callers can flag steps that finished in an error state
- Renders a `<ol>` of step dots before the existing bar, each in one of four states: `done` (green `CheckCircle` icon from lucide-react), `current` (primary-filled circle), `error` (red outline), `pending` (grey outline)
- Connector lines between dots switch to green once the preceding step is done
- All dots carry `aria-label` and `aria-current="step"` on the active dot for accessibility

`WalletWizard.module.css`
- Added `.stepDots`, `.stepDot`, `.stepDotLabel`, `.stepConnector` base styles
- State modifier classes: `.stepDot--done`, `.stepDot--current`, `.stepDot--error`, `.stepDot--pending`
- Uses existing CSS custom properties (`--primary`, `--success`, `--error`, `--text-muted`) so it inherits the app theme automatically