### PR TITLE
fix(api): unify backend API error responses to structured envelope (#500)

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -229,11 +229,22 @@ export function createApp(opts: AppOptions = {}): {
   // ── Payment reconciliation routes ──────────────────────────────────────────
   app.use("/api/reconciliation", createReconciliationRouter(opts.reconciliation));
 
-  app.use((_req: Request, res: Response) => {
+  app.use((req: Request, res: Response) => {
+    const correlationId =
+      (res.locals.traceId as string | undefined) ??
+      (res.locals.correlationId as string | undefined) ??
+      "unknown";
     res.status(404).json({
-      error: { message: "Not found", code: "NOT_FOUND" },
-      requestId: res.locals.requestId,
-      traceId: res.locals.traceId,
+      error: {
+        code: "NOT_FOUND",
+        message: "Not found",
+        path: req.path,
+        correlationId,
+        timestamp: new Date().toISOString(),
+      },
+      statusCode: 404,
+      path: req.path,
+      requestId: res.locals.requestId ?? "unknown",
     });
   });
 

--- a/backend/src/api/middleware/errorHandler.ts
+++ b/backend/src/api/middleware/errorHandler.ts
@@ -1,22 +1,90 @@
 import type { Request, Response, NextFunction } from "express";
 import { createLogger } from "../../utils/logger";
 import { AppError } from "../../errors";
+import { getConfig } from "../../config";
+import { HTTP_STATUS_FOR_CODE } from "../../errors/ErrorCode";
 
-const log = createLogger();
 const isProduction = process.env.NODE_ENV === "production";
-const isDevelopment = process.env.NODE_ENV === "development";
+
+/**
+ * Build the canonical error envelope for every API response.
+ *
+ * Schema: { error: { code, message, details?, path, correlationId, timestamp? } }
+ */
+function buildErrorEnvelope({
+  code,
+  message,
+  statusCode,
+  path,
+  correlationId,
+  details,
+  includeTimestamp = true,
+}: {
+  code: string;
+  message: string;
+  statusCode: number;
+  path: string;
+  correlationId: string;
+  details?: unknown;
+  includeTimestamp?: boolean;
+}): Record<string, unknown> {
+  const envelope: Record<string, unknown> = {
+    error: {
+      code,
+      message,
+      path,
+      correlationId,
+    },
+  };
+
+  if (details !== undefined) {
+    (envelope.error as Record<string, unknown>).details = details;
+  }
+
+  if (includeTimestamp) {
+    (envelope.error as Record<string, unknown>).timestamp = new Date().toISOString();
+  }
+
+  // Legacy top-level fields kept for backward compatibility with older clients/tests
+  return {
+    ...envelope,
+    statusCode,
+    path,
+    requestId: correlationId,
+  };
+}
+
+/**
+ * Resolve the HTTP status for an unknown error that may carry a code/status.
+ */
+function resolveStatusCode(err: unknown): number {
+  if (err instanceof AppError) return err.statusCode;
+  return (
+    (err as any)?.statusCode ??
+    (err as any)?.status ??
+    HTTP_STATUS_FOR_CODE[(err as any)?.code] ??
+    500
+  );
+}
+
+/**
+ * Resolve the machine-readable error code for an unknown error.
+ */
+function resolveErrorCode(err: unknown, isDevelopment: boolean): string {
+  if (err instanceof AppError) return err.code;
+  return isDevelopment ? ((err as any)?.code ?? "INTERNAL_ERROR") : "INTERNAL_ERROR";
+}
 
 /**
  * Central Express error-handling middleware.
  *
- * Behaviour:
- *  - AppError instances are serialized with their structured fields.
- *  - Unknown errors are treated as 500 and their internals are hidden in
- *    production.
- *  - Every response carries the correlationId (from AppError or from
- *    res.locals) so clients can correlate API errors with backend traces.
- *  - Unhandled (non-AppError) errors are always logged with a full stack
- *    trace so they can be investigated server-side.
+ * Every response conforms to the canonical envelope:
+ *   { error: { code, message, details?, path, correlationId, timestamp } }
+ *
+ * AppError instances preserve their structured fields. Unknown errors are
+ * treated as 500 INTERNAL_ERROR and their internals are hidden in production.
+ * Every response carries the correlationId so clients can correlate API errors
+ * with backend traces.
  */
 export function errorHandler(
   err: unknown,
@@ -24,81 +92,55 @@ export function errorHandler(
   res: Response,
   _next: NextFunction,
 ): void {
-  const isDevelopment = getConfig().NODE_ENV === "development";
-  const traceId: string =
-    err instanceof AppError
+  const config = getConfig();
+  const isDevelopment = config.NODE_ENV === "development";
+
+  const correlationId: string =
+    (err instanceof AppError
       ? err.correlationId
       : (res.locals.traceId as string | undefined) ??
-        (res.locals.correlationId as string | undefined) ??
-        "unknown";
+        (res.locals.correlationId as string | undefined)) ??
+    "unknown";
+
   const requestId = (res.locals.requestId as string | undefined) ?? "unknown";
+  const path = req.path;
+
   const log = createLogger({
     ...(res.locals.logContext as Record<string, unknown> | undefined),
     requestId,
-    traceId,
-    route: req.route?.path ? `${req.baseUrl}${req.route.path}` : req.path,
+    traceId: correlationId,
+    route: req.route?.path ? `${req.baseUrl}${req.route.path}` : path,
   });
-  const statusCode =
-    err instanceof AppError
-      ? err.statusCode
-      : (err as any)?.statusCode ?? (err as any)?.status ?? 500;
-  const errorCode =
-    err instanceof AppError
-      ? err.code
-      : isDevelopment
-        ? (err as any)?.code ?? "INTERNAL_SERVER_ERROR"
-        : "INTERNAL_SERVER_ERROR";
+
+  const statusCode = resolveStatusCode(err);
+  const errorCode = resolveErrorCode(err, isDevelopment);
 
   if (err instanceof AppError) {
-    if (!err.isOperational) {
-      log.error(
-        {
-          err,
-          error: err.message,
-          code: err.code,
-          statusCode: err.statusCode,
-          stack: err.stack,
-          method: req.method,
-          path: req.path,
-          requestId: res.locals.requestId,
-          correlationId,
-        },
-        "non-operational error",
-      );
-    } else {
-      log.warn(
-        {
-          err,
-          error: err.message,
-          code: err.code,
-          statusCode: err.statusCode,
-          method: req.method,
-          path: req.path,
-          requestId: res.locals.requestId,
-          correlationId,
-        },
-        "operational error",
-      );
-    }
-
-    const body: {
-      error: {
-        code: string;
-        message: string;
-        details?: unknown;
-        correlationId: string;
-      };
-    } = {
-      error: {
-        code: err.code,
-        message: err.message,
-        correlationId,
-      },
+    const logPayload: Record<string, unknown> = {
+      err,
+      error: err.message,
+      code: err.code,
+      statusCode: err.statusCode,
+      method: req.method,
+      path,
+      requestId,
+      correlationId,
     };
 
-    if (err.details !== undefined) {
-      body.error.details = err.details;
+    if (!err.isOperational) {
+      log.error({ ...logPayload, stack: err.stack }, "non-operational error");
+    } else {
+      log.warn(logPayload, "operational error");
     }
+
+    const body = buildErrorEnvelope({
+      code: err.code,
+      message: err.message,
+      statusCode: err.statusCode,
+      path,
+      correlationId,
+      details: err.details,
+    });
 
     res.status(err.statusCode).json(body);
     return;
@@ -112,9 +154,9 @@ export function errorHandler(
       err,
       code: errorCode,
       statusCode,
-      traceId,
+      correlationId,
       requestId,
-      path: req.path,
+      path,
       method: req.method,
       payload: req.body,
       stack: err instanceof Error ? err.stack : undefined,
@@ -122,26 +164,20 @@ export function errorHandler(
     "unhandled error",
   );
 
-  const response: Record<string, unknown> = {
-    error: {
-      message: isProduction
-        ? "Internal server error"
-        : err instanceof Error
-          ? err.message || "Internal server error"
-          : "An unexpected error occurred",
-      code: "INTERNAL_ERROR",
-      correlationId,
-      timestamp: new Date().toISOString(),
-      path: req.path,
-      ...(isDevelopment && err instanceof Error
-        ? { stack: err.stack }
-        : {}),
-    },
-    // Legacy fields kept for backward-compatibility with existing tests
-    statusCode,
-    path: req.path,
-    requestId,
-  };
+  const message = isProduction
+    ? "Internal server error"
+    : err instanceof Error
+      ? err.message || "Internal server error"
+      : "An unexpected error occurred";
 
-  res.status(statusCode).json(response);
+  const body = buildErrorEnvelope({
+    code: errorCode,
+    message,
+    statusCode,
+    path,
+    correlationId,
+    details: isDevelopment && err instanceof Error ? { stack: err.stack } : undefined,
+  });
+
+  res.status(statusCode).json(body);
 }

--- a/backend/src/api/middleware/validate.ts
+++ b/backend/src/api/middleware/validate.ts
@@ -16,18 +16,29 @@ export interface ValidateMiddleware {
   openApiParameters: OpenApiParameter[];
 }
 
-/** 400 payload emitted when validation fails. */
+/**
+ * Standardized validation error payload.
+ *
+ * Conforms to the canonical API error envelope:
+ *   { error: { code, message, details, path, correlationId, timestamp } }
+ */
 export interface ValidationErrorBody {
-  error: "Validation failed";
-  /** Per-target field errors, e.g. `{ body: { prompt: ["Prompt is required"] } }`. */
-  details: Record<string, Record<string, string[]>>;
-  /**
-   * Flat list with full dotted paths.
-   *
-   * `details` loses the path for nested objects, so a form cannot tell which
-   * input to highlight; `fieldErrors` keeps it.
-   */
-  fieldErrors: FieldError[];
+  error: {
+    code: "VALIDATION_ERROR";
+    message: string;
+    details: {
+      /** Per-target field errors, e.g. `{ body: { prompt: ["Prompt is required"] } }`. */
+      fieldErrors: Record<string, Record<string, string[]>>;
+      /** Flat list with full dotted paths. */
+      flatErrors: FieldError[];
+    };
+    path: string;
+    correlationId: string;
+    timestamp: string;
+  };
+  statusCode: number;
+  path: string;
+  requestId: string;
 }
 
 /**
@@ -96,10 +107,26 @@ export function validate(schemaOrTargets: ZodSchema | ValidateTargets): Validate
     });
 
     if (Object.keys(errors).length > 0) {
+      const correlationId =
+        (res.locals.traceId as string | undefined) ??
+        (res.locals.correlationId as string | undefined) ??
+        "unknown";
+
       const body: ValidationErrorBody = {
-        error: "Validation failed",
-        details: errors,
-        fieldErrors,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Request validation failed",
+          details: {
+            fieldErrors: errors,
+            flatErrors: fieldErrors,
+          },
+          path: req.path,
+          correlationId,
+          timestamp: new Date().toISOString(),
+        },
+        statusCode: 400,
+        path: req.path,
+        requestId: (res.locals.requestId as string | undefined) ?? "unknown",
       };
       res.status(400).json(body);
       return;

--- a/backend/src/api/routes/admin.ts
+++ b/backend/src/api/routes/admin.ts
@@ -22,6 +22,7 @@ import {
 import type { ReconciliationRouterOptions } from "./reconciliation";
 import type { ReconciliationTrigger } from "../../services/reconciliation.types";
 import { createLogger } from "../../utils/logger";
+import { ValidationError, NotFoundError, AppError } from "../../errors";
 
 const logger = createLogger({ module: "admin" });
 
@@ -97,10 +98,14 @@ export function createAdminRouter(options: AdminRouterOptions = {}): Router {
     res.json(getReadOnlyState());
   });
 
-  router.put("/read-only", (req: Request, res: Response) => {
+  router.put("/read-only", (req: Request, res: Response, next: NextFunction) => {
     const parsed = readOnlySchema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: "INVALID_BODY", details: parsed.error.flatten() });
+      next(new ValidationError(
+        "Invalid request body",
+        { issues: parsed.error.flatten() },
+        res.locals.correlationId as string | undefined,
+      ));
       return;
     }
 
@@ -112,28 +117,32 @@ export function createAdminRouter(options: AdminRouterOptions = {}): Router {
     res.json(state);
   });
 
-  router.get("/agents", (req: Request, res: Response) => {
+  router.get("/agents", (req: Request, res: Response, next: NextFunction) => {
     const parsed = agentListSchema.safeParse(req.query);
     if (!parsed.success) {
-      res.status(400).json({ error: "INVALID_QUERY", details: parsed.error.flatten() });
+      next(new ValidationError(
+        "Invalid query parameters",
+        { issues: parsed.error.flatten() },
+        res.locals.correlationId as string | undefined,
+      ));
       return;
     }
     res.json({ agents: listAgentsForAdmin(parsed.data.status) });
   });
 
-  router.post("/agents/:id/enable", (req: Request, res: Response) => {
+  router.post("/agents/:id/enable", (req: Request, res: Response, next: NextFunction) => {
     const agent = setAgentEnabled(req.params.id, true);
     if (!agent) {
-      res.status(404).json({ error: "AGENT_NOT_FOUND" });
+      next(new NotFoundError("Agent", req.params.id, res.locals.correlationId as string | undefined));
       return;
     }
     res.json({ enabled: true, agent });
   });
 
-  router.post("/agents/:id/disable", (req: Request, res: Response) => {
+  router.post("/agents/:id/disable", (req: Request, res: Response, next: NextFunction) => {
     const agent = setAgentEnabled(req.params.id, false);
     if (!agent) {
-      res.status(404).json({ error: "AGENT_NOT_FOUND" });
+      next(new NotFoundError("Agent", req.params.id, res.locals.correlationId as string | undefined));
       return;
     }
     res.json({ enabled: false, agent });
@@ -141,10 +150,14 @@ export function createAdminRouter(options: AdminRouterOptions = {}): Router {
 
   router.post(
     "/reconciliation/run",
-    asyncHandler(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
       const parsed = reconciliationSchema.safeParse(req.body ?? {});
       if (!parsed.success) {
-        res.status(400).json({ error: "INVALID_BODY", details: parsed.error.flatten() });
+        next(new ValidationError(
+          "Invalid request body",
+          { issues: parsed.error.flatten() },
+          res.locals.correlationId as string | undefined,
+        ));
         return;
       }
 
@@ -160,10 +173,14 @@ export function createAdminRouter(options: AdminRouterOptions = {}): Router {
 
   router.post(
     "/maintenance/backup",
-    asyncHandler(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
       const parsed = backupSchema.safeParse(req.body ?? {});
       if (!parsed.success) {
-        res.status(400).json({ error: "INVALID_BODY", details: parsed.error.flatten() });
+        next(new ValidationError(
+          "Invalid request body",
+          { issues: parsed.error.flatten() },
+          res.locals.correlationId as string | undefined,
+        ));
         return;
       }
 
@@ -172,10 +189,14 @@ export function createAdminRouter(options: AdminRouterOptions = {}): Router {
     }),
   );
 
-  router.get("/audit-log", (req: Request, res: Response) => {
+  router.get("/audit-log", (req: Request, res: Response, next: NextFunction) => {
     const parsed = auditLogQuerySchema.safeParse(req.query);
     if (!parsed.success) {
-      res.status(400).json({ error: "INVALID_QUERY", details: parsed.error.flatten() });
+      next(new ValidationError(
+        "Invalid query parameters",
+        { issues: parsed.error.flatten() },
+        res.locals.correlationId as string | undefined,
+      ));
       return;
     }
 
@@ -191,12 +212,9 @@ export function createAdminRouter(options: AdminRouterOptions = {}): Router {
   router.use("/queue", createAdminQueueRouter(jobQueue));
   router.use("/", createAdminQueueRouter(jobQueue));
 
-  router.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  router.use((err: Error, _req: Request, _res: Response, next: NextFunction) => {
     logger.error({ err }, "admin operation failed");
-    res.status(500).json({
-      error: "ADMIN_OPERATION_FAILED",
-      message: err.message,
-    });
+    next(err instanceof AppError ? err : new AppError("Admin operation failed", 500, "INTERNAL_ERROR"));
   });
 
   return router;

--- a/backend/src/api/routes/agents.ts
+++ b/backend/src/api/routes/agents.ts
@@ -85,8 +85,11 @@ export function createAgentsRouter(options: AgentsRouterOptions = {}): Router {
     if (useCursor) {
       const parse = AgentCursorListSchema.safeParse(req.query);
       if (!parse.success) {
-        res.status(400).json({ error: parse.error.flatten() });
-        return;
+        throw new ValidationError(
+          "Invalid query parameters",
+          { issues: parse.error.flatten() },
+          res.locals.correlationId as string | undefined,
+        );
       }
       const { cursor, limit, capability, minReputation, maxPriceXLM, status } = parse.data;
       try {
@@ -108,7 +111,7 @@ export function createAgentsRouter(options: AgentsRouterOptions = {}): Router {
           },
         });
       } catch (err) {
-        res.status(500).json({ error: "Internal Server Error" });
+        next(new AppError("Internal Server Error", 500, "INTERNAL_ERROR", undefined, res.locals.correlationId as string | undefined));
       }
       return;
     }
@@ -161,8 +164,7 @@ export function createAgentsRouter(options: AgentsRouterOptions = {}): Router {
     try {
       const agent = getDb().findById(req.params.id);
       if (!agent) {
-        res.status(404).json({ error: "Agent not found" });
-        return;
+        throw new NotFoundError("Agent", req.params.id, res.locals.correlationId as string | undefined);
       }
       res.json(agent);
     } catch (error) {
@@ -195,8 +197,7 @@ export function createAgentsRouter(options: AgentsRouterOptions = {}): Router {
     try {
       const agent = getDb().findById(req.params.id);
       if (!agent) {
-        res.status(404).json({ error: "Agent not found" });
-        return;
+        throw new NotFoundError("Agent", req.params.id, res.locals.correlationId as string | undefined);
       }
 
       const startedAt = Date.now();
@@ -268,18 +269,20 @@ export function createAgentsRouter(options: AgentsRouterOptions = {}): Router {
           await horizon.loadAccount(data.stellarPublicKey);
         } catch (error: any) {
           if (error?.response?.status === 404) {
-            res.status(400).json({
-              error: "Stellar account not found",
-              code: "StellarAccountNotFound",
-            });
-            return;
+            throw new ValidationError(
+              "Stellar account not found",
+              { stellarPublicKey: data.stellarPublicKey },
+              correlationId,
+            );
           }
           if (process.env.NODE_ENV !== "test") {
-            res.status(400).json({
-              error: "Failed to verify Stellar account",
-              code: "StellarVerificationFailed",
-            });
-            return;
+            throw new AppError(
+              "Failed to verify Stellar account",
+              503,
+              "STELLAR_UNAVAILABLE",
+              { stellarPublicKey: data.stellarPublicKey, reason: error?.message },
+              correlationId,
+            );
           }
         }
       }
@@ -351,8 +354,7 @@ export function createAgentsRouter(options: AgentsRouterOptions = {}): Router {
       const db = getDb();
       const agent = db.findById(req.params.id);
       if (!agent) {
-        res.status(404).json({ error: "Agent not found" });
-        return;
+        throw new NotFoundError("Agent", req.params.id, res.locals.correlationId as string | undefined);
       }
 
       db.upsert({ ...agent, lastSeenAt: new Date().toISOString(), status: "online" });
@@ -431,8 +433,7 @@ export function createAgentsRouter(options: AgentsRouterOptions = {}): Router {
       const db = getDb();
       const agent = db.findById(req.params.id);
       if (!agent) {
-        res.status(404).json({ error: "Agent not found" });
-        return;
+        throw new NotFoundError("Agent", req.params.id, correlationId);
       }
 
       const signature = req.headers["x-signature"] as string | undefined;

--- a/backend/src/api/routes/ratelimit.ts
+++ b/backend/src/api/routes/ratelimit.ts
@@ -1,6 +1,7 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { getRateLimiter } from "../middleware/rateLimit";
 import { RATE_LIMIT_RULES } from "../rateLimitRules";
+import { ValidationError, NotFoundError, AppError } from "../../errors";
 
 export function createRateLimitRouter(): Router {
   const router = Router();
@@ -30,28 +31,26 @@ export function createRateLimitRouter(): Router {
    *       404:
    *         description: Key not found in rate limiter cache
    */
-  router.get("/status", async (req: Request, res: Response) => {
-    const key = req.query.key as string;
-    const ruleName = (req.query.rule as keyof typeof RATE_LIMIT_RULES) || "GLOBAL";
-
-    if (!key) {
-      res.status(400).json({ error: { code: "VALIDATION_ERROR", message: "Missing 'key' query parameter" } });
-      return;
-    }
-
-    const rule = RATE_LIMIT_RULES[ruleName];
-    if (!rule) {
-      res.status(400).json({ error: { code: "VALIDATION_ERROR", message: `Invalid rule name: ${ruleName}` } });
-      return;
-    }
-
+  router.get("/status", async (req: Request, res: Response, next: NextFunction) => {
     try {
+      const key = req.query.key as string;
+      const ruleName = (req.query.rule as keyof typeof RATE_LIMIT_RULES) || "GLOBAL";
+      const correlationId = res.locals.correlationId as string | undefined;
+
+      if (!key) {
+        throw new ValidationError("Missing 'key' query parameter", undefined, correlationId);
+      }
+
+      const rule = RATE_LIMIT_RULES[ruleName];
+      if (!rule) {
+        throw new ValidationError(`Invalid rule name: ${ruleName}`, { rule: ruleName }, correlationId);
+      }
+
       const limiter = getRateLimiter();
       const status = await limiter.getStatus(key, rule);
 
       if (!status) {
-        res.status(404).json({ error: { code: "NOT_FOUND", message: `Key '${key}' not found in rate limiter cache` } });
-        return;
+        throw new NotFoundError("Rate limit key", key, correlationId);
       }
 
       res.json({
@@ -63,7 +62,7 @@ export function createRateLimitRouter(): Router {
         resetTimeMs: status.resetTime,
       });
     } catch (err) {
-      res.status(500).json({ error: { code: "INTERNAL_ERROR", message: "Failed to get rate limit status" } });
+      next(err instanceof AppError ? err : new AppError("Failed to get rate limit status", 500, "INTERNAL_ERROR"));
     }
   });
 

--- a/backend/src/api/routes/tasks.ts
+++ b/backend/src/api/routes/tasks.ts
@@ -9,6 +9,7 @@ import { createTask, getTask } from "../../coordinator/taskStore";
 import { createLogger } from "../../utils/logger";
 import { validate } from "../middleware/validate";
 import { rateLimitMiddleware } from "../middleware/rateLimit";
+import { idempotencyMiddleware } from "../middleware/idempotency";
 import { ValidationError, NotFoundError, AppError, RateLimitError } from "../../errors";
 
 import { getGlobalJobQueue, type JobQueue, type JobPriority } from "../../queue";
@@ -148,7 +149,7 @@ export function createTasksRouter(
           const correlationId = res.locals.correlationId as string | undefined;
           throw new RateLimitError(
             `Daily task limit reached (max ${dailyTaskLimit} per 24 hours)`,
-            { code: "DAILY_LIMIT_EXCEEDED", limit: dailyTaskLimit, window: "24h" },
+            { limit: dailyTaskLimit, window: "24h" },
             correlationId,
           );
         }

--- a/backend/src/api/routes/v1/tasks.ts
+++ b/backend/src/api/routes/v1/tasks.ts
@@ -9,8 +9,10 @@ import { createTask, getTask } from "../../../coordinator/taskStore";
 import { createLogger } from "../../../utils/logger";
 import { validate } from "../../middleware/validate";
 import { rateLimitMiddleware } from "../../middleware/rateLimit";
+import { idempotencyMiddleware } from "../../middleware/idempotency";
 import { currentTraceId } from "../../../services/traceContext";
 import { getConfig } from "../../../config";
+import { NotFoundError, ForbiddenError, ConflictError, RateLimitError } from "../../../errors";
 
 import { getGlobalJobQueue, type JobQueue, type JobPriority } from "../../../queue";
 
@@ -24,6 +26,8 @@ const DAILY_TASK_LIMIT = Number(process.env.DAILY_TASK_LIMIT_PER_WALLET ?? 100);
 // of `createTaskSchema` working.
 export { createTaskSchema } from "../../../schemas/task";
 import { createTaskSchema, listTasksQuerySchema } from "../../../schemas/task";
+
+const log = createLogger({ module: "tasks-v1" });
 
 /**
  * Creates a v1 tasks router with the original API response format.
@@ -51,13 +55,10 @@ export function createV1TasksRouter(
       const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
       const { total } = db.list(walletPublicKey, 1, 1, { createdAfter: since });
       if (total >= dailyTaskLimit) {
-        res.status(429).json({
-          error: {
-            message: `Daily task limit reached (max ${dailyTaskLimit} per 24 hours)`,
-            code: "DAILY_LIMIT_EXCEEDED",
-          },
+        throw new RateLimitError(`Daily task limit reached (max ${dailyTaskLimit} per 24 hours)`, {
+          limit: dailyTaskLimit,
+          window: "24h",
         });
-        return;
       }
     }
 
@@ -91,15 +92,9 @@ export function createV1TasksRouter(
   });
 
   // GET /api/tasks — v1 format
-  tasksRouter.get("/", (req: Request, res: Response): void => {
+  tasksRouter.get("/", validate({ query: listTasksQuerySchema }), (req: Request, res: Response): void => {
     const walletPublicKey = (req.headers["walletpublickey"] as string) ?? "";
-    const parse = listTasksQuerySchema.safeParse(req.query);
-    if (!parse.success) {
-      res.status(400).json({ error: parse.error.flatten() });
-      return;
-    }
-
-    const { page, pageSize, status, sort, q } = parse.data;
+    const { page, pageSize, status, sort, q } = req.query as unknown as z.infer<typeof listTasksQuerySchema>;
     const db = createTaskDb(getTaskDb());
     const { tasks, total } = db.list(walletPublicKey, page, pageSize, {
       status,
@@ -116,13 +111,11 @@ export function createV1TasksRouter(
     const db = createTaskDb(getTaskDb());
     const task = db.findById(req.params.id);
     if (!task) {
-      res.status(404).json({ error: "Task not found" });
-      return;
+      throw new NotFoundError("Task", req.params.id);
     }
     const requesterKey = req.headers["walletpublickey"] as string;
     if (!requesterKey || requesterKey !== task.walletPublicKey) {
-      res.status(403).json({ error: "Access denied" });
-      return;
+      throw new ForbiddenError("Access denied");
     }
     // v1 response format - raw task object
     res.json(task);
@@ -133,19 +126,16 @@ export function createV1TasksRouter(
     const db = createTaskDb(getTaskDb());
     const task = db.findById(req.params.id);
     if (!task) {
-      res.status(404).json({ error: "Task not found" });
-      return;
+      throw new NotFoundError("Task", req.params.id);
     }
 
     const requesterKey = req.headers["walletpublickey"] as string;
     if (!requesterKey || requesterKey !== task.walletPublicKey) {
-      res.status(403).json({ error: "Not authorized to cancel this task" });
-      return;
+      throw new ForbiddenError("Not authorized to cancel this task");
     }
 
     if (task.status !== "queued") {
-      res.status(409).json({ error: `Cannot cancel task in '${task.status}' status` });
-      return;
+      throw new ConflictError(`Cannot cancel task in '${task.status}' status`);
     }
 
     db.updateStatus(req.params.id, "cancelled");

--- a/backend/src/api/routes/v2/tasks.ts
+++ b/backend/src/api/routes/v2/tasks.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { nanoid } from "nanoid";
 import { getTaskDb, createTaskDb } from "../../../db/tasks";
@@ -9,8 +9,10 @@ import { createTask, getTask } from "../../../coordinator/taskStore";
 import { createLogger } from "../../../utils/logger";
 import { validate } from "../../middleware/validate";
 import { rateLimitMiddleware } from "../../middleware/rateLimit";
+import { idempotencyMiddleware } from "../../middleware/idempotency";
 import { currentTraceId } from "../../../services/traceContext";
 import { getConfig } from "../../../config";
+import { RateLimitError, NotFoundError, ForbiddenError, ConflictError } from "../../../errors";
 
 import { getGlobalJobQueue, type JobQueue, type JobPriority } from "../../../queue";
 
@@ -24,6 +26,7 @@ const DAILY_TASK_LIMIT = Number(process.env.DAILY_TASK_LIMIT_PER_WALLET ?? 100);
 // of `createTaskSchema` working.
 export { createTaskSchema } from "../../../schemas/task";
 import { createTaskSchema, listTasksQuerySchema } from "../../../schemas/task";
+import { TaskListSchema as LegacyTaskListSchema } from "../../schemas/task.schema";
 
 const TaskCursorListSchema = z.object({
   cursor: z.string().optional(),
@@ -46,7 +49,8 @@ export function createV2TasksRouter(
   const jobQueue = queue ?? getGlobalJobQueue();
 
   // POST /api/tasks — v2 format with enhanced response, idempotent
-  tasksRouter.post("/", idempotencyMiddleware, rateLimitMiddleware, validate(createTaskSchema), (req: Request, res: Response): void => {
+  tasksRouter.post("/", idempotencyMiddleware, rateLimitMiddleware, validate(createTaskSchema), (req: Request, res: Response, next: NextFunction): void => {
+    try {
     const { prompt, priority } = req.body as z.infer<typeof createTaskSchema>;
     const walletPublicKey: string =
       (req.body as z.infer<typeof createTaskSchema>).walletPublicKey ??
@@ -59,17 +63,12 @@ export function createV2TasksRouter(
       const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
       const { total } = db.list(walletPublicKey, 1, 1, { createdAfter: since });
       if (total >= dailyTaskLimit) {
-        res.status(429).json({
-          error: {
-            message: `Daily task limit reached (max ${dailyTaskLimit} per 24 hours)`,
-            code: "DAILY_LIMIT_EXCEEDED",
-          },
-          _meta: {
-            version: "2.0",
-            timestamp: new Date().toISOString(),
-          },
-        });
-        return;
+        const correlationId = res.locals.correlationId as string | undefined;
+        throw new RateLimitError(
+          `Daily task limit reached (max ${dailyTaskLimit} per 24 hours)`,
+          { limit: dailyTaskLimit, window: "24h" },
+          correlationId,
+        );
       }
     }
 
@@ -116,10 +115,14 @@ export function createV2TasksRouter(
         stream: `/api/tasks/${task.id}/stream`,
       },
     });
+    } catch (err) {
+      next(err);
+    }
   });
 
   // GET /api/tasks — v2 format: cursor pagination when ?cursor or ?limit present, offset otherwise
-  tasksRouter.get("/", (req: Request, res: Response): void => {
+  tasksRouter.get("/", (req: Request, res: Response, next: NextFunction): void => {
+    try {
     const walletPublicKey = (req.headers["walletpublickey"] as string) ?? "";
     const now = new Date().toISOString();
 
@@ -129,11 +132,11 @@ export function createV2TasksRouter(
     if (useCursor) {
       const parse = TaskCursorListSchema.safeParse(req.query);
       if (!parse.success) {
-        res.status(400).json({
-          error: parse.error.flatten(),
-          _meta: { version: "2.0", timestamp: now },
-        });
-        return;
+        throw new ValidationError(
+          "Invalid query parameters",
+          { issues: parse.error.flatten() },
+          res.locals.correlationId as string | undefined,
+        );
       }
 
       const { cursor, limit, status, sort, q } = parse.data;
@@ -172,13 +175,13 @@ export function createV2TasksRouter(
     }
 
     // Offset fallback (backward-compatible)
-    const parse = TaskListSchema.safeParse(req.query);
+    const parse = LegacyTaskListSchema.safeParse(req.query);
     if (!parse.success) {
-      res.status(400).json({
-        error: parse.error.flatten(),
-        _meta: { version: "2.0", timestamp: now },
-      });
-      return;
+      throw new ValidationError(
+        "Invalid query parameters",
+        { issues: parse.error.flatten() },
+        res.locals.correlationId as string | undefined,
+      );
     }
 
     const { page, pageSize, status, sort, q } = parse.data;
@@ -208,32 +211,26 @@ export function createV2TasksRouter(
         apiVersion: res.locals.apiVersion || "2.0",
       },
     });
+    } catch (err) {
+      next(err);
+    }
   });
 
   // GET /api/tasks/:id — v2 format with enhanced response
-  tasksRouter.get("/:id", (req: Request, res: Response): void => {
+  tasksRouter.get("/:id", (req: Request, res: Response, next: NextFunction): void => {
+    try {
     const db = createTaskDb(getTaskDb());
     const task = db.findById(req.params.id);
     if (!task) {
-      res.status(404).json({
-        error: "Task not found",
-        _meta: {
-          version: "2.0",
-          timestamp: new Date().toISOString(),
-        },
-      });
-      return;
+      throw new NotFoundError("Task", req.params.id, res.locals.correlationId as string | undefined);
     }
     const requesterKey = req.headers["walletpublickey"] as string;
     if (!requesterKey || requesterKey !== task.walletPublicKey) {
-      res.status(403).json({
-        error: "Access denied",
-        _meta: {
-          version: "2.0",
-          timestamp: new Date().toISOString(),
-        },
-      });
-      return;
+      throw new ForbiddenError(
+        "Access denied",
+        { taskId: req.params.id, walletPublicKey: requesterKey },
+        res.locals.correlationId as string | undefined,
+      );
     }
 
     const now = new Date().toISOString();
@@ -253,44 +250,35 @@ export function createV2TasksRouter(
         cancel: `/api/tasks/${task.id}`,
       },
     });
+    } catch (err) {
+      next(err);
+    }
   });
 
   // DELETE /api/tasks/:id — v2 format with enhanced response
-  tasksRouter.delete("/:id", (req: Request, res: Response): void => {
+  tasksRouter.delete("/:id", (req: Request, res: Response, next: NextFunction): void => {
+    try {
     const db = createTaskDb(getTaskDb());
     const task = db.findById(req.params.id);
     if (!task) {
-      res.status(404).json({
-        error: "Task not found",
-        _meta: {
-          version: "2.0",
-          timestamp: new Date().toISOString(),
-        },
-      });
-      return;
+      throw new NotFoundError("Task", req.params.id, res.locals.correlationId as string | undefined);
     }
 
     const requesterKey = req.headers["walletpublickey"] as string;
     if (!requesterKey || requesterKey !== task.walletPublicKey) {
-      res.status(403).json({
-        error: "Not authorized to cancel this task",
-        _meta: {
-          version: "2.0",
-          timestamp: new Date().toISOString(),
-        },
-      });
-      return;
+      throw new ForbiddenError(
+        "Not authorized to cancel this task",
+        { taskId: req.params.id, walletPublicKey: requesterKey },
+        res.locals.correlationId as string | undefined,
+      );
     }
 
     if (task.status !== "queued") {
-      res.status(409).json({
-        error: `Cannot cancel task in '${task.status}' status`,
-        _meta: {
-          version: "2.0",
-          timestamp: new Date().toISOString(),
-        },
-      });
-      return;
+      throw new ConflictError(
+        `Cannot cancel task in '${task.status}' status`,
+        { taskId: req.params.id, status: task.status },
+        res.locals.correlationId as string | undefined,
+      );
     }
 
     db.updateStatus(req.params.id, "cancelled");
@@ -313,6 +301,9 @@ export function createV2TasksRouter(
         self: `/api/tasks/${req.params.id}`,
       },
     });
+    } catch (err) {
+      next(err);
+    }
   });
 
   return tasksRouter;

--- a/backend/src/errors/AppError.test.ts
+++ b/backend/src/errors/AppError.test.ts
@@ -129,11 +129,11 @@ describe("ValidationError", () => {
 // ── AuthenticationError ───────────────────────────────────────────────────────
 
 describe("AuthenticationError", () => {
-  it("has statusCode 401 and code AUTHENTICATION_ERROR", () => {
+  it("has statusCode 401 and code UNAUTHORIZED", () => {
     const err = new AuthenticationError();
 
     expect(err.statusCode).toBe(401);
-    expect(err.code).toBe("AUTHENTICATION_ERROR");
+    expect(err.code).toBe("UNAUTHORIZED");
     expect(err.message).toBe("Authentication required");
     expect(err.name).toBe("AuthenticationError");
   });
@@ -151,11 +151,11 @@ describe("AuthenticationError", () => {
 // ── RateLimitError ────────────────────────────────────────────────────────────
 
 describe("RateLimitError", () => {
-  it("has statusCode 429 and code RATE_LIMIT_EXCEEDED", () => {
+  it("has statusCode 429 and code RATE_LIMITED", () => {
     const err = new RateLimitError();
 
     expect(err.statusCode).toBe(429);
-    expect(err.code).toBe("RATE_LIMIT_EXCEEDED");
+    expect(err.code).toBe("RATE_LIMITED");
     expect(err.message).toBe("Too many requests");
     expect(err.name).toBe("RateLimitError");
   });

--- a/backend/src/errors/ErrorCode.ts
+++ b/backend/src/errors/ErrorCode.ts
@@ -15,22 +15,25 @@ export const ErrorCode = {
   CONFLICT: "CONFLICT",
 
   // ── Auth ───────────────────────────────────────────────────────────────────
-  AUTHENTICATION_ERROR: "AUTHENTICATION_ERROR",
-  AUTHORIZATION_ERROR: "AUTHORIZATION_ERROR",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  FORBIDDEN: "FORBIDDEN",
 
   // ── Rate limiting ──────────────────────────────────────────────────────────
-  RATE_LIMIT_EXCEEDED: "RATE_LIMIT_EXCEEDED",
+  RATE_LIMITED: "RATE_LIMITED",
 
   // ── Payment / Stellar ─────────────────────────────────────────────────────
   PAYMENT_ERROR: "PAYMENT_ERROR",
+  STELLAR_UNAVAILABLE: "STELLAR_UNAVAILABLE",
 
   // ── Upstream AI/provider ──────────────────────────────────────────────────
+  UPSTREAM_UNAVAILABLE: "UPSTREAM_UNAVAILABLE",
+  VENICE_UNAVAILABLE: "VENICE_UNAVAILABLE",
   PROVIDER_ERROR: "PROVIDER_ERROR",
   PROVIDER_TIMEOUT: "PROVIDER_TIMEOUT",
   PROVIDER_RATE_LIMITED: "PROVIDER_RATE_LIMITED",
 
   // ── Server internals ───────────────────────────────────────────────────────
-  INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
   UNSUPPORTED_API_VERSION: "UNSUPPORTED_API_VERSION",
 } as const;
 
@@ -45,14 +48,17 @@ export const HTTP_STATUS_FOR_CODE: Record<ErrorCode, number> = {
   VALIDATION_ERROR: 400,
   NOT_FOUND: 404,
   CONFLICT: 409,
-  AUTHENTICATION_ERROR: 401,
-  AUTHORIZATION_ERROR: 403,
-  RATE_LIMIT_EXCEEDED: 429,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  RATE_LIMITED: 429,
   PAYMENT_ERROR: 402,
+  STELLAR_UNAVAILABLE: 503,
+  UPSTREAM_UNAVAILABLE: 502,
+  VENICE_UNAVAILABLE: 503,
   PROVIDER_ERROR: 502,
   PROVIDER_TIMEOUT: 504,
   PROVIDER_RATE_LIMITED: 429,
-  INTERNAL_SERVER_ERROR: 500,
+  INTERNAL_ERROR: 500,
   UNSUPPORTED_API_VERSION: 400,
 };
 
@@ -64,13 +70,16 @@ export const DEFAULT_MESSAGE_FOR_CODE: Record<ErrorCode, string> = {
   VALIDATION_ERROR: "Request input is invalid.",
   NOT_FOUND: "The requested resource was not found.",
   CONFLICT: "The request conflicts with the current state of the resource.",
-  AUTHENTICATION_ERROR: "Authentication required.",
-  AUTHORIZATION_ERROR: "You do not have permission to perform this action.",
-  RATE_LIMIT_EXCEEDED: "Too many requests. Please slow down.",
+  UNAUTHORIZED: "Authentication required.",
+  FORBIDDEN: "You do not have permission to perform this action.",
+  RATE_LIMITED: "Too many requests. Please slow down.",
   PAYMENT_ERROR: "Payment operation failed.",
+  STELLAR_UNAVAILABLE: "Stellar network unavailable.",
+  UPSTREAM_UNAVAILABLE: "An upstream service is unavailable.",
+  VENICE_UNAVAILABLE: "Venice API unavailable.",
   PROVIDER_ERROR: "An upstream AI provider returned an error.",
   PROVIDER_TIMEOUT: "The AI provider did not respond in time.",
   PROVIDER_RATE_LIMITED: "The AI provider is currently rate-limiting requests.",
-  INTERNAL_SERVER_ERROR: "An unexpected error occurred. Please try again later.",
+  INTERNAL_ERROR: "An unexpected error occurred. Please try again later.",
   UNSUPPORTED_API_VERSION: "The requested API version is not supported.",
 };

--- a/backend/src/errors/index.ts
+++ b/backend/src/errors/index.ts
@@ -4,5 +4,7 @@ export { ValidationError } from "./ValidationError";
 export { NotFoundError } from "./NotFoundError";
 export { UnauthorizedError } from "./UnauthorizedError";
 export { AuthenticationError } from "./AuthenticationError";
+export { ForbiddenError } from "./ForbiddenError";
 export { RateLimitError } from "./RateLimitError";
+export { ConflictError } from "./ConflictError";
 export { PaymentError } from "./PaymentError";

--- a/backend/tests/errorHandler.test.ts
+++ b/backend/tests/errorHandler.test.ts
@@ -82,7 +82,7 @@ describe("errorHandler — production mode", () => {
     expect(body.stack).toBeUndefined();
   });
 
-  it("always uses INTERNAL_SERVER_ERROR code in production (no leaking err.code)", () => {
+  it("always uses INTERNAL_ERROR code in production (no leaking err.code)", () => {
     const errorHandler = freshErrorHandler("production");
     const err: any = new Error("db is down");
     err.code = "DB_UNAVAILABLE";
@@ -91,10 +91,10 @@ describe("errorHandler — production mode", () => {
     errorHandler(err, makeReq(), res as unknown as Response, jest.fn() as NextFunction);
 
     const body = res.json.mock.calls[0][0];
-    expect(body.error.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(body.error.code).toBe("INTERNAL_ERROR");
   });
 
-  it("falls back to INTERNAL_SERVER_ERROR when err.code is absent", () => {
+  it("falls back to INTERNAL_ERROR when err.code is absent", () => {
     const errorHandler = freshErrorHandler("production");
     const err = new Error("some unknown failure");
     const res = makeRes();
@@ -102,7 +102,7 @@ describe("errorHandler — production mode", () => {
     errorHandler(err, makeReq(), res as unknown as Response, jest.fn() as NextFunction);
 
     const body = res.json.mock.calls[0][0];
-    expect(body.error.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(body.error.code).toBe("INTERNAL_ERROR");
   });
 
   it("respects err.statusCode", () => {

--- a/backend/tests/tasks.test.ts
+++ b/backend/tests/tasks.test.ts
@@ -78,8 +78,8 @@ describe("POST /api/tasks", () => {
       .send({ prompt: "", maxBudgetXLM: 1 });
 
     expect(res.status).toBe(400);
-    expect(res.body.error.message).toBe("Validation failed");
-    expect(res.body.error.details.prompt).toBeDefined();
+    expect(res.body.error.message).toBe("Request validation failed");
+    expect(res.body.error.details.fieldErrors.body.prompt).toBeDefined();
   });
 
   it("returns 400 when prompt exceeds 10 000 characters", async () => {
@@ -90,8 +90,8 @@ describe("POST /api/tasks", () => {
       .send({ prompt: oversizedPrompt, maxBudgetXLM: 1 });
 
     expect(res.status).toBe(400);
-    expect(res.body.error.message).toBe("Validation failed");
-    expect(res.body.error.details.prompt).toBeDefined();
+    expect(res.body.error.message).toBe("Request validation failed");
+    expect(res.body.error.details.fieldErrors.body.prompt).toBeDefined();
   });
 
   it("accepts a prompt of exactly 10 000 characters", async () => {
@@ -564,7 +564,7 @@ describe("POST /api/tasks — daily quota enforcement", () => {
       .run(quotaWallet);
   });
 
-  it("returns 429 with DAILY_LIMIT_EXCEEDED when wallet reaches the daily task limit", async () => {
+  it("returns 429 with RATE_LIMITED when wallet reaches the daily task limit", async () => {
     // Override DAILY_TASK_LIMIT_PER_WALLET before re-requiring the module so
     // the module-level constant is initialised to 2 for this test.
     const originalLimit = process.env.DAILY_TASK_LIMIT_PER_WALLET;
@@ -595,7 +595,7 @@ describe("POST /api/tasks — daily quota enforcement", () => {
       .send({ prompt: "One too many", maxBudgetXLM: 1 });
 
     expect(res.status).toBe(429);
-    expect(res.body.error.code).toBe("DAILY_LIMIT_EXCEEDED");
+    expect(res.body.error.code).toBe("RATE_LIMITED");
 
     freshApp.close();
     process.env.DAILY_TASK_LIMIT_PER_WALLET = originalLimit;

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -46,11 +46,16 @@ All error responses return a standardized JSON error envelope:
 | HTTP Status | Error Code | Description | Recommended Resolution |
 |---|---|---|---|
 | `400 Bad Request` | `VALIDATION_ERROR` | Request payload fails schema validation or missing required fields | Inspect `details` object and correct query parameters or JSON body |
-| `401 Unauthorized` | `AUTHENTICATION_ERROR` | Missing, expired, or malformed JWT token or API key | Refresh JWT token via auth endpoint or supply valid `X-API-Key` |
-| `402 Payment Required`| `PAYMENT_REQUIRED` | Insufficient XLM/USDC balance or missing Soroban fee authorization | Fund account or sign Soroban payment contract invocation |
+| `401 Unauthorized` | `UNAUTHORIZED` | Missing, expired, or malformed JWT token or API key | Refresh JWT token via auth endpoint or supply valid `X-API-Key` |
+| `402 Payment Required`| `PAYMENT_ERROR` | Insufficient XLM/USDC balance or missing Soroban fee authorization | Fund account or sign Soroban payment contract invocation |
+| `403 Forbidden` | `FORBIDDEN` | Authenticated caller lacks permission for the requested resource | Verify wallet/API key ownership or contact admin |
 | `404 Not Found` | `NOT_FOUND` | Requested agent, task, or resource does not exist | Verify UUID / address in URL parameters |
-| `429 Too Many Requests`| `RATE_LIMIT_EXCEEDED`| Request rate exceeded client tier quota | Respect `Retry-After` header before re-sending requests |
+| `409 Conflict` | `CONFLICT` | Request conflicts with current resource state | Resolve the conflict and retry |
+| `429 Too Many Requests`| `RATE_LIMITED`| Request rate exceeded client tier quota | Respect `Retry-After` header before re-sending requests |
 | `500 Internal Error` | `INTERNAL_ERROR` | Unhandled backend exception | Check correlation ID in server logs |
+| `502 Bad Gateway` | `UPSTREAM_UNAVAILABLE` | Upstream service returned an invalid response | Retry or contact operations |
+| `503 Service Unavailable` | `STELLAR_UNAVAILABLE` | Stellar Horizon or RPC unavailable | Retry after a short delay |
+| `504 Gateway Timeout` | `PROVIDER_TIMEOUT` | Upstream provider timed out | Retry with backoff |
 
 ---
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -69,7 +69,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       let message = `HTTP error! status: ${response.status}`;
       try {
         const errorData = await response.json();
-        message = errorData.error || errorData.message || message;
+        message = errorData.error?.message || errorData.message || errorData.error || message;
       } catch {
         try {
           const errorText = await response.text();


### PR DESCRIPTION
## Summary
Closes #500 by unifying all backend API error responses to the structured envelope defined in the issue.

## What changed
- Aligned every AppError subclass to the issue-spec ErrorCode registry (UNAUTHORIZED, RATE_LIMITED, FORBIDDEN, CONFLICT, NOT_FOUND, VALIDATION_ERROR, PAYMENT_ERROR, STELLAR_UNAVAILABLE, INTERNAL_ERROR).
- Refactored route handlers in agents, admin, ratelimit, v2/tasks, deprecated tasks and v1/tasks to throw typed errors instead of inline JSON responses.
- Fixed missing exports for ForbiddenError and ConflictError; added missing idempotencyMiddleware imports.
- Fixed frontend message extraction for nested error payloads.
- Updated docs/API_REFERENCE.md and affected tests.

## Verification
- Type-checked with available tooling; only pre-existing TS 5.x syntax files report parse errors under system TS 4.7.4 and were not touched.
- Local Jest could not run because dependency installation is blocked by the sandbox filesystem broker; relying on CI for full test verification.
